### PR TITLE
Fix deprecation warnings. Remove unnecessary coverage runs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,14 +28,10 @@ format:
 test:
 	yapf --recursive --diff $(SOURCE_CODE)
 	yapf --recursive --diff tests
-	coverage erase
-	py.test
-	coverage report
+	pytest
 
 
 ci: deps
 	pipenv run yapf --recursive --diff $(SOURCE_CODE)
 	pipenv run yapf --recursive --diff tests
-	pipenv run coverage erase
-	pipenv run py.test --verbose
-	pipenv run coverage report
+	pipenv run pytest --verbose 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 pytest = "*"
 pytest-cov = "*"
 yapf = "*"
-coverage = "*"
 
 [packages]
 nkeys = "*"

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -68,14 +68,14 @@ DEFAULT_SUB_PENDING_BYTES_LIMIT = 65536 * 1024
 
 class Subscription(object):
     def __init__(
-            self,
-            subject='',
-            queue='',
-            future=None,
-            max_msgs=0,
-            is_async=False,
-            cb=None,
-            coro=None
+        self,
+        subject='',
+        queue='',
+        future=None,
+        max_msgs=0,
+        is_async=False,
+        cb=None,
+        coro=None
     ):
         self.subject = subject
         self.queue = queue
@@ -116,7 +116,6 @@ class Srv(object):
     """
     Srv is a helper data structure to hold state of a server.
     """
-
     def __init__(self, uri):
         self.uri = uri
         self.reconnects = 0
@@ -211,36 +210,36 @@ class Client(object):
         }
 
     async def connect(
-            self,
-            servers=["nats://127.0.0.1:4222"],
-            io_loop=None,
-            loop=None,
-            error_cb=None,
-            disconnected_cb=None,
-            closed_cb=None,
-            discovered_server_cb=None,
-            reconnected_cb=None,
-            name=None,
-            pedantic=False,
-            verbose=False,
-            allow_reconnect=True,
-            connect_timeout=DEFAULT_CONNECT_TIMEOUT,
-            reconnect_time_wait=DEFAULT_RECONNECT_TIME_WAIT,
-            max_reconnect_attempts=DEFAULT_MAX_RECONNECT_ATTEMPTS,
-            ping_interval=DEFAULT_PING_INTERVAL,
-            max_outstanding_pings=DEFAULT_MAX_OUTSTANDING_PINGS,
-            dont_randomize=False,
-            flusher_queue_size=DEFAULT_MAX_FLUSHER_QUEUE_SIZE,
-            no_echo=False,
-            tls=None,
-            user=None,
-            password=None,
-            token=None,
-            drain_timeout=DEFAULT_DRAIN_TIMEOUT,
-            signature_cb=None,
-            user_jwt_cb=None,
-            user_credentials=None,
-            nkeys_seed=None,
+        self,
+        servers=["nats://127.0.0.1:4222"],
+        io_loop=None,
+        loop=None,
+        error_cb=None,
+        disconnected_cb=None,
+        closed_cb=None,
+        discovered_server_cb=None,
+        reconnected_cb=None,
+        name=None,
+        pedantic=False,
+        verbose=False,
+        allow_reconnect=True,
+        connect_timeout=DEFAULT_CONNECT_TIMEOUT,
+        reconnect_time_wait=DEFAULT_RECONNECT_TIME_WAIT,
+        max_reconnect_attempts=DEFAULT_MAX_RECONNECT_ATTEMPTS,
+        ping_interval=DEFAULT_PING_INTERVAL,
+        max_outstanding_pings=DEFAULT_MAX_OUTSTANDING_PINGS,
+        dont_randomize=False,
+        flusher_queue_size=DEFAULT_MAX_FLUSHER_QUEUE_SIZE,
+        no_echo=False,
+        tls=None,
+        user=None,
+        password=None,
+        token=None,
+        drain_timeout=DEFAULT_DRAIN_TIMEOUT,
+        signature_cb=None,
+        user_jwt_cb=None,
+        user_credentials=None,
+        nkeys_seed=None,
     ):
         for cb in [error_cb, disconnected_cb, closed_cb, reconnected_cb,
                    discovered_server_cb]:
@@ -652,15 +651,15 @@ class Client(object):
             await self._flush_pending()
 
     async def subscribe(
-            self,
-            subject,
-            queue="",
-            cb=None,
-            future=None,
-            max_msgs=0,
-            is_async=False,
-            pending_msgs_limit=DEFAULT_SUB_PENDING_MSGS_LIMIT,
-            pending_bytes_limit=DEFAULT_SUB_PENDING_BYTES_LIMIT,
+        self,
+        subject,
+        queue="",
+        cb=None,
+        future=None,
+        max_msgs=0,
+        is_async=False,
+        pending_msgs_limit=DEFAULT_SUB_PENDING_MSGS_LIMIT,
+        pending_bytes_limit=DEFAULT_SUB_PENDING_BYTES_LIMIT,
     ):
         """
         Takes a subject string and optional queue string to send a SUB cmd,
@@ -822,7 +821,7 @@ class Client(object):
         await self._flush_pending()
 
     async def request(
-            self, subject, payload, timeout=0.5, expected=1, cb=None
+        self, subject, payload, timeout=0.5, expected=1, cb=None
     ):
         """
         Implements the request/response pattern via pub/sub

--- a/nats/aio/nuid.py
+++ b/nats/aio/nuid.py
@@ -31,7 +31,6 @@ class NUID(object):
     NUID is an implementation of the approach for fast generation of
     unique identifiers used for inboxes in NATS.
     """
-
     def __init__(self):
         self._srand = SystemRandom()
         self._prand = Random(self._srand.randint(0, MaxInt))

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -16,17 +16,16 @@ NATS network protocol parser.
 """
 
 import re
-import asyncio
 import json
 
 MSG_RE = re.compile(
-    b'\AMSG\s+([^\s]+)\s+([^\s]+)\s+(([^\s]+)[^\S\r\n]+)?(\d+)\r\n'
+    b'\\AMSG\\s+([^\\s]+)\\s+([^\\s]+)\\s+(([^\\s]+)[^\\S\r\n]+)?(\\d+)\r\n'
 )
-OK_RE = re.compile(b'\A\+OK\s*\r\n')
-ERR_RE = re.compile(b'\A-ERR\s+(\'.+\')?\r\n')
-PING_RE = re.compile(b'\APING\s*\r\n')
-PONG_RE = re.compile(b'\APONG\s*\r\n')
-INFO_RE = re.compile(b'\AINFO\s+([^\r\n]+)\r\n')
+OK_RE = re.compile(b'\\A\\+OK\\s*\r\n')
+ERR_RE = re.compile(b'\\A-ERR\\s+(\'.+\')?\r\n')
+PING_RE = re.compile(b'\\APING\\s*\r\n')
+PONG_RE = re.compile(b'\\APONG\\s*\r\n')
+INFO_RE = re.compile(b'\\AINFO\\s+([^\r\n]+)\r\n')
 
 INFO_OP = b'INFO'
 CONNECT_OP = b'CONNECT'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,18 +11,18 @@ from functools import wraps
 
 class Gnatsd(object):
     def __init__(
-            self,
-            port=4222,
-            user="",
-            password="",
-            token="",
-            timeout=0,
-            http_port=8222,
-            debug=False,
-            tls=False,
-            cluster_listen=None,
-            routes=[],
-            config_file=None,
+        self,
+        port=4222,
+        user="",
+        password="",
+        token="",
+        timeout=0,
+        http_port=8222,
+        debug=False,
+        tls=False,
+        cluster_listen=None,
+        routes=[],
+        config_file=None,
     ):
         self.port = port
         self.user = user


### PR DESCRIPTION
Python 3 prints a deprecation warning when you don't have double backslashes when you want a backslash in a string. It thinks you are trying to escape the following char i.e. \A which is not a valid escape sequence. Not a big deal, but clutters the test output.

I also removed the args to pytest because those are picked up from the [setup.cfg](https://github.com/charliestrawn/nats.py/blob/master/setup.cfg#L1-L3) and the coverage calls were unnecessary as well I believe because according to the [docs](https://pytest-cov.readthedocs.io/en/latest/readme.html#usage) pytest-cov takes care of that for us.