### PR TITLE
Add Python 3.8 to setuptools classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
         ],
     url='https://github.com/nats-io/nats.py',
     author='Waldemar Quevedo',


### PR DESCRIPTION
@wallyqs Adds on https://github.com/nats-io/nats.py/pull/168 by setting the 3.8 setuptools classifier.

I didn't add 3.9 yet since it's in dev.