### PR TITLE
Revise tls upgrade process in newer versions of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ cache:
   - $HOME/nats-server
 
 python:
+  - "3.6"
   - "3.7"
+  - "3.8"
 
 before_install:
   - bash ./script/install_nats.sh
@@ -29,4 +31,3 @@ jobs:
   allow_failures:
     python:
       - "3.6"
-      - "3.8"


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.py/issues/134

The current process used for tls is deprecated and will be removed in python 3.9. In python 3.7, [start_tls](https://docs.python.org/3/library/asyncio-eventloop.html#tls-upgrade) was added, which is a cleaner way to do the tls upgrade process than what is currently implemented. This requires manually creating the stream reader/writer from a transport and protocol, but it isn't that hard to do. I left the previous method for python 3.5 and 3.6, as `start_tls` wasn't present for those versions.

Additionally, the `allow_failures` section of the ci config doesn't actually run those configurations, it just allows failures, so they must be run in the main section. Because of this, python 3.6 and 3.8 weren't being run in ci. I made 3.8 non-optional but left 3.6 as optional, as the tests use an api introduced in 3.7, and an exception class for tls hostname mismatches appears to be different in 3.6.

@wallyqs 