### PR TITLE
use async/await instead of asyncio.coroutine/yield from

### DIFF
--- a/benchmark/parser_perf.py
+++ b/benchmark/parser_perf.py
@@ -19,25 +19,20 @@ class DummyNatsClient:
             'errors_received': 0
             }
 
-    @asyncio.coroutine
-    def _send_command(self, cmd):
+    async def _send_command(self, cmd):
         pass
 
-    @asyncio.coroutine
-    def _process_pong(self):
+    async def _process_pong(self):
         pass
 
-    @asyncio.coroutine
-    def _process_ping(self):
+    async def _process_ping(self):
         pass
 
-    @asyncio.coroutine
-    def _process_msg(self, sid, subject, reply, data):
+    async def _process_msg(self, sid, subject, reply, data):
         self.stats['in_msgs']  += 1
         self.stats['in_bytes'] += len(data)
 
-    @asyncio.coroutine
-    def _process_err(self, err=None):
+    async def _process_err(self, err=None):
         pass
 
 def generate_msg(subject, nbytes, reply=""):

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -2,14 +2,12 @@ import asyncio
 from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrConnectionClosed, ErrTimeout, ErrNoServers
 
-@asyncio.coroutine
-def run(loop):
+async def run(loop):
     nc = NATS()
 
-    yield from nc.connect("127.0.0.1:4222", loop=loop)
+    await nc.connect("127.0.0.1:4222", loop=loop)
 
-    @asyncio.coroutine
-    def message_handler(msg):
+    async def message_handler(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
@@ -17,40 +15,39 @@ def run(loop):
             subject=subject, reply=reply, data=data))
 
     # Simple publisher and async subscriber via coroutine.
-    sid = yield from nc.subscribe("foo", cb=message_handler)
+    sid = await nc.subscribe("foo", cb=message_handler)
 
     # Stop receiving after 2 messages.
-    yield from nc.auto_unsubscribe(sid, 2)
-    yield from nc.publish("foo", b'Hello')
-    yield from nc.publish("foo", b'World')
-    yield from nc.publish("foo", b'!!!!!')
+    await nc.auto_unsubscribe(sid, 2)
+    await nc.publish("foo", b'Hello')
+    await nc.publish("foo", b'World')
+    await nc.publish("foo", b'!!!!!')
 
-    @asyncio.coroutine
-    def help_request(msg):
+    async def help_request(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
         print("Received a message on '{subject} {reply}': {data}".format(
             subject=subject, reply=reply, data=data))
-        yield from nc.publish(reply, b'I can help')
+        await nc.publish(reply, b'I can help')
 
     # Use queue named 'workers' for distributing requests
     # among subscribers.
-    sid = yield from nc.subscribe("help", "workers", help_request)
+    sid = await nc.subscribe("help", "workers", help_request)
 
     # Send a request and expect a single response
     # and trigger timeout if not faster than 50 ms.
     try:
-        response = yield from nc.request("help", b'help me', 0.050)
+        response = await nc.request("help", b'help me', 0.050)
         print("Received response: {message}".format(
             message=response.data.decode()))
     except ErrTimeout:
         print("Request timed out")
 
     # Remove interest in subscription.
-    yield from nc.unsubscribe(sid)
+    await nc.unsubscribe(sid)
 
-    yield from nc.close()
+    await nc.close()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/examples/client.py
+++ b/examples/client.py
@@ -9,34 +9,32 @@ class Client:
         self.nc = nc
         self.loop = loop
 
-    @asyncio.coroutine
-    def message_handler(self, msg):
+    async def message_handler(self, msg):
         print("[Received on '{}']: {}".format(msg.subject, msg.data.decode()))
 
-    @asyncio.coroutine
-    def request_handler(self, msg):
+    async def request_handler(self, msg):
         print("[Request on '{} {}']: {}".format(msg.subject, msg.reply,
                                                 msg.data.decode()))
-        yield from self.nc.publish(msg.reply, b"I can help!")
+        await self.nc.publish(msg.reply, b"I can help!")
 
     def start(self):
         try:
-            yield from self.nc.connect(io_loop=self.loop)
+            await self.nc.connect(io_loop=self.loop)
         except:
             pass
 
         nc = self.nc
         try:
             # Interested in receiving 2 messages from the 'discover' subject.
-            sid = yield from nc.subscribe("discover", "", self.message_handler)
-            yield from nc.auto_unsubscribe(sid, 2)
+            sid = await nc.subscribe("discover", "", self.message_handler)
+            await nc.auto_unsubscribe(sid, 2)
 
-            yield from nc.publish("discover", b'hello')
-            yield from nc.publish("discover", b'world')
+            await nc.publish("discover", b'hello')
+            await nc.publish("discover", b'world')
 
             # Following 2 messages won't be received.
-            yield from nc.publish("discover", b'again')
-            yield from nc.publish("discover", b'!!!!!')
+            await nc.publish("discover", b'again')
+            await nc.publish("discover", b'!!!!!')
         except ErrConnectionClosed:
             print("Connection closed prematurely")
 
@@ -44,13 +42,13 @@ class Client:
 
             # Subscription using a 'workers' queue so that only a single subscriber
             # gets a request at a time.
-            yield from nc.subscribe("help", "workers", self.request_handler)
+            await nc.subscribe("help", "workers", self.request_handler)
 
             try:
                 # Make a request expecting a single response within 500 ms,
                 # otherwise raising a timeout error.
                 start_time = datetime.now()
-                response = yield from nc.timed_request("help", b'help please',
+                response = await nc.timed_request("help", b'help please',
                                                        0.500)
                 end_time = datetime.now()
                 print("[Response]: {}".format(response.data))
@@ -58,15 +56,15 @@ class Client:
 
                 # Make a roundtrip to the server to ensure messages
                 # that sent messages have been processed already.
-                yield from nc.flush(0.500)
+                await nc.flush(0.500)
             except ErrTimeout:
                 print("[Error] Timeout!")
 
             # Wait a bit for messages to be dispatched...
-            yield from asyncio.sleep(2, loop=self.loop)
+            await asyncio.sleep(2, loop=self.loop)
 
             # Detach from the server.
-            yield from nc.close()
+            await nc.close()
 
         if nc.last_error is not None:
             print("Last Error: {}".format(nc.last_error))

--- a/examples/context-manager.py
+++ b/examples/context-manager.py
@@ -4,13 +4,11 @@ import signal
 import nats
 
 
-@asyncio.coroutine
-def run(loop):
+async def run(loop):
 
     is_done = asyncio.Future(loop=loop)
 
-    @asyncio.coroutine
-    def closed_cb():
+    async def closed_cb():
         print("Connection to NATS is closed.")
         is_done.set_result(True)
 
@@ -20,25 +18,24 @@ def run(loop):
         "closed_cb": closed_cb
     }
 
-    with (yield from nats.connect(**opts)) as nc:
+    with (await nats.connect(**opts)) as nc:
         print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
-        @asyncio.coroutine
-        def subscribe_handler(msg):
+        async def subscribe_handler(msg):
             subject = msg.subject
             reply = msg.reply
             data = msg.data.decode()
             print("Received a message on '{subject} {reply}': {data}".format(
                 subject=subject, reply=reply, data=data))
 
-        yield from nc.subscribe("discover", cb=subscribe_handler)
-        yield from nc.flush()
+        await nc.subscribe("discover", cb=subscribe_handler)
+        await nc.flush()
 
         for i in range(0, 10):
-            yield from nc.publish("discover", b"hello world")
-            yield from asyncio.sleep(0.1, loop=loop)
+            await nc.publish("discover", b"hello world")
+            await asyncio.sleep(0.1, loop=loop)
 
-    yield from asyncio.wait_for(is_done, 60.0, loop=loop)
+    await asyncio.wait_for(is_done, 60.0, loop=loop)
     loop.stop()
 
 

--- a/examples/coroutine_threadsafe.py
+++ b/examples/coroutine_threadsafe.py
@@ -13,16 +13,15 @@ class Component(object):
     def response_handler(self, msg):
         print("--- Received: ", msg.subject, msg.data)
 
-    @asyncio.coroutine
-    def another_handler(self, msg):
+    async def another_handler(self, msg):
         print("--- Another: ", msg.subject, msg.data, msg.reply)
-        yield from self.nc.publish(msg.reply, b'I can help!')
+        await self.nc.publish(msg.reply, b'I can help!')
 
     def run(self):
-        yield from self.nc.connect(io_loop=self.loop)
-        yield from self.nc.subscribe("hello", cb=self.response_handler)
-        yield from self.nc.subscribe("another", cb=self.another_handler)
-        yield from self.nc.flush()
+        await self.nc.connect(io_loop=self.loop)
+        await self.nc.subscribe("hello", cb=self.response_handler)
+        await self.nc.subscribe("another", cb=self.another_handler)
+        await self.nc.flush()
 
 
 def another_thread(c):

--- a/examples/example.py
+++ b/examples/example.py
@@ -7,57 +7,55 @@ def go(loop):
     nc = NATS()
 
     try:
-        yield from nc.connect(io_loop=loop)
+        await nc.connect(io_loop=loop)
     except:
         pass
 
-    @asyncio.coroutine
-    def message_handler(msg):
+    async def message_handler(msg):
         print("[Received on '{}']: {}".format(msg.subject, msg.data.decode()))
 
     try:
         # Interested in receiving 2 messages from the 'discover' subject.
-        sid = yield from nc.subscribe("discover", "", message_handler)
-        yield from nc.auto_unsubscribe(sid, 2)
+        sid = await nc.subscribe("discover", "", message_handler)
+        await nc.auto_unsubscribe(sid, 2)
 
-        yield from nc.publish("discover", b'hello')
-        yield from nc.publish("discover", b'world')
+        await nc.publish("discover", b'hello')
+        await nc.publish("discover", b'world')
 
         # Following 2 messages won't be received.
-        yield from nc.publish("discover", b'again')
-        yield from nc.publish("discover", b'!!!!!')
+        await nc.publish("discover", b'again')
+        await nc.publish("discover", b'!!!!!')
     except ErrConnectionClosed:
         print("Connection closed prematurely")
 
-    @asyncio.coroutine
-    def request_handler(msg):
+    async def request_handler(msg):
         print("[Request on '{} {}']: {}".format(msg.subject, msg.reply,
                                                 msg.data.decode()))
-        yield from nc.publish(msg.reply, b'OK')
+        await nc.publish(msg.reply, b'OK')
 
     if nc.is_connected:
 
         # Subscription using a 'workers' queue so that only a single subscriber
         # gets a request at a time.
-        yield from nc.subscribe("help", "workers", cb=request_handler)
+        await nc.subscribe("help", "workers", cb=request_handler)
 
         try:
             # Make a request expecting a single response within 500 ms,
             # otherwise raising a timeout error.
-            msg = yield from nc.timed_request("help", b'help please', 0.500)
+            msg = await nc.timed_request("help", b'help please', 0.500)
             print("[Response]: {}".format(msg.data))
 
             # Make a roundtrip to the server to ensure messages
             # that sent messages have been processed already.
-            yield from nc.flush(0.500)
+            await nc.flush(0.500)
         except ErrTimeout:
             print("[Error] Timeout!")
 
         # Wait a bit for message to be dispatched...
-        yield from asyncio.sleep(1, loop=loop)
+        await asyncio.sleep(1, loop=loop)
 
         # Detach from the server.
-        yield from nc.close()
+        await nc.close()
 
     if nc.last_error is not None:
         print("Last Error: {}".format(nc.last_error))

--- a/examples/nats-pub/__main__.py
+++ b/examples/nats-pub/__main__.py
@@ -44,16 +44,13 @@ def run(loop):
 
     nc = NATS()
 
-    @asyncio.coroutine
-    def error_cb(e):
+    async def error_cb(e):
         print("Error:", e)
 
-    @asyncio.coroutine
-    def closed_cb():
+    async def closed_cb():
         print("Connection to NATS is closed.")
 
-    @asyncio.coroutine
-    def reconnected_cb():
+    async def reconnected_cb():
         print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
     options = {
@@ -70,15 +67,15 @@ def run(loop):
         if len(args.servers) > 0:
             options['servers'] = args.servers
 
-        yield from nc.connect(**options)
+        await nc.connect(**options)
     except Exception as e:
         print(e)
         show_usage_and_die()
 
     print("Connected to NATS at {}...".format(nc.connected_url.netloc))
-    yield from nc.publish(args.subject, args.data.encode())
-    yield from nc.flush()
-    yield from nc.close()
+    await nc.publish(args.subject, args.data.encode())
+    await nc.flush()
+    await nc.close()
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -44,22 +44,18 @@ def run(loop):
 
     nc = NATS()
 
-    @asyncio.coroutine
-    def error_cb(e):
+    async def error_cb(e):
         print("Error:", e)
 
-    @asyncio.coroutine
-    def closed_cb():
+    async def closed_cb():
         print("Connection to NATS is closed.")
-        yield from asyncio.sleep(0.1, loop=loop)
+        await asyncio.sleep(0.1, loop=loop)
         loop.stop()
 
-    @asyncio.coroutine
-    def reconnected_cb():
+    async def reconnected_cb():
         print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
-    @asyncio.coroutine
-    def subscribe_handler(msg):
+    async def subscribe_handler(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
@@ -80,7 +76,7 @@ def run(loop):
         if len(args.servers) > 0:
             options['servers'] = args.servers
 
-        yield from nc.connect(**options)
+        await nc.connect(**options)
     except Exception as e:
         print(e)
         show_usage_and_die()
@@ -95,7 +91,7 @@ def run(loop):
     for sig in ('SIGINT', 'SIGTERM'):
         loop.add_signal_handler(getattr(signal, sig), signal_handler)
 
-    yield from nc.subscribe(args.subject, args.queue, subscribe_handler)
+    await nc.subscribe(args.subject, args.queue, subscribe_handler)
 
 if __name__ == '__main__':
     loop = asyncio.get_event_loop()

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -7,10 +7,9 @@ from nats.aio.client import Client as NATS
 def run(loop):
     nc = NATS()
 
-    @asyncio.coroutine
-    def closed_cb():
+    async def closed_cb():
         print("Connection to NATS is closed.")
-        yield from asyncio.sleep(0.1, loop=loop)
+        await asyncio.sleep(0.1, loop=loop)
         loop.stop()
 
     options = {
@@ -19,11 +18,10 @@ def run(loop):
         "closed_cb": closed_cb
     }
 
-    yield from nc.connect(**options)
+    await nc.connect(**options)
     print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
-    @asyncio.coroutine
-    def subscribe_handler(msg):
+    async def subscribe_handler(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
@@ -32,11 +30,11 @@ def run(loop):
 
     # Basic subscription to receive all published messages
     # which are being sent to a single topic 'discover'
-    yield from nc.subscribe("discover", cb=subscribe_handler)
+    await nc.subscribe("discover", cb=subscribe_handler)
 
     # Subscription on queue named 'workers' so that
     # one subscriber handles message a request at a time.
-    yield from nc.subscribe("help.*", "workers", subscribe_handler)
+    await nc.subscribe("help.*", "workers", subscribe_handler)
 
     def signal_handler():
         if nc.is_closed:

--- a/examples/tls.py
+++ b/examples/tls.py
@@ -13,10 +13,9 @@ def run(loop):
     ssl_ctx.load_cert_chain(
         certfile='../tests/certs/client-cert.pem',
         keyfile='../tests/certs/client-key.pem')
-    yield from nc.connect(io_loop=loop, tls=ssl_ctx)
+    await nc.connect(io_loop=loop, tls=ssl_ctx)
 
-    @asyncio.coroutine
-    def message_handler(msg):
+    async def message_handler(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
@@ -24,38 +23,37 @@ def run(loop):
             subject=subject, reply=reply, data=data))
 
     # Simple publisher and async subscriber via coroutine.
-    sid = yield from nc.subscribe("foo", cb=message_handler)
+    sid = await nc.subscribe("foo", cb=message_handler)
 
     # Stop receiving after 2 messages.
-    yield from nc.auto_unsubscribe(sid, 2)
-    yield from nc.publish("foo", b'Hello')
-    yield from nc.publish("foo", b'World')
-    yield from nc.publish("foo", b'!!!!!')
+    await nc.auto_unsubscribe(sid, 2)
+    await nc.publish("foo", b'Hello')
+    await nc.publish("foo", b'World')
+    await nc.publish("foo", b'!!!!!')
 
-    @asyncio.coroutine
-    def help_request(msg):
+    async def help_request(msg):
         subject = msg.subject
         reply = msg.reply
         data = msg.data.decode()
         print("Received a message on '{subject} {reply}': {data}".format(
             subject=subject, reply=reply, data=data))
-        yield from nc.publish(reply, b'I can help')
+        await nc.publish(reply, b'I can help')
 
     # Use queue named 'workers' for distributing requests
     # among subscribers.
-    yield from nc.subscribe("help", "workers", help_request)
+    await nc.subscribe("help", "workers", help_request)
 
     # Send a request and expect a single response
     # and trigger timeout if not faster than 50 ms.
     try:
-        response = yield from nc.timed_request("help", b'help me', 0.050)
+        response = await nc.timed_request("help", b'help me', 0.050)
         print("Received response: {message}".format(
             message=response.data.decode()))
     except ErrTimeout:
         print("Request timed out")
 
-    yield from asyncio.sleep(1, loop=loop)
-    yield from nc.close()
+    await asyncio.sleep(1, loop=loop)
+    await nc.close()
 
 
 if __name__ == '__main__':

--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -16,8 +16,7 @@ import asyncio
 from .aio.client import Client as NATS
 
 
-@asyncio.coroutine
-def connect(**options):
+async def connect(**options):
     nc = NATS()
-    yield from nc.connect(**options)
+    await nc.connect(**options)
     return nc

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -116,6 +116,7 @@ class Srv(object):
     """
     Srv is a helper data structure to hold state of a server.
     """
+
     def __init__(self, uri):
         self.uri = uri
         self.reconnects = 0

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -116,7 +116,6 @@ class Srv(object):
     """
     Srv is a helper data structure to hold state of a server.
     """
-
     def __init__(self, uri):
         self.uri = uri
         self.reconnects = 0
@@ -210,8 +209,7 @@ class Client(object):
             'errors_received': 0,
         }
 
-    @asyncio.coroutine
-    def connect(
+    async def connect(
             self,
             servers=["nats://127.0.0.1:4222"],
             io_loop=None,
@@ -290,8 +288,8 @@ class Client(object):
 
         while True:
             try:
-                yield from self._select_next_server()
-                yield from self._process_connect_init()
+                await self._select_next_server()
+                await self._process_connect_init()
                 self._current_server.reconnects = 0
                 break
             except ErrNoServers as e:
@@ -303,13 +301,13 @@ class Client(object):
             except (OSError, NatsError, asyncio.TimeoutError) as e:
                 self._err = e
                 if self._error_cb is not None:
-                    yield from self._error_cb(e)
+                    await self._error_cb(e)
 
                 # Bail on first attempt if reconnecting is disallowed.
                 if not self.options["allow_reconnect"]:
                     raise e
 
-                yield from self._close(Client.DISCONNECTED, False)
+                await self._close(Client.DISCONNECTED, False)
                 self._current_server.last_attempt = time.monotonic()
                 self._current_server.reconnects += 1
 
@@ -431,17 +429,15 @@ class Client(object):
 
         self._signature_cb = sig_cb
 
-    @asyncio.coroutine
-    def close(self):
+    async def close(self):
         """
         Closes the socket to which we are connected and
         sets the client to be in the CLOSED state.
         No further reconnections occur once reaching this point.
         """
-        yield from self._close(Client.CLOSED)
+        await self._close(Client.CLOSED)
 
-    @asyncio.coroutine
-    def _close(self, status, do_cbs=True):
+    async def _close(self, status, do_cbs=True):
         if self.is_closed:
             self._status = status
             return
@@ -449,7 +445,7 @@ class Client(object):
 
         # Kick the flusher once again so it breaks
         # and avoid pending futures.
-        yield from self._flush_pending()
+        await self._flush_pending()
 
         if self._reading_task is not None and not self._reading_task.cancelled(
         ):
@@ -471,7 +467,7 @@ class Client(object):
             try:
                 if self._reconnection_task_future is not None and not self._reconnection_task_future.cancelled(
                 ):
-                    yield from asyncio.wait_for(
+                    await asyncio.wait_for(
                         self._reconnection_task_future,
                         self.options["reconnect_time_wait"],
                         loop=self._loop,
@@ -480,7 +476,7 @@ class Client(object):
                 pass
 
         # Relinquish control to allow background tasks to wrap up.
-        yield from asyncio.sleep(0, loop=self._loop)
+        await asyncio.sleep(0, loop=self._loop)
 
         if self._current_server is not None:
             # In case there is any pending data at this point, flush before disconnecting.
@@ -488,7 +484,7 @@ class Client(object):
                 self._io_writer.writelines(self._pending[:])
                 self._pending = []
                 self._pending_data_size = 0
-                yield from self._io_writer.drain()
+                await self._io_writer.drain()
 
         # Cleanup subscriptions since not reconnecting so no need
         # to replay the subscriptions anymore.
@@ -504,12 +500,11 @@ class Client(object):
 
         if do_cbs:
             if self._disconnected_cb is not None:
-                yield from self._disconnected_cb()
+                await self._disconnected_cb()
             if self._closed_cb is not None:
-                yield from self._closed_cb()
+                await self._closed_cb()
 
-    @asyncio.coroutine
-    def drain(self, sid=None):
+    async def drain(self, sid=None):
         """
         Drain will put a connection into a drain state. All subscriptions will
         immediately be put into a drain state. Upon completion, the publishers
@@ -540,20 +535,20 @@ class Client(object):
 
         drain_is_done = asyncio.gather(*drain_tasks)
         try:
-            yield from asyncio.wait_for(
+            await asyncio.wait_for(
                 drain_is_done, self.options["drain_timeout"]
             )
         except asyncio.TimeoutError:
             drain_is_done.exception()
             drain_is_done.cancel()
             if self._error_cb is not None:
-                yield from self._error_cb(ErrDrainTimeout)
+                await self._error_cb(ErrDrainTimeout)
         except asyncio.CancelledError:
             pass
         finally:
             self._status = Client.DRAINING_PUBS
-            yield from self.flush()
-            yield from self._close(Client.CLOSED)
+            await self.flush()
+            await self._close(Client.CLOSED)
 
     def _drain_sub(self, sid):
         sub = self._subs.get(sid)
@@ -563,8 +558,7 @@ class Client(object):
         nc = self
 
         # Draining happens async under a task per sub which can be awaited.
-        @asyncio.coroutine
-        def drain_subscription():
+        async def drain_subscription():
             nonlocal sub
             nonlocal sid
             nonlocal nc
@@ -572,15 +566,15 @@ class Client(object):
             try:
                 # Announce server that no longer want to receive more
                 # messages in this sub and just process the ones remaining.
-                yield from nc._unsubscribe(sid)
+                await nc._unsubscribe(sid)
 
                 # Roundtrip to ensure that the server has sent all messages.
-                yield from nc.flush()
+                await nc.flush()
 
                 # Wait until no more messages are left,
                 # then cancel the subscription task.
                 while sub.pending_queue.qsize() > 0:
-                    yield from asyncio.sleep(0.1, loop=nc._loop)
+                    await asyncio.sleep(0.1, loop=nc._loop)
 
                 # Subscription is done and won't be receiving further
                 # messages so can throw it away now.
@@ -592,8 +586,7 @@ class Client(object):
 
         return self._loop.create_task(drain_subscription())
 
-    @asyncio.coroutine
-    def publish(self, subject, payload):
+    async def publish(self, subject, payload):
         """
         Sends a PUB command to the server on the specified subject.
 
@@ -610,10 +603,9 @@ class Client(object):
         payload_size = len(payload)
         if payload_size > self._max_payload:
             raise ErrMaxPayload
-        yield from self._publish(subject, _EMPTY_, payload, payload_size)
+        await self._publish(subject, _EMPTY_, payload, payload_size)
 
-    @asyncio.coroutine
-    def publish_request(self, subject, reply, payload):
+    async def publish_request(self, subject, reply, payload):
         """
         Publishes a message tagging it with a reply subscription
         which can be used by those receiving the message to respond.
@@ -631,12 +623,9 @@ class Client(object):
         payload_size = len(payload)
         if payload_size > self._max_payload:
             raise ErrMaxPayload
-        yield from self._publish(
-            subject, reply.encode(), payload, payload_size
-        )
+        await self._publish(subject, reply.encode(), payload, payload_size)
 
-    @asyncio.coroutine
-    def _publish(self, subject, reply, payload, payload_size):
+    async def _publish(self, subject, reply, payload, payload_size):
         """
         Sends PUB command to the NATS server.
         """
@@ -652,12 +641,11 @@ class Client(object):
         ])
         self.stats['out_msgs'] += 1
         self.stats['out_bytes'] += payload_size
-        yield from self._send_command(pub_cmd)
+        await self._send_command(pub_cmd)
         if self._flush_queue.empty():
-            yield from self._flush_pending()
+            await self._flush_pending()
 
-    @asyncio.coroutine
-    def subscribe(
+    async def subscribe(
             self,
             subject,
             queue="",
@@ -714,14 +702,13 @@ class Client(object):
             # instead of having subscription type hold over state of the conn.
             err_cb = self._error_cb
 
-            @asyncio.coroutine
-            def wait_for_msgs():
+            async def wait_for_msgs():
                 nonlocal sub
                 nonlocal err_cb
 
                 while True:
                     try:
-                        msg = yield from sub.pending_queue.get()
+                        msg = await sub.pending_queue.get()
                         sub.pending_size -= len(msg.data)
 
                         try:
@@ -734,7 +721,7 @@ class Client(object):
                                     # should be processed.
                                     self._loop.create_task(sub.coro(msg))
                                 else:
-                                    yield from sub.coro(msg)
+                                    await sub.coro(msg)
                             elif sub.cb is not None:
                                 if sub.is_async:
                                     raise NatsError(
@@ -751,7 +738,7 @@ class Client(object):
                             # All errors from calling a handler
                             # are async errors.
                             if err_cb is not None:
-                                yield from err_cb(e)
+                                await err_cb(e)
 
                     except asyncio.CancelledError:
                         break
@@ -769,11 +756,10 @@ class Client(object):
         self._ssid += 1
         ssid = self._ssid
         self._subs[ssid] = sub
-        yield from self._subscribe(sub, ssid)
+        await self._subscribe(sub, ssid)
         return ssid
 
-    @asyncio.coroutine
-    def subscribe_async(self, subject, **kwargs):
+    async def subscribe_async(self, subject, **kwargs):
         """
         Sets the subcription to use a task per message to be processed.
 
@@ -781,11 +767,10 @@ class Client(object):
           Will be removed 9.0.
         """
         kwargs["is_async"] = True
-        sid = yield from self.subscribe(subject, **kwargs)
+        sid = await self.subscribe(subject, **kwargs)
         return sid
 
-    @asyncio.coroutine
-    def unsubscribe(self, ssid, max_msgs=0):
+    async def unsubscribe(self, ssid, max_msgs=0):
         """
         Takes a subscription sequence id and removes the subscription
         from the client, optionally after receiving more than max_msgs.
@@ -800,7 +785,7 @@ class Client(object):
         # We will send these for all subs when we reconnect anyway,
         # so that we can suppress here.
         if not self.is_reconnecting:
-            yield from self.auto_unsubscribe(ssid, max_msgs)
+            await self.auto_unsubscribe(ssid, max_msgs)
 
     def _remove_sub(self, ssid, max_msgs=0):
         sub = None
@@ -821,18 +806,18 @@ class Client(object):
         ):
             sub.wait_for_msgs_task.cancel()
 
-    @asyncio.coroutine
-    def _subscribe(self, sub, ssid):
+    async def _subscribe(self, sub, ssid):
         sub_cmd = b''.join([
             SUB_OP, _SPC_,
             sub.subject.encode(), _SPC_,
             sub.queue.encode(), _SPC_, ("%d" % ssid).encode(), _CRLF_
         ])
-        yield from self._send_command(sub_cmd)
-        yield from self._flush_pending()
+        await self._send_command(sub_cmd)
+        await self._flush_pending()
 
-    @asyncio.coroutine
-    def request(self, subject, payload, timeout=0.5, expected=1, cb=None):
+    async def request(
+            self, subject, payload, timeout=0.5, expected=1, cb=None
+    ):
         """
         Implements the request/response pattern via pub/sub
         using a single wildcard subscription that handles
@@ -848,9 +833,9 @@ class Client(object):
             next_inbox.extend(self._nuid.next())
             inbox = next_inbox.decode()
 
-            sid = yield from self.subscribe(inbox, cb=cb)
-            yield from self.auto_unsubscribe(sid, expected)
-            yield from self.publish_request(subject, inbox, payload)
+            sid = await self.subscribe(inbox, cb=cb)
+            await self.auto_unsubscribe(sid, expected)
+            await self.publish_request(subject, inbox, payload)
             return sid
 
         if self._resp_sub_prefix is None:
@@ -873,12 +858,11 @@ class Client(object):
             )
 
             # Single task for handling the requests
-            @asyncio.coroutine
-            def wait_for_msgs():
+            async def wait_for_msgs():
                 nonlocal sub
                 while True:
                     try:
-                        msg = yield from sub.pending_queue.get()
+                        msg = await sub.pending_queue.get()
                         sub.pending_size -= len(msg.data)
                         token = msg.subject[INBOX_PREFIX_LEN:]
 
@@ -906,7 +890,7 @@ class Client(object):
             self._ssid += 1
             ssid = self._ssid
             self._subs[ssid] = sub
-            yield from self._subscribe(sub, ssid)
+            await self._subscribe(sub, ssid)
 
         # Use a new NUID for the token inbox and then use the future.
         token = self._nuid.next()
@@ -914,18 +898,17 @@ class Client(object):
         inbox.extend(token)
         future = asyncio.Future(loop=self._loop)
         self._resp_map[token.decode()] = future
-        yield from self.publish_request(subject, inbox.decode(), payload)
+        await self.publish_request(subject, inbox.decode(), payload)
 
         # Wait for the response or give up on timeout.
         try:
-            msg = yield from asyncio.wait_for(future, timeout, loop=self._loop)
+            msg = await asyncio.wait_for(future, timeout, loop=self._loop)
             return msg
         except asyncio.TimeoutError:
             future.cancel()
             raise ErrTimeout
 
-    @asyncio.coroutine
-    def timed_request(self, subject, payload, timeout=0.5):
+    async def timed_request(self, subject, payload, timeout=0.5):
         """
         Implements the request/response pattern via pub/sub
         using an ephemeral subscription which will be published
@@ -944,19 +927,18 @@ class Client(object):
         inbox = next_inbox.decode()
 
         future = asyncio.Future(loop=self._loop)
-        sid = yield from self.subscribe(inbox, future=future, max_msgs=1)
-        yield from self.auto_unsubscribe(sid, 1)
-        yield from self.publish_request(subject, inbox, payload)
+        sid = await self.subscribe(inbox, future=future, max_msgs=1)
+        await self.auto_unsubscribe(sid, 1)
+        await self.publish_request(subject, inbox, payload)
 
         try:
-            msg = yield from asyncio.wait_for(future, timeout, loop=self._loop)
+            msg = await asyncio.wait_for(future, timeout, loop=self._loop)
             return msg
         except asyncio.TimeoutError:
             future.cancel()
             raise ErrTimeout
 
-    @asyncio.coroutine
-    def auto_unsubscribe(self, sid, limit=1):
+    async def auto_unsubscribe(self, sid, limit=1):
         """
         Sends an UNSUB command to the server.  Unsubscribe is one of the basic building
         blocks in order to be able to define request/response semantics via pub/sub
@@ -964,20 +946,18 @@ class Client(object):
         """
         if self.is_draining:
             raise ErrConnectionDraining
-        yield from self._unsubscribe(sid, limit)
+        await self._unsubscribe(sid, limit)
 
-    @asyncio.coroutine
-    def _unsubscribe(self, sid, limit=1):
+    async def _unsubscribe(self, sid, limit=1):
         b_limit = b''
         if limit > 0:
             b_limit = ("%d" % limit).encode()
         b_sid = ("%d" % sid).encode()
         unsub_cmd = b''.join([UNSUB_OP, _SPC_, b_sid, _SPC_, b_limit, _CRLF_])
-        yield from self._send_command(unsub_cmd)
-        yield from self._flush_pending()
+        await self._send_command(unsub_cmd)
+        await self._flush_pending()
 
-    @asyncio.coroutine
-    def flush(self, timeout=60):
+    async def flush(self, timeout=60):
         """
         Sends a ping to the server expecting a pong back ensuring
         what we have written so far has made it to the server and
@@ -993,8 +973,8 @@ class Client(object):
 
         future = asyncio.Future(loop=self._loop)
         try:
-            yield from self._send_ping(future)
-            yield from asyncio.wait_for(future, timeout, loop=self._loop)
+            await self._send_ping(future)
+            await asyncio.wait_for(future, timeout, loop=self._loop)
         except asyncio.TimeoutError:
             future.cancel()
             raise ErrTimeout
@@ -1066,21 +1046,19 @@ class Client(object):
     def is_draining_pubs(self):
         return self._status == Client.DRAINING_PUBS
 
-    @asyncio.coroutine
-    def _send_command(self, cmd, priority=False):
+    async def _send_command(self, cmd, priority=False):
         if priority:
             self._pending.insert(0, cmd)
         else:
             self._pending.append(cmd)
         self._pending_data_size += len(cmd)
         if self._pending_data_size > DEFAULT_PENDING_SIZE:
-            yield from self._flush_pending()
+            await self._flush_pending()
 
-    @asyncio.coroutine
-    def _flush_pending(self):
+    async def _flush_pending(self):
         try:
             # kick the flusher!
-            yield from self._flush_queue.put(None)
+            await self._flush_queue.put(None)
 
             if not self.is_connected:
                 return
@@ -1124,8 +1102,7 @@ class Client(object):
         else:
             raise NatsError("nats: invalid connect url option")
 
-    @asyncio.coroutine
-    def _select_next_server(self):
+    async def _select_next_server(self):
         """
         Looks up in the server pool for an available server
         and attempts to connect.
@@ -1149,12 +1126,12 @@ class Client(object):
             if s.last_attempt is not None and now < s.last_attempt + self.options[
                     "reconnect_time_wait"]:
                 # Backoff connecting to server if we attempted recently.
-                yield from asyncio.sleep(
+                await asyncio.sleep(
                     self.options["reconnect_time_wait"], loop=self._loop
                 )
             try:
                 s.last_attempt = time.monotonic()
-                r, w = yield from asyncio.open_connection(
+                r, w = await asyncio.open_connection(
                     s.uri.hostname,
                     s.uri.port,
                     loop=self._loop,
@@ -1178,17 +1155,16 @@ class Client(object):
 
                 self._err = e
                 if self._error_cb is not None:
-                    yield from self._error_cb(e)
+                    await self._error_cb(e)
                 continue
 
-    @asyncio.coroutine
-    def _process_err(self, err_msg):
+    async def _process_err(self, err_msg):
         """
         Processes the raw error message sent by the server
         and close connection with current server.
         """
         if STALE_CONNECTION in err_msg:
-            yield from self._process_op_err(ErrStaleConnection)
+            await self._process_op_err(ErrStaleConnection)
             return
 
         if AUTHORIZATION_VIOLATION in err_msg:
@@ -1200,7 +1176,7 @@ class Client(object):
 
             if PERMISSIONS_ERR in m:
                 if self._error_cb is not None:
-                    yield from self._error_cb(err)
+                    await self._error_cb(err)
                 return
 
         do_cbs = False
@@ -1212,8 +1188,7 @@ class Client(object):
         # For now we handle similar as other clients and close.
         self._loop.create_task(self._close(Client.CLOSED, do_cbs))
 
-    @asyncio.coroutine
-    def _process_op_err(self, e):
+    async def _process_op_err(self, e):
         """
         Process errors which occured while reading or parsing
         the protocol. If allow_reconnect is enabled it will
@@ -1238,10 +1213,9 @@ class Client(object):
         else:
             self._process_disconnect()
             self._err = e
-            yield from self._close(Client.CLOSED, True)
+            await self._close(Client.CLOSED, True)
 
-    @asyncio.coroutine
-    def _attempt_reconnect(self):
+    async def _attempt_reconnect(self):
         if self._reading_task is not None and not self._reading_task.cancelled(
         ):
             self._reading_task.cancel()
@@ -1259,7 +1233,7 @@ class Client(object):
 
         self._err = None
         if self._disconnected_cb is not None:
-            yield from self._disconnected_cb()
+            await self._disconnected_cb()
 
         if self.is_closed:
             return
@@ -1275,8 +1249,8 @@ class Client(object):
             try:
                 # Try to establish a TCP connection to a server in
                 # the cluster then send CONNECT command to it.
-                yield from self._select_next_server()
-                yield from self._process_connect_init()
+                await self._select_next_server()
+                await self._process_connect_init()
 
                 # Consider a reconnect to be done once CONNECT was
                 # processed by the server successfully.
@@ -1296,26 +1270,26 @@ class Client(object):
                         _CRLF_
                     ])
                     self._io_writer.write(sub_cmd)
-                yield from self._io_writer.drain()
+                await self._io_writer.drain()
 
                 # Flush pending data before continuing in connected status.
                 # FIXME: Could use future here and wait for an error result
                 # to bail earlier in case there are errors in the connection.
-                yield from self._flush_pending()
+                await self._flush_pending()
                 self._status = Client.CONNECTED
-                yield from self.flush()
+                await self.flush()
                 if self._reconnected_cb is not None:
-                    yield from self._reconnected_cb()
+                    await self._reconnected_cb()
                 self._reconnection_task_future = None
                 break
             except ErrNoServers as e:
                 self._err = e
-                yield from self.close()
+                await self.close()
                 break
             except (OSError, NatsError, ErrTimeout) as e:
                 self._err = e
                 if self._error_cb is not None:
-                    yield from self._error_cb(e)
+                    await self._error_cb(e)
                 self._status = Client.RECONNECTING
                 self._current_server.last_attempt = time.monotonic()
                 self._current_server.reconnects += 1
@@ -1376,16 +1350,14 @@ class Client(object):
         connect_opts = json.dumps(options, sort_keys=True)
         return b''.join([CONNECT_OP + _SPC_ + connect_opts.encode() + _CRLF_])
 
-    @asyncio.coroutine
-    def _process_ping(self):
+    async def _process_ping(self):
         """
         Process PING sent by server.
         """
-        yield from self._send_command(PONG)
-        yield from self._flush_pending()
+        await self._send_command(PONG)
+        await self._flush_pending()
 
-    @asyncio.coroutine
-    def _process_pong(self):
+    async def _process_pong(self):
         """
         Process PONG sent by server.
         """
@@ -1395,8 +1367,7 @@ class Client(object):
             self._pongs_received += 1
             self._pings_outstanding -= 1
 
-    @asyncio.coroutine
-    def _process_msg(self, sid, subject, reply, data):
+    async def _process_msg(self, sid, subject, reply, data):
         """
         Process MSG sent by server.
         """
@@ -1434,16 +1405,14 @@ class Client(object):
                 sub.pending_size -= payload_size
 
                 if self._error_cb is not None:
-                    yield from self._error_cb(
+                    await self._error_cb(
                         ErrSlowConsumer(subject=subject, sid=sid)
                     )
                 return
             sub.pending_queue.put_nowait(msg)
         except asyncio.QueueFull:
             if self._error_cb is not None:
-                yield from self._error_cb(
-                    ErrSlowConsumer(subject=subject, sid=sid)
-                )
+                await self._error_cb(ErrSlowConsumer(subject=subject, sid=sid))
 
     def _build_message(self, subject, reply, data):
         return self.msg_class(
@@ -1504,8 +1473,7 @@ class Client(object):
         except:
             return False
 
-    @asyncio.coroutine
-    def _process_connect_init(self):
+    async def _process_connect_init(self):
         """
         Process INFO received from the server and CONNECT to the server
         with authentication.  It is also responsible of setting up the
@@ -1514,7 +1482,7 @@ class Client(object):
         self._status = Client.CONNECTING
 
         connection_completed = self._io_reader.readline()
-        info_line = yield from asyncio.wait_for(
+        info_line = await asyncio.wait_for(
             connection_completed, self.options["connect_timeout"]
         )
         if INFO_OP not in info_line:
@@ -1551,8 +1519,7 @@ class Client(object):
                 # This shouldn't happen
                 raise NatsError('nats: unable to get socket')
 
-            yield from self._io_writer.drain(
-            )  # just in case something is left
+            await self._io_writer.drain()  # just in case something is left
 
             # Check whether to reuse the original hostname for an implicit route.
             hostname = None
@@ -1561,7 +1528,7 @@ class Client(object):
             else:
                 hostname = self._current_server.uri.hostname
 
-            self._io_reader, self._io_writer = yield from asyncio.open_connection(
+            self._io_reader, self._io_writer = await asyncio.open_connection(
                 loop=self._loop,
                 limit=DEFAULT_BUFFER_SIZE,
                 sock=sock,
@@ -1575,10 +1542,10 @@ class Client(object):
 
         connect_cmd = self._connect_command()
         self._io_writer.write(connect_cmd)
-        yield from self._io_writer.drain()
+        await self._io_writer.drain()
         if self.options["verbose"]:
             future = self._io_reader.readline()
-            next_op = yield from asyncio.wait_for(
+            next_op = await asyncio.wait_for(
                 future, self.options["connect_timeout"]
             )
             if OK_OP in next_op:
@@ -1590,14 +1557,14 @@ class Client(object):
 
                 # FIXME: Maybe handling could be more special here,
                 # checking for ErrAuthorization for example.
-                # yield from self._process_err(err_msg)
+                # await self._process_err(err_msg)
                 raise NatsError("nats: " + err_msg.rstrip('\r\n'))
 
         self._io_writer.write(PING_PROTO)
-        yield from self._io_writer.drain()
+        await self._io_writer.drain()
 
         future = self._io_reader.readline()
-        next_op = yield from asyncio.wait_for(
+        next_op = await asyncio.wait_for(
             future, self.options["connect_timeout"]
         )
 
@@ -1609,7 +1576,7 @@ class Client(object):
 
             # FIXME: Maybe handling could be more special here,
             # checking for ErrAuthorization for example.
-            # yield from self._process_err(err_msg)
+            # await self._process_err(err_msg)
             raise NatsError("nats: " + err_msg.rstrip('\r\n'))
 
         if PONG_PROTO in next_op:
@@ -1625,16 +1592,14 @@ class Client(object):
         # Task for kicking the flusher queue
         self._flusher_task = self._loop.create_task(self._flusher())
 
-    @asyncio.coroutine
-    def _send_ping(self, future=None):
+    async def _send_ping(self, future=None):
         if future is None:
             future = asyncio.Future(loop=self._loop)
         self._pongs.append(future)
         self._io_writer.write(PING_PROTO)
-        yield from self._flush_pending()
+        await self._flush_pending()
 
-    @asyncio.coroutine
-    def _flusher(self):
+    async def _flusher(self):
         """
         Coroutine which continuously tries to consume pending commands
         and then flushes them to the socket.
@@ -1644,43 +1609,39 @@ class Client(object):
                 break
 
             try:
-                yield from self._flush_queue.get()
+                await self._flush_queue.get()
 
                 if self._pending_data_size > 0:
                     self._io_writer.writelines(self._pending[:])
                     self._pending = []
                     self._pending_data_size = 0
-                    yield from self._io_writer.drain()
+                    await self._io_writer.drain()
             except OSError as e:
                 if self._error_cb is not None:
-                    yield from self._error_cb(e)
-                yield from self._process_op_err(e)
+                    await self._error_cb(e)
+                await self._process_op_err(e)
                 break
             except asyncio.CancelledError:
                 break
 
-    @asyncio.coroutine
-    def _ping_interval(self):
+    async def _ping_interval(self):
         while True:
-            yield from asyncio.sleep(
-                self.options["ping_interval"], loop=self._loop
-            )
+            await asyncio.sleep(self.options["ping_interval"], loop=self._loop)
             if not self.is_connected:
                 continue
             try:
                 self._pings_outstanding += 1
                 if self._pings_outstanding > self.options[
                         "max_outstanding_pings"]:
-                    yield from self._process_op_err(ErrStaleConnection)
+                    await self._process_op_err(ErrStaleConnection)
                     return
-                yield from self._send_ping()
+                await self._send_ping()
             except asyncio.CancelledError:
                 break
             # except asyncio.InvalidStateError:
             #     pass
 
-    @asyncio.coroutine
-    def _read_loop(self):
+    async def _read_loop(self):
         """
         Coroutine which gathers bytes sent by the server
         and feeds them to the protocol parser.
@@ -1694,17 +1655,17 @@ class Client(object):
                     break
                 if self.is_connected and self._io_reader.at_eof():
                     if self._error_cb is not None:
-                        yield from self._error_cb(ErrStaleConnection)
-                    yield from self._process_op_err(ErrStaleConnection)
+                        await self._error_cb(ErrStaleConnection)
+                    await self._process_op_err(ErrStaleConnection)
                     break
 
-                b = yield from self._io_reader.read(DEFAULT_BUFFER_SIZE)
-                yield from self._ps.parse(b)
+                b = await self._io_reader.read(DEFAULT_BUFFER_SIZE)
+                await self._ps.parse(b)
             except ErrProtocol:
-                yield from self._process_op_err(ErrProtocol)
+                await self._process_op_err(ErrProtocol)
                 break
             except OSError as e:
-                yield from self._process_op_err(e)
+                await self._process_op_err(e)
                 break
             except asyncio.CancelledError:
                 break

--- a/nats/aio/nuid.py
+++ b/nats/aio/nuid.py
@@ -31,6 +31,7 @@ class NUID(object):
     NUID is an implementation of the approach for fast generation of
     unique identifiers used for inboxes in NATS.
     """
+
     def __init__(self):
         self._srand = SystemRandom()
         self._prand = Random(self._srand.randint(0, MaxInt))

--- a/nats/aio/nuid.py
+++ b/nats/aio/nuid.py
@@ -31,7 +31,6 @@ class NUID(object):
     NUID is an implementation of the approach for fast generation of
     unique identifiers used for inboxes in NATS.
     """
-
     def __init__(self):
         self._srand = SystemRandom()
         self._prand = Random(self._srand.randint(0, MaxInt))

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -72,8 +72,7 @@ class Parser(object):
         self.needed = 0
         self.msg_arg = {}
 
-    @asyncio.coroutine
-    def parse(self, data=b''):
+    async def parse(self, data=b''):
         """
         Parses the wire protocol from NATS for the client
         and dispatches the subscription callbacks.
@@ -107,20 +106,20 @@ class Parser(object):
                 err = ERR_RE.match(self.buf)
                 if err:
                     err_msg = err.groups()
-                    yield from self.nc._process_err(err_msg)
+                    await self.nc._process_err(err_msg)
                     del self.buf[:err.end()]
                     continue
 
                 ping = PING_RE.match(self.buf)
                 if ping:
                     del self.buf[:ping.end()]
-                    yield from self.nc._process_ping()
+                    await self.nc._process_ping()
                     continue
 
                 pong = PONG_RE.match(self.buf)
                 if pong:
                     del self.buf[:pong.end()]
-                    yield from self.nc._process_pong()
+                    await self.nc._process_pong()
                     continue
 
                 info = INFO_RE.match(self.buf)
@@ -154,9 +153,7 @@ class Parser(object):
                     payload = bytes(self.buf[:self.needed])
                     del self.buf[:self.needed + CRLF_SIZE]
                     self.state = AWAITING_CONTROL_LINE
-                    yield from self.nc._process_msg(
-                        sid, subject, reply, payload
-                    )
+                    await self.nc._process_msg(sid, subject, reply, payload)
                 else:
                     # Wait until we have enough bytes in buffer.
                     break

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -935,7 +935,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         # to the handling of the currently running test.
         expected_tasks = 2
         pending_tasks_count = 0
-        for task in asyncio.Task.all_tasks(loop=self.loop):
+        for task in asyncio.all_tasks(loop=self.loop):
             if not task.done():
                 pending_tasks_count += 1
         self.assertEqual(expected_tasks, pending_tasks_count)
@@ -1056,8 +1056,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         post_flush_pending_data = None
         done_once = False
 
-        @asyncio.coroutine
-        def cb(msg):
+        async def cb(msg):
             pass
 
         await nc.subscribe("example.*", cb=cb)
@@ -1327,8 +1326,7 @@ class ClientTLSTest(TLSServerTestCase):
         nc = NATS()
         msgs = []
 
-        @asyncio.coroutine
-        def subscription_handler(msg):
+        async def subscription_handler(msg):
             msgs.append(msg)
 
         payload = b'hello world'

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -15,25 +15,20 @@ class MockNatsClient:
         self._server_info = {"max_payload": 1048576, "auth_required": False}
         self._server_pool = []
 
-    @asyncio.coroutine
-    def _send_command(self, cmd):
+    async def _send_command(self, cmd):
         pass
 
-    @asyncio.coroutine
-    def _process_pong(self):
+    async def _process_pong(self):
         pass
 
-    @asyncio.coroutine
-    def _process_ping(self):
+    async def _process_ping(self):
         pass
 
-    @asyncio.coroutine
-    def _process_msg(self, sid, subject, reply, payload):
+    async def _process_msg(self, sid, subject, reply, payload):
         sub = self._subs[sid]
-        yield from sub.cb(sid, subject, reply, payload)
+        await sub.cb(sid, subject, reply, payload)
 
-    @asyncio.coroutine
-    def _process_err(self, err=None):
+    async def _process_err(self, err=None):
         pass
 
     def _process_info(self, info):
@@ -46,36 +41,35 @@ class ProtocolParserTest(NatsTestCase):
         self.loop = asyncio.new_event_loop()
 
     @async_test
-    def test_parse_ping(self):
+    async def test_parse_ping(self):
         ps = Parser(MockNatsClient())
         data = b'PING\r\n'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_pong(self):
+    async def test_parse_pong(self):
         ps = Parser(MockNatsClient())
         data = b'PONG\r\n'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_ok(self):
+    async def test_parse_ok(self):
         ps = Parser()
         data = b'+OK\r\n'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_msg(self):
+    async def test_parse_msg(self):
         nc = MockNatsClient()
         expected = b'hello world!'
 
-        @asyncio.coroutine
-        def payload_test(sid, subject, reply, payload):
+        async def payload_test(sid, subject, reply, payload):
             self.assertEqual(payload, expected)
 
         params = {
@@ -89,7 +83,7 @@ class ProtocolParserTest(NatsTestCase):
         ps = Parser(nc)
         data = b'MSG hello 1 world 12\r\n'
 
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(len(ps.msg_arg.keys()), 3)
         self.assertEqual(ps.msg_arg["subject"], b'hello')
@@ -98,86 +92,85 @@ class ProtocolParserTest(NatsTestCase):
         self.assertEqual(ps.needed, 12)
         self.assertEqual(ps.state, AWAITING_MSG_PAYLOAD)
 
-        yield from ps.parse(b'hello world!')
+        await ps.parse(b'hello world!')
         self.assertEqual(len(ps.buf), 12)
         self.assertEqual(ps.state, AWAITING_MSG_PAYLOAD)
 
         data = b'\r\n'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_msg_op(self):
+    async def test_parse_msg_op(self):
         ps = Parser()
         data = b'MSG hello'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 9)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_split_msg_op(self):
+    async def test_parse_split_msg_op(self):
         ps = Parser()
         data = b'MSG'
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 3)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_split_msg_op_space(self):
+    async def test_parse_split_msg_op_space(self):
         ps = Parser()
         data = b'MSG '
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 4)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_split_msg_op_wrong_args(self):
+    async def test_parse_split_msg_op_wrong_args(self):
         ps = Parser(MockNatsClient())
         data = b'MSG PONG\r\n'
         with self.assertRaises(ErrProtocol):
-            yield from ps.parse(data)
+            await ps.parse(data)
 
     @async_test
-    def test_parse_err_op(self):
+    async def test_parse_err_op(self):
         ps = Parser(MockNatsClient())
         data = b"-ERR 'Slow "
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 11)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
         data = b"Consumer'\r\n"
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_err(self):
+    async def test_parse_err(self):
         ps = Parser(MockNatsClient())
         data = b"-ERR 'Slow Consumer'\r\n"
-        yield from ps.parse(data)
+        await ps.parse(data)
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
 
     @async_test
-    def test_parse_info(self):
+    async def test_parse_info(self):
         nc = MockNatsClient()
         ps = Parser(nc)
         server_id = 'A' * 2048
         data = '''INFO {"server_id": "%s", "max_payload": 100, "auth_required": false, "connect_urls":["127.0.0.0.1:4223"]}\r\n''' % server_id
-        yield from ps.parse(data.encode())
+        await ps.parse(data.encode())
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
         self.assertEqual(len(nc._server_info['server_id']), 2048)
 
     @async_test
-    def test_parse_msg_long_subject_reply(self):
+    async def test_parse_msg_long_subject_reply(self):
         nc = MockNatsClient()
 
         msgs = 0
 
-        @asyncio.coroutine
-        def payload_test(sid, subject, reply, payload):
+        async def payload_test(sid, subject, reply, payload):
             nonlocal msgs
             msgs += 1
 
@@ -193,22 +186,21 @@ class ProtocolParserTest(NatsTestCase):
         ps = Parser(nc)
         reply = 'A' * 2043
         data = '''PING\r\nMSG hello 1 %s''' % reply
-        yield from ps.parse(data.encode())
-        yield from ps.parse(b'''AAAAA 0\r\n\r\nMSG hello 1 world 0''')
+        await ps.parse(data.encode())
+        await ps.parse(b'''AAAAA 0\r\n\r\nMSG hello 1 world 0''')
         self.assertEqual(msgs, 1)
         self.assertEqual(len(ps.buf), 19)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
-        yield from ps.parse(b'''\r\n\r\n''')
+        await ps.parse(b'''\r\n\r\n''')
         self.assertEqual(msgs, 2)
 
     @async_test
-    def test_parse_unknown_long_protocol_line(self):
+    async def test_parse_unknown_long_protocol_line(self):
         nc = MockNatsClient()
 
         msgs = 0
 
-        @asyncio.coroutine
-        def payload_test(sid, subject, reply, payload):
+        async def payload_test(sid, subject, reply, payload):
             nonlocal msgs
             msgs += 1
 
@@ -228,11 +220,11 @@ class ProtocolParserTest(NatsTestCase):
         # by the client, so we rely on the ping/pong interval
         # from the client to give up instead.
         data = '''PING\r\nWRONG hello 1 %s''' % reply
-        yield from ps.parse(data.encode())
-        yield from ps.parse(b'''AAAAA 0''')
+        await ps.parse(data.encode())
+        await ps.parse(b'''AAAAA 0''')
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
-        yield from ps.parse(b'''\r\n\r\n''')
-        yield from ps.parse(b'''\r\n\r\n''')
+        await ps.parse(b'''\r\n\r\n''')
+        await ps.parse(b'''\r\n\r\n''')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This should be fine as the readme already states python 3.5+, which is when async/await were introduced as keywords. Also fixed a deprecation warning around `asyncio.Task.all_tasks()` in the tests.

Resolves https://github.com/nats-io/nats.py/issues/68