### PR TITLE
fix examples

### DIFF
--- a/examples/aiohttp-example.py
+++ b/examples/aiohttp-example.py
@@ -11,11 +11,16 @@ from nats.aio.client import Client as NATS
 
 __version___ = "0.1.0"
 
+# It is very likely that the demo server will see traffic from clients other than yours.
+# To avoid this, start your own locally and modify the example to use it.
+# nats_server="nats://127.0.0.1:4222"
+nats_server="nats://demo.nats.io:4222"
+
 class Component():
 
     def __init__(self,
                  name="aiohttp-nats-example",
-                 uri="nats://127.0.0.1:4222",
+                 uri=nats_server,
                  loop=asyncio.get_event_loop(),
                  logger=logging.getLogger(),
                  nats_options={},
@@ -143,7 +148,7 @@ class Requestor():
 class Subscriber():
     def __init__(self,
                  name="nats-subscriber",
-                 uri="nats://127.0.0.1:4222",
+                 uri=nats_server,
                  loop=asyncio.get_event_loop(),
                  logger=logging.getLogger("subscriber"),
                  nats_options={},

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -5,7 +5,10 @@ from nats.aio.errors import ErrConnectionClosed, ErrTimeout, ErrNoServers
 async def run(loop):
     nc = NATS()
 
-    await nc.connect("127.0.0.1:4222", loop=loop)
+    # It is very likely that the demo server will see traffic from clients other than yours.
+    # To avoid this, start your own locally and modify the example to use it.
+    # await nc.connect("nats://127.0.0.1:4222", loop=loop)
+    await nc.connect("nats://demo.nats.io:4222", loop=loop)
 
     async def message_handler(msg):
         subject = msg.subject
@@ -36,9 +39,9 @@ async def run(loop):
     sid = await nc.subscribe("help", "workers", help_request)
 
     # Send a request and expect a single response
-    # and trigger timeout if not faster than 50 ms.
+    # and trigger timeout if not faster than 500 ms.
     try:
-        response = await nc.request("help", b'help me', 0.050)
+        response = await nc.request("help", b'help me', 0.5)
         print("Received response: {message}".format(
             message=response.data.decode()))
     except ErrTimeout:
@@ -47,6 +50,7 @@ async def run(loop):
     # Remove interest in subscription.
     await nc.unsubscribe(sid)
 
+    # Terminate connection to NATS.
     await nc.close()
 
 if __name__ == '__main__':

--- a/examples/client.py
+++ b/examples/client.py
@@ -19,7 +19,10 @@ class Client:
 
     async def start(self):
         try:
-            await self.nc.connect(io_loop=self.loop)
+            # It is very likely that the demo server will see traffic from clients other than yours.
+            # To avoid this, start your own locally and modify the example to use it.
+            # await self.nc.connect(servers=["nats://127.0.0.1:4222"], loop=self.loop)
+            await self.nc.connect(servers=["nats://demo.nats.io:4222"], loop=self.loop)
         except:
             pass
 

--- a/examples/context-manager.py
+++ b/examples/context-manager.py
@@ -12,9 +12,12 @@ async def run(loop):
         print("Connection to NATS is closed.")
         is_done.set_result(True)
 
+    # It is very likely that the demo server will see traffic from clients other than yours.
+    # To avoid this, start your own locally and modify the example to use it.
     opts = {
-        "servers": ["nats://127.0.0.1:4222"],
-        "io_loop": loop,
+        # "servers": ["nats://127.0.0.1:4222"],
+        "servers": ["nats://demo.nats.io:4222"],
+        "loop": loop,
         "closed_cb": closed_cb
     }
 

--- a/examples/coroutine_threadsafe.py
+++ b/examples/coroutine_threadsafe.py
@@ -51,12 +51,15 @@ class Component:
             await self.nc.publish(msg.reply, b'I can help!')
 
         async def run(self):
-            await self.nc.connect(loop=self.loop)
+            # It is very likely that the demo server will see traffic from clients other than yours.
+            # To avoid this, start your own locally and modify the example to use it.
+            # await self.nc.connect(servers=["nats://127.0.0.1:4222"], loop=self.loop)
+            await self.nc.connect(servers=["nats://demo.nats.io:4222"], loop=self.loop)
             await self.nc.subscribe("help", cb=self.msg_handler)
             await self.nc.flush()
 
 def another_thread(c):
-    for i in range(0, 1000):
+    for i in range(0, 5):
         print("Publishing...")
         c.publish("help", b'hello world')
         time.sleep(1)

--- a/examples/drain-sub.py
+++ b/examples/drain-sub.py
@@ -5,8 +5,10 @@ from nats.aio.errors import ErrConnectionClosed, ErrTimeout, ErrNoServers
 async def run(loop):
     nc = NATS()
 
-    # await nc.connect("demo.nats.io:4222", loop=loop)
-    await nc.connect("127.0.0.1:4222", loop=loop)
+    # It is very likely that the demo server will see traffic from clients other than yours.
+    # To avoid this, start your own locally and modify the example to use it.
+    # await nc.connect("nats://127.0.0.1:4222", loop=loop)
+    await nc.connect("nats://demo.nats.io:4222", loop=loop)
 
     async def message_handler(msg):
         subject = msg.subject
@@ -52,20 +54,21 @@ async def run(loop):
 
     # Send multiple requests and drain the subscription.
     requests = []
-    for i in range(0, 1000):
-        request = nc.request("help", b'help me', 0.2)
+    for i in range(0, 100):
+        request = nc.request("help", b'help me', 0.5)
         requests.append(request)
 
     # Wait for all the responses
     try:
         responses = await asyncio.gather(*requests)
+
+        print("Received {count} responses!".format(count=len(responses)))
+
+        for response in responses[:5]:
+            print("Received response: {message}".format(
+                message=response.data.decode()))
     except:
         pass
-    print("Received {count} responses!".format(count=len(responses)))
-
-    for response in responses[:5]:
-        print("Received response: {message}".format(
-            message=response.data.decode()))
 
     # Terminate connection to NATS.
     await nc.close()

--- a/examples/example.py
+++ b/examples/example.py
@@ -6,7 +6,10 @@ async def go(loop):
     nc = NATS()
 
     try:
-        await nc.connect(io_loop=loop)
+        # It is very likely that the demo server will see traffic from clients other than yours.
+        # To avoid this, start your own locally and modify the example to use it.
+        # await nc.connect(servers=["nats://127.0.0.1:4222"], loop=loop)
+        await nc.connect(servers=["nats://demo.nats.io:4222"], loop=loop)
     except:
         pass
 

--- a/examples/nats-pub/__main__.py
+++ b/examples/nats-pub/__main__.py
@@ -54,7 +54,7 @@ async def run(loop):
         print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
     options = {
-        "io_loop": loop,
+        "loop": loop,
         "error_cb": error_cb,
         "closed_cb": closed_cb,
         "reconnected_cb": reconnected_cb

--- a/examples/nats-req/__main__.py
+++ b/examples/nats-req/__main__.py
@@ -54,7 +54,7 @@ async def run(loop):
         print("Connected to NATS at {}...".format(nc.connected_url.netloc))
 
     options = {
-        "io_loop": loop,
+        "loop": loop,
         "error_cb": error_cb,
         "closed_cb": closed_cb,
         "reconnected_cb": reconnected_cb

--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -63,7 +63,7 @@ async def run(loop):
           subject=subject, reply=reply, data=data))
 
     options = {
-        "io_loop": loop,
+        "loop": loop,
         "error_cb": error_cb,
         "closed_cb": closed_cb,
         "reconnected_cb": reconnected_cb

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -12,9 +12,12 @@ async def run(loop):
         await asyncio.sleep(0.1, loop=loop)
         loop.stop()
 
+    # It is very likely that the demo server will see traffic from clients other than yours.
+    # To avoid this, start your own locally and modify the example to use it.
     options = {
-        "servers": ["nats://127.0.0.1:4222"],
-        "io_loop": loop,
+        # "servers": ["nats://127.0.0.1:4222"],
+        "servers": ["nats://demo.nats.io:4222"],
+        "loop": loop,
         "closed_cb": closed_cb
     }
 
@@ -30,7 +33,7 @@ async def run(loop):
 
     # Basic subscription to receive all published messages
     # which are being sent to a single topic 'discover'
-    await nc.subscribe("discover", cb=subscribe_handler)
+    await nc.subscribe("help", cb=subscribe_handler)
 
     # Subscription on queue named 'workers' so that
     # one subscriber handles message a request at a time.

--- a/examples/tls.py
+++ b/examples/tls.py
@@ -7,13 +7,14 @@ from nats.aio.errors import ErrTimeout
 async def run(loop):
     nc = NATS()
 
+    # Your local server needs to configured with the server certificate in the ../tests/certs directory.
     ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
-    ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
+    ssl_ctx.minimum_version = ssl.PROTOCOL_TLSv1_2
     ssl_ctx.load_verify_locations('../tests/certs/ca.pem')
     ssl_ctx.load_cert_chain(
         certfile='../tests/certs/client-cert.pem',
         keyfile='../tests/certs/client-key.pem')
-    await nc.connect(io_loop=loop, tls=ssl_ctx)
+    await nc.connect(servers=["nats://127.0.0.1:4222"], loop=loop, tls=ssl_ctx)
 
     async def message_handler(msg):
         subject = msg.subject

--- a/examples/wildcard.py
+++ b/examples/wildcard.py
@@ -6,7 +6,10 @@ from nats.aio.errors import ErrConnectionClosed, ErrTimeout, ErrNoServers
 async def run(loop):
     nc = NATS()
 
-    await nc.connect("nats://127.0.0.1:4222", loop=loop)
+    # It is very likely that the demo server will see traffic from clients other than yours.
+    # To avoid this, start your own locally and modify the example to use it.
+    # await nc.connect("nats://127.0.0.1:4222", loop=loop)
+    await nc.connect("nats://demo.nats.io:4222", loop=loop)
 
     async def message_handler(msg):
         subject = msg.subject


### PR DESCRIPTION
Use demo.nats.io as url everywhere but cluster. 
fix ssl example.
in drain_sub.py fix error on exception
use loop instead of io_loop.
(change timeouts to be more suitable for non local usage)
