### PR TITLE
Ability to access the connection identifier

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -167,6 +167,13 @@ class Client(object):
         self._reconnection_task = None
         self._reconnection_task_future = None
         self._max_payload = DEFAULT_MAX_PAYLOAD_SIZE
+        # This is the client id that the NATS server knows
+        # about. Useful in debugging application errors
+        # when logged with this identifier along
+        # with nats server log.
+        # This would make more sense if we log the server
+        # connected to as well in case of cluster setup.
+        self._client_id = None
         self._ssid = 0
         self._subs = {}
         self._status = Client.DISCONNECTED
@@ -1015,6 +1022,13 @@ class Client(object):
         return self._max_payload
 
     @property
+    def client_id(self):
+      """
+      Returns the client id which we received from the servers INFO
+      """
+      return self._client_id
+
+    @property
     def last_error(self):
         """
         Returns the last error which may have occured.
@@ -1508,6 +1522,9 @@ class Client(object):
 
         if 'max_payload' in self._server_info:
             self._max_payload = self._server_info["max_payload"]
+
+        if 'client_id' in self._server_info:
+            self._client_id = self._server_info["client_id"]
 
         if 'tls_required' in self._server_info and self._server_info[
                 'tls_required']:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -517,6 +517,9 @@ class Client(object):
             if self._closed_cb is not None:
                 await self._closed_cb()
 
+        # Set the client_id back to None
+        self._client_id = None
+
     async def drain(self, sid=None):
         """
         Drain will put a connection into a drain state. All subscriptions will

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1023,10 +1023,10 @@ class Client(object):
 
     @property
     def client_id(self):
-      """
-      Returns the client id which we received from the servers INFO
-      """
-      return self._client_id
+        """
+        Returns the client id which we received from the servers INFO
+        """
+        return self._client_id
 
     @property
     def last_error(self):


### PR DESCRIPTION
There are cases where I would have liked to know about the connection identifier in the application logs. This helps in figuring out what happened to those connections from the nats server log.

This pull, exposes the "client_id" which I believe is also the connection identifier in nats server.