### PR TITLE
Shorten drain test waits

### DIFF
--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1859,8 +1859,6 @@ class ClientDrainTest(SingleServerTestCase):
         async def handler(msg):
             if len(msgs) % 20 == 1:
                 await asyncio.sleep(0.2, loop=self.loop)
-            if len(msgs) % 50 == 1:
-                await asyncio.sleep(0.5, loop=self.loop)
             await nc.publish_request(msg.reply, msg.subject, b'OK!')
             await nc2.flush()
 


### PR DESCRIPTION
This unit test was intermittently failing, I believe this will fix the issue. I think the callback for the subscription was waiting too long given the timeout in the test.

With 201 messages being sent, the old waits would translate too `0.2 * 11 + 0.5 * 5 = 4.7`, which is very close to the test timeout of 5s. Given execution time for the other things in the test and the drain wait granularity is 0.1s, the test just happened to run too long sometimes. Removing the second wait condition should put the execution time comfortably under the wait time.

This ran successfully for me locally very consistently