### PR TITLE
clean up subscriptions in the event of a timeout

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -921,6 +921,7 @@ class Client:
             msg = await asyncio.wait_for(future, timeout, loop=self._loop)
             return msg
         except asyncio.TimeoutError:
+            del self._resp_map[token.decode()]
             future.cancel()
             raise ErrTimeout
 
@@ -951,6 +952,7 @@ class Client:
             msg = await asyncio.wait_for(future, timeout, loop=self._loop)
             return msg
         except asyncio.TimeoutError:
+            await self.unsubscribe(sid)
             future.cancel()
             raise ErrTimeout
 


### PR DESCRIPTION
Also, aren't the `future.cancel()` redundant given that `wait_for` cancels in the event of a timeout?