### PR TITLE
Fix issue when reconnecting against LB

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1353,7 +1353,7 @@ class Client:
                 self._err = e
                 await self.close()
                 break
-            except (OSError, NatsError, ErrTimeout) as e:
+            except (OSError, NatsError, asyncio.TimeoutError) as e:
                 self._err = e
                 await self._error_cb(e)
                 self._status = Client.RECONNECTING

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -28,7 +28,7 @@ from nats.aio.utils import new_inbox
 from nats.aio.nuid import NUID
 from nats.protocol.parser import *
 
-__version__ = '0.11.2'
+__version__ = '0.11.4'
 __lang__ = 'python3'
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1


### PR DESCRIPTION
When a NATS Server restarted behind an LB, reconnection would fail since the proper connect timeout exception was not being caught, leaving the client hanging sometimes.

Fixes #184 