### PR TITLE
use fstrings where possible

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -27,6 +27,7 @@ from nats.aio.errors import *
 from nats.aio.utils import new_inbox
 from nats.aio.nuid import NUID
 from nats.protocol.parser import *
+from nats.protocol import command as prot_command
 
 __version__ = '0.11.2'
 __lang__ = 'python3'
@@ -37,9 +38,6 @@ INFO_OP = b'INFO'
 CONNECT_OP = b'CONNECT'
 PING_OP = b'PING'
 PONG_OP = b'PONG'
-PUB_OP = b'PUB'
-SUB_OP = b'SUB'
-UNSUB_OP = b'UNSUB'
 OK_OP = b'+OK'
 ERR_OP = b'-ERR'
 _CRLF_ = b'\r\n'
@@ -266,12 +264,7 @@ class Msg:
         self._client = client
 
     def __repr__(self):
-        return "<{}: subject='{}' reply='{}' data='{}...'>".format(
-            self.__class__.__name__,
-            self.subject,
-            self.reply,
-            self.data[:10].decode(),
-        )
+        return f"<{self.__class__.__name__}: subject='{self.subject}' reply='{self.reply}' data='{self.data[:10].decode()}...'>"
 
     async def respond(self, data: bytes):
         if not self.reply:
@@ -758,12 +751,7 @@ class Client:
             # Avoid sending messages with empty replies.
             raise ErrBadSubject
 
-        payload_size_bytes = ("%d" % payload_size).encode()
-        pub_cmd = b''.join([
-            PUB_OP, _SPC_,
-            subject.encode(), _SPC_,
-            reply.encode(), _SPC_, payload_size_bytes, _CRLF_, payload, _CRLF_
-        ])
+        pub_cmd = prot_command.pub_cmd(subject, reply, payload)
         self.stats['out_msgs'] += 1
         self.stats['out_bytes'] += payload_size
         await self._send_command(pub_cmd)
@@ -821,11 +809,7 @@ class Client:
         self._subs.pop(sid, None)
 
     async def _send_subscribe(self, sub):
-        sub_cmd = b''.join([
-            SUB_OP, _SPC_,
-            sub._subject.encode(), _SPC_,
-            sub._queue.encode(), _SPC_, ("%d" % sub._id).encode(), _CRLF_
-        ])
+        sub_cmd = prot_command.sub_cmd(sub._subject, sub._queue, sub._id)
         await self._send_command(sub_cmd)
         await self._flush_pending()
 
@@ -916,11 +900,7 @@ class Client:
             raise ErrTimeout
 
     async def _send_unsubscribe(self, sid, limit=1):
-        b_limit = b''
-        if limit > 0:
-            b_limit = ("%d" % limit).encode()
-        b_sid = ("%d" % sid).encode()
-        unsub_cmd = b''.join([UNSUB_OP, _SPC_, b_sid, _SPC_, b_limit, _CRLF_])
+        unsub_cmd = prot_command.unsub_cmd(sid, limit)
         await self._send_command(unsub_cmd)
         await self._flush_pending()
 
@@ -1050,16 +1030,16 @@ class Client:
                 elif ":" in connect_url:
                     # Expand the scheme for the user
                     # e.g. 127.0.0.1:4222
-                    uri = urlparse("nats://%s" % connect_url)
+                    uri = urlparse(f"nats://{connect_url}")
                 else:
                     # Just use the endpoint with the default NATS port.
                     # e.g. demo.nats.io
-                    uri = urlparse("nats://%s:4222" % connect_url)
+                    uri = urlparse(f"nats://{connect_url}:4222")
 
                 # In case only endpoint with scheme was set.
                 # e.g. nats://demo.nats.io or localhost:
                 if uri.port is None:
-                    uri = urlparse("nats://%s:4222" % uri.hostname)
+                    uri = urlparse(f"nats://{uri.hostname}:4222")
             except ValueError:
                 raise NatsError("nats: invalid connect url option")
 
@@ -1245,20 +1225,13 @@ class Client:
                         # auto unsubscribe the number of messages we have left
                         max_msgs = sub._max_msgs - sub._received
 
-                    sub_cmd = b''.join([
-                        SUB_OP, _SPC_,
-                        sub._subject.encode(), _SPC_,
-                        sub._queue.encode(), _SPC_, ("%d" % sid).encode(),
-                        _CRLF_
-                    ])
+                    sub_cmd = prot_command.sub_cmd(
+                        sub._subject, sub._queue, sid
+                    )
                     self._io_writer.write(sub_cmd)
 
                     if max_msgs > 0:
-                        b_max_msgs = ("%d" % max_msgs).encode()
-                        b_sid = ("%d" % sid).encode()
-                        unsub_cmd = b''.join([
-                            UNSUB_OP, _SPC_, b_sid, _SPC_, b_max_msgs, _CRLF_
-                        ])
+                        unsub_cmd = prot_command.unsub_cmd(sid, max_msgs)
                         self._io_writer.write(unsub_cmd)
 
                 for sid in subs_to_remove:

--- a/nats/protocol/command.py
+++ b/nats/protocol/command.py
@@ -1,0 +1,18 @@
+PUB_OP = 'PUB'
+SUB_OP = 'SUB'
+UNSUB_OP = 'UNSUB'
+_CRLF_ = '\r\n'
+
+
+def pub_cmd(subject, reply, payload):
+    return f'{PUB_OP} {subject} {reply} {len(payload)}{_CRLF_}'.encode(
+    ) + payload + _CRLF_.encode()
+
+
+def sub_cmd(subject, queue, sid):
+    return f'{SUB_OP} {subject} {queue} {sid}{_CRLF_}'.encode()
+
+
+def unsub_cmd(sid, limit):
+    limit_s = '' if limit == 0 else f'{limit}'
+    return f'{UNSUB_OP} {sid} {limit_s}{_CRLF_}'.encode()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -27,7 +27,7 @@ class ClientUtilsTest(NatsTestCase):
         nc.options["name"] = None
         nc.options["no_echo"] = False
         got = nc._connect_command()
-        expected = 'CONNECT {"echo": true, "lang": "python3", "pedantic": false, "protocol": 1, "verbose": false, "version": "%s"}\r\n' % __version__
+        expected = f'CONNECT {{"echo": true, "lang": "python3", "pedantic": false, "protocol": 1, "verbose": false, "version": "{__version__}"}}\r\n'
         self.assertEqual(expected.encode(), got)
 
     def test_default_connect_command_with_name(self):
@@ -38,7 +38,7 @@ class ClientUtilsTest(NatsTestCase):
         nc.options["name"] = "secret"
         nc.options["no_echo"] = False
         got = nc._connect_command()
-        expected = 'CONNECT {"echo": true, "lang": "python3", "name": "secret", "pedantic": false, "protocol": 1, "verbose": false, "version": "%s"}\r\n' % __version__
+        expected = f'CONNECT {{"echo": true, "lang": "python3", "name": "secret", "pedantic": false, "protocol": 1, "verbose": false, "version": "{__version__}"}}\r\n'
         self.assertEqual(expected.encode(), got)
 
     def tests_generate_new_inbox(self):
@@ -197,7 +197,7 @@ class ClientTest(SingleServerTestCase):
         nc = NATS()
         await nc.connect()
         for i in range(0, 100):
-            await nc.publish("hello.%d" % i, b'A')
+            await nc.publish(f"hello.{i}", b'A')
 
         with self.assertRaises(ErrBadSubject):
             await nc.publish("", b'')
@@ -208,9 +208,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(100, nc.stats['out_msgs'])
         self.assertEqual(100, nc.stats['out_bytes'])
 
-        endpoint = '127.0.0.1:{port}'.format(
-            port=self.server_pool[0].http_port
-        )
+        endpoint = f'127.0.0.1:{self.server_pool[0].http_port}'
         httpclient = http.client.HTTPConnection(endpoint, timeout=5)
         httpclient.request('GET', '/varz')
         response = httpclient.getresponse()
@@ -223,7 +221,7 @@ class ClientTest(SingleServerTestCase):
         nc = NATS()
         await nc.connect()
         for i in range(0, 10):
-            await nc.publish("flush.%d" % i, b'AA')
+            await nc.publish(f"flush.{i}", b'AA')
             await nc.flush()
         self.assertEqual(10, nc.stats['out_msgs'])
         self.assertEqual(20, nc.stats['out_bytes'])
@@ -266,9 +264,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(2, nc.stats['out_msgs'])
         self.assertEqual(22, nc.stats['out_bytes'])
 
-        endpoint = '127.0.0.1:{port}'.format(
-            port=self.server_pool[0].http_port
-        )
+        endpoint = f'127.0.0.1:{self.server_pool[0].http_port}'
         httpclient = http.client.HTTPConnection(endpoint, timeout=5)
         httpclient.request('GET', '/connz')
         response = httpclient.getresponse()
@@ -576,9 +572,7 @@ class ClientTest(SingleServerTestCase):
             nc._subs[sub._id].received
 
         await asyncio.sleep(1)
-        endpoint = '127.0.0.1:{port}'.format(
-            port=self.server_pool[0].http_port
-        )
+        endpoint = f'127.0.0.1:{self.server_pool[0].http_port}'
         httpclient = http.client.HTTPConnection(endpoint, timeout=5)
         httpclient.request('GET', '/connz')
         response = httpclient.getresponse()
@@ -1966,19 +1960,15 @@ class ClientDrainTest(SingleServerTestCase):
         await nc2.subscribe("my-replies.*", cb=replies)
         for i in range(0, 201):
             await nc2.publish(
-                "foo",
-                b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                "foo", b'help', reply=f"my-replies.{nc._nuid.next().decode()}"
             )
             await nc2.publish(
-                "bar",
-                b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                "bar", b'help', reply=f"my-replies.{nc._nuid.next().decode()}"
             )
             await nc2.publish(
                 "quux",
                 b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                reply=f"my-replies.{nc._nuid.next().decode()}"
             )
 
             # Relinquish control so that messages are processed.
@@ -2064,19 +2054,15 @@ class ClientDrainTest(SingleServerTestCase):
         await nc2.subscribe("my-replies.*", cb=replies)
         for i in range(0, 201):
             await nc2.publish(
-                "foo",
-                b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                "foo", b'help', reply=f"my-replies.{nc._nuid.next().decode()}"
             )
             await nc2.publish(
-                "bar",
-                b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                "bar", b'help', reply=f"my-replies.{nc._nuid.next().decode()}"
             )
             await nc2.publish(
                 "quux",
                 b'help',
-                reply="my-replies.%s" % nc._nuid.next().decode()
+                reply=f"my-replies.{nc._nuid.next().decode()}"
             )
 
             # Relinquish control so that messages are processed.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -158,7 +158,7 @@ class ProtocolParserTest(NatsTestCase):
         nc = MockNatsClient()
         ps = Parser(nc)
         server_id = 'A' * 2048
-        data = '''INFO {"server_id": "%s", "max_payload": 100, "auth_required": false, "connect_urls":["127.0.0.0.1:4223"]}\r\n''' % server_id
+        data = f'INFO {{"server_id": "{server_id}", "max_payload": 100, "auth_required": false, "connect_urls":["127.0.0.0.1:4223"]}}\r\n'
         await ps.parse(data.encode())
         self.assertEqual(len(ps.buf), 0)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
@@ -185,13 +185,13 @@ class ProtocolParserTest(NatsTestCase):
 
         ps = Parser(nc)
         reply = 'A' * 2043
-        data = '''PING\r\nMSG hello 1 %s''' % reply
+        data = f'PING\r\nMSG hello 1 {reply}'
         await ps.parse(data.encode())
-        await ps.parse(b'''AAAAA 0\r\n\r\nMSG hello 1 world 0''')
+        await ps.parse(b'AAAAA 0\r\n\r\nMSG hello 1 world 0')
         self.assertEqual(msgs, 1)
         self.assertEqual(len(ps.buf), 19)
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
-        await ps.parse(b'''\r\n\r\n''')
+        await ps.parse(b'\r\n\r\n')
         self.assertEqual(msgs, 2)
 
     @async_test
@@ -219,12 +219,12 @@ class ProtocolParserTest(NatsTestCase):
         # FIXME: Malformed long protocol lines will not be detected
         # by the client, so we rely on the ping/pong interval
         # from the client to give up instead.
-        data = '''PING\r\nWRONG hello 1 %s''' % reply
+        data = f'PING\r\nWRONG hello 1 {reply}'
         await ps.parse(data.encode())
-        await ps.parse(b'''AAAAA 0''')
+        await ps.parse(b'AAAAA 0')
         self.assertEqual(ps.state, AWAITING_CONTROL_LINE)
-        await ps.parse(b'''\r\n\r\n''')
-        await ps.parse(b'''\r\n\r\n''')
+        await ps.parse(b'\r\n\r\n')
+        await ps.parse(b'\r\n\r\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Now that this is 3.6+, we can use fstrings. This change uses fstrings where possible. Also, I extracted some of the protocol logic to the protocol package, as it was duplicated in client.py. Not sure what your feelings on this are.

@wallyqs @charliestrawn 