### PR TITLE
allow to specify tls_hostname

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -239,6 +239,7 @@ class Client:
         flusher_queue_size=DEFAULT_MAX_FLUSHER_QUEUE_SIZE,
         no_echo=False,
         tls=None,
+        tls_hostname=None,
         user=None,
         password=None,
         token=None,
@@ -286,6 +287,8 @@ class Client:
 
         if tls:
             self.options['tls'] = tls
+        if tls_hostname:
+            self.options['tls_hostname'] = tls_hostname
 
         if self._user_credentials is not None or self._nkeys_seed is not None:
             self._setup_nkeys_connect()
@@ -1551,7 +1554,9 @@ class Client:
 
             # Check whether to reuse the original hostname for an implicit route.
             hostname = None
-            if self._current_server.tls_name is not None:
+            if "tls_hostname" in self.options:
+                hostname = self.options["tls_hostname"]
+            elif self._current_server.tls_name is not None:
                 hostname = self._current_server.tls_name
             else:
                 hostname = self._current_server.uri.hostname

--- a/readme.md
+++ b/readme.md
@@ -292,7 +292,7 @@ ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
 ssl_ctx.load_verify_locations('ca.pem')
 ssl_ctx.load_cert_chain(certfile='client-cert.pem',
                         keyfile='client-key.pem')
-await nc.connect(servers=["tls://127.0.0.1:4443"], loop=loop, tls=ssl_ctx)
+await nc.connect(servers=["tls://127.0.0.1:4443"], loop=loop, tls=ssl_ctx, tls_hostname="localhost")
 ```
 
 Setting the scheme to `tls` in the connect URL will make the client create a [default ssl context](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) automatically:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1319,6 +1319,20 @@ class ClientTLSTest(TLSServerTestCase):
             )
 
     @async_test
+    async def test_connect_tls_with_custom_hostname(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with an invalid hostname.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect(
+                io_loop=self.loop,
+                servers=['nats://127.0.0.1:4224'],
+                tls=self.ssl_ctx,
+                tls_hostname="nats.example",
+                allow_reconnect=False,
+            )
+
+    @async_test
     async def test_subscribe(self):
         nc = NATS()
         msgs = []


### PR DESCRIPTION
Add a new option `tls_hostname` to be used as `server_hostname` in `connect()` along with a ssl_ctx. This matches the behavior of the Go client, where `ServerName` can be set in a custom TLS config.