### PR TITLE
Raise error when client callback functions are not coroutines

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -242,6 +242,11 @@ class Client(object):
             user_credentials=None,
             nkeys_seed=None,
     ):
+        for cb in [error_cb, disconnected_cb, closed_cb, reconnected_cb,
+                   discovered_server_cb]:
+            if cb is not None and not asyncio.iscoroutinefunction(cb):
+                raise ErrInvalidCallbackType()
+
         self._setup_server_pool(servers)
         self._loop = io_loop or loop or asyncio.get_event_loop()
         self._error_cb = error_cb

--- a/nats/aio/errors.py
+++ b/nats/aio/errors.py
@@ -115,3 +115,8 @@ class ErrConnectionReconnecting(NatsError):
 class ErrInvalidUserCredentials(NatsError):
     def __str__(self):
         return "nats: Invalid user credentials"
+
+
+class ErrInvalidCallbackType(NatsError):
+    def __str__(self):
+        return "nats: Callbacks must be coroutine functions"


### PR DESCRIPTION
Closes #127.

Raise a `nats.aio.errors.ErrInvalidCallbackType` error if any of the client callbacks are not coroutine functions (check with `asyncio.iscoroutinefunction`)

Also added relevant test cases.