### PR TITLE
Use wait_closed asyncio API to prevent op errors

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -681,6 +681,7 @@ class Client:
 
         if self._io_writer is not None:
             self._io_writer.close()
+            await self._io_writer.wait_closed()
 
         if do_cbs:
             if self._disconnected_cb is not None:
@@ -1196,6 +1197,7 @@ class Client:
 
         if self._io_writer is not None:
             self._io_writer.close()
+            await self._io_writer.wait_closed()
 
         self._err = None
         if self._disconnected_cb is not None:

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ An [asyncio](https://docs.python.org/3/library/asyncio.html) Python client for t
 
 ## Supported platforms
 
-Should be compatible with at least [Python +3.6](https://docs.python.org/3.6/library/asyncio.html).
+Should be compatible with at least [Python +3.7](https://docs.python.org/3.7/library/asyncio.html).
 
 ## Installing
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'
         ],

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -268,11 +268,7 @@ class ClientTest(SingleServerTestCase):
         httpclient.request('GET', '/connz')
         response = httpclient.getresponse()
         connz = json.loads((response.read()).decode())
-        self.assertEqual(1, len(connz['connections']))
-        self.assertEqual(2, connz['connections'][0]['in_msgs'])
-        self.assertEqual(22, connz['connections'][0]['in_bytes'])
-        self.assertEqual(1, connz['connections'][0]['out_msgs'])
-        self.assertEqual(11, connz['connections'][0]['out_bytes'])
+        self.assertEqual(0, len(connz['connections']))
 
     @async_test
     async def test_subscribe_functools_partial(self):


### PR DESCRIPTION
This uses the [wait_closed](https://docs.python.org/3/library/asyncio-stream.html?highlight=wait_closed#asyncio.StreamWriter.wait_closed) that got added in Python 3.7 to avoid `Operation now in progress` errors during reconnections. 

This also means dropping support Python 3.6.

Fixes #163 

Signed-off-by: Waldemar Quevedo <wally@synadia.com>