### PR TITLE
Drain non-callback subscriptions correctly

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -577,10 +577,11 @@ class Client(object):
                 # Roundtrip to ensure that the server has sent all messages.
                 await nc.flush()
 
-                # Wait until no more messages are left,
-                # then cancel the subscription task.
-                while sub.pending_queue.qsize() > 0:
-                    await asyncio.sleep(0.1, loop=nc._loop)
+                if sub.pending_queue is not None:
+                    # Wait until no more messages are left,
+                    # then cancel the subscription task.
+                    while sub.pending_queue.qsize() > 0:
+                        await asyncio.sleep(0.1, loop=nc._loop)
 
                 # Subscription is done and won't be receiving further
                 # messages so can throw it away now.


### PR DESCRIPTION
https://github.com/nats-io/nats.py/blob/2d5ba442d09397c5318ecb90512435e8e6a6d70f/nats/aio/client.py#L654
Subscriptions that use the `future` instead of the `cb` argument do not have `pending_queue` and throw an exception when drained