### PR TITLE
js: Implement js.subscribe

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -17,6 +17,20 @@ from .aio.client import Client as NATS
 
 
 async def connect(servers=["nats://localhost:4222"], **options) -> NATS:
+    """
+    :param servers: List of servers to connect.
+    :param options: NATS connect options.
+
+    ::
+
+      import nats
+
+      # Connect to NATS demo server
+      nc = await nats.connect('demo.nats.io')
+      await nc.publish('hello', 'Hello NATS!')
+      await nc.close()
+
+    """
     nc = NATS()
     await nc.connect(servers, **options)
     return nc

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from nats.errors import *
 from nats.aio.errors import *
 from nats.nuid import NUID
+from nats.aio.subscription import *
 from nats.protocol.parser import *
 from nats.protocol import command as prot_command
 from nats.js import JetStream, JetStreamContext, JetStreamManager
@@ -69,10 +70,6 @@ DEFAULT_CONNECT_TIMEOUT = 2  # in seconds
 DEFAULT_DRAIN_TIMEOUT = 30  # in seconds
 MAX_CONTROL_LINE_SIZE = 1024
 
-# Default Pending Limits of Subscriptions
-DEFAULT_SUB_PENDING_MSGS_LIMIT = 512 * 1024
-DEFAULT_SUB_PENDING_BYTES_LIMIT = 128 * 1024 * 1024
-
 NATS_HDR_LINE = bytearray(b'NATS/1.0\r\n')
 NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
 NO_RESPONDERS_STATUS = "503"
@@ -80,268 +77,6 @@ STATUS_MSG_LEN = 3  # e.g. 20x, 40x, 50x
 CTRL_LEN = len(_CRLF_)
 STATUS_HDR = "Status"
 DESC_HDR = "Description"
-
-
-class Subscription:
-    """
-    A Subscription represents interest in a particular subject.
-
-    A Subscription should not be constructed directly, rather
-    `connection.subscribe()` should be used to get a subscription.
-
-    ::
-
-        nc = nats.connect()
-
-        # Async Subscription
-        async def cb(msg):
-          print('Received', msg)
-        await nc.subscribe('foo', cb=cb)
-
-        # Sync Subscription
-        sub = nc.subscribe('foo')
-        msg = await sub.next_msg()
-        print('Received', msg)
-    
-    """
-    def __init__(
-        self,
-        conn: 'Client',
-        id: int = 0,
-        subject: str = '',
-        queue: str = '',
-        cb: Optional[Callable[['Msg'], None]] = None,
-        future: Optional[asyncio.Future] = None,
-        max_msgs: int = 0,
-        pending_msgs_limit: int = DEFAULT_SUB_PENDING_MSGS_LIMIT,
-        pending_bytes_limit: int = DEFAULT_SUB_PENDING_BYTES_LIMIT,
-    ):
-        self._conn = conn
-        self._id = id
-        self._subject = subject
-        self._queue = queue
-        self._max_msgs = max_msgs
-        self._received = 0
-        self._cb = cb
-        self._future = future
-        self._closed = False
-
-        # Per subscription message processor.
-        self._pending_msgs_limit = pending_msgs_limit
-        self._pending_bytes_limit = pending_bytes_limit
-        self._pending_queue = asyncio.Queue(maxsize=pending_msgs_limit)
-        self._pending_size = 0
-        self._wait_for_msgs_task = None
-        self._message_iterator = None
-
-    @property
-    def subject(self) -> str:
-        """
-        Returns the subject of the `Subscription`.
-        """
-        return self._subject
-
-    @property
-    def queue(self) -> str:
-        """
-        Returns the queue name of the `Subscription` if part of a queue group.
-        """
-        return self._queue
-
-    @property
-    def messages(self) -> AsyncIterator['Msg']:
-        """
-        Retrieves an async iterator for the messages from the subscription.
-
-        This is only available if a callback isn't provided when creating a
-        subscription.
-        """
-        if not self._message_iterator:
-            raise NatsError(
-                "cannot iterate over messages with a non iteration subscription type"
-            )
-
-        return self._message_iterator
-
-    @property
-    def pending_msgs(self) -> int:
-        return self._pending_queue.qsize()
-
-    async def next_msg(self, timeout: float = 1.0):
-        """
-        :params timeout: Time to wait for next message before
-        :raises nats.errors.TimeoutError:
-
-        next_msg can be used to retrieve the next message
-        from a stream of messages using await syntax, this
-        only works when not passing a callback on `subscribe`::
-
-            sub = await nc.subscribe('hello')
-            msg = await sub.next_msg(timeout=1)
-
-        """
-        future = asyncio.Future()
-
-        async def _next_msg():
-            msg = await self._pending_queue.get()
-            future.set_result(msg)
-
-        task = asyncio.get_running_loop().create_task(_next_msg())
-        try:
-            msg = await asyncio.wait_for(future, timeout)
-            return msg
-        except asyncio.TimeoutError:
-            future.cancel()
-            task.cancel()
-            raise ErrTimeout
-
-    def _start(self, error_cb):
-        """
-        Creates the resources for the subscription to start processing messages.
-        """
-        if self._cb:
-            if not asyncio.iscoroutinefunction(self._cb) and \
-                not (hasattr(self._cb, "func") and asyncio.iscoroutinefunction(self._cb.func)):
-                raise NatsError("nats: must use coroutine for subscriptions")
-
-            self._wait_for_msgs_task = asyncio.get_running_loop().create_task(
-                self._wait_for_msgs(error_cb)
-            )
-
-        elif self._future:
-            # Used to handle the single response from a request.
-            pass
-        else:
-            self._message_iterator = _SubscriptionMessageIterator(
-                self._pending_queue
-            )
-
-    async def drain(self):
-        """
-        Removes interest in a subject, but will process remaining messages.
-        """
-        if self._conn.is_closed:
-            raise ConnectionClosedError
-        if self._conn.is_draining:
-            raise ConnectionDrainingError
-        if self._closed:
-            raise BadSubscriptionError
-
-        try:
-            # Announce server that no longer want to receive more
-            # messages in this sub and just process the ones remaining.
-            await self._conn._send_unsubscribe(self._id)
-
-            # Roundtrip to ensure that the server has sent all messages.
-            await self._conn.flush()
-
-            if self._pending_queue:
-                # Wait until no more messages are left,
-                # then cancel the subscription task.
-                await self._pending_queue.join()
-
-            # stop waiting for messages
-            self._stop_processing()
-
-            # Subscription is done and won't be receiving further
-            # messages so can throw it away now.
-            self._conn._remove_sub(self._id)
-        except asyncio.CancelledError:
-            # In case draining of a connection times out then
-            # the sub per task will be canceled as well.
-            pass
-        finally:
-            self._closed = True
-
-    async def unsubscribe(self, limit: int = 0):
-        """
-        :param limit: Max number of messages to receive before unsubscribing.
-
-        Removes interest in a subject, remaining messages will be discarded.
-
-        If `limit` is greater than zero, interest is not immediately removed,
-        rather, interest will be automatically removed after `limit` messages
-        are received.
-        """
-        if self._conn.is_closed:
-            raise ConnectionClosedError
-        if self._conn.is_draining:
-            raise ConnectionDrainingError
-        if self._closed:
-            raise BadSubscriptionError
-
-        self._max_msgs = limit
-        if limit == 0 or self._received >= limit:
-            self._stop_processing()
-            self._conn._remove_sub(self._id)
-
-        if not self._conn.is_reconnecting:
-            await self._conn._send_unsubscribe(self._id, limit=limit)
-        self._closed = True
-
-    def _stop_processing(self):
-        """
-        Stops the subscription from processing new messages.
-        """
-        if self._wait_for_msgs_task and not self._wait_for_msgs_task.done():
-            self._wait_for_msgs_task.cancel()
-        if self._message_iterator:
-            self._message_iterator._cancel()
-
-    async def _wait_for_msgs(self, error_cb):
-        """
-        A coroutine to read and process messages if a callback is provided.
-
-        Should be called as a task.
-        """
-        while True:
-            try:
-                msg = await self._pending_queue.get()
-                self._pending_size -= len(msg.data)
-
-                try:
-                    # Invoke depending of type of handler.
-                    await self._cb(msg)
-                except asyncio.CancelledError:
-                    # In case the coroutine handler gets cancelled
-                    # then stop task loop and return.
-                    break
-                except Exception as e:
-                    # All errors from calling a handler
-                    # are async errors.
-                    if error_cb:
-                        await error_cb(e)
-                finally:
-                    # indicate the message finished processing so drain can continue
-                    self._pending_queue.task_done()
-
-            except asyncio.CancelledError:
-                break
-
-
-class _SubscriptionMessageIterator:
-    def __init__(self, queue):
-        self._queue = queue
-        self._unsubscribed_future = asyncio.Future()
-
-    def _cancel(self):
-        if not self._unsubscribed_future.done():
-            self._unsubscribed_future.set_result(True)
-
-    def __aiter__(self):
-        return self
-
-    async def __anext__(self):
-        get_task = asyncio.get_running_loop().create_task(self._queue.get())
-        finished, _ = await asyncio.wait([get_task, self._unsubscribed_future],
-                                         return_when=asyncio.FIRST_COMPLETED)
-        if get_task in finished:
-            self._queue.task_done()
-            return get_task.result()
-        elif self._unsubscribed_future.done():
-            get_task.cancel()
-
-        raise StopAsyncIteration
 
 
 class Msg:
@@ -961,16 +696,20 @@ class Client:
         if self.is_connecting or self.is_reconnecting:
             raise ErrConnectionReconnecting
 
-        # Start draining the subscriptions
-        self._status = Client.DRAINING_SUBS
-
         drain_tasks = []
         for sub in self._subs.values():
-            coro = sub.drain()
+            coro = sub._drain()
             task = asyncio.get_running_loop().create_task(coro)
             drain_tasks.append(task)
 
         drain_is_done = asyncio.gather(*drain_tasks)
+
+        # Start draining the subscriptions.
+        # Relinquish CPU to allow drain tasks to start in the background,
+        # before setting state to draining.
+        await asyncio.sleep(0)
+        self._status = Client.DRAINING_SUBS
+
         try:
             await asyncio.wait_for(
                 drain_is_done, self.options["drain_timeout"]
@@ -1213,6 +952,9 @@ class Client:
 
         try:
             msg = await asyncio.wait_for(future, timeout)
+            if msg.headers and msg.headers.get(STATUS_HDR
+                                               ) == NO_RESPONDERS_STATUS:
+                raise NoRespondersError
             return msg
         except asyncio.TimeoutError:
             await sub.unsubscribe()

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -1,0 +1,286 @@
+# Copyright 2016-2021 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Default Pending Limits of Subscriptions
+DEFAULT_SUB_PENDING_MSGS_LIMIT = 512 * 1024
+DEFAULT_SUB_PENDING_BYTES_LIMIT = 128 * 1024 * 1024
+
+import asyncio
+from typing import AsyncIterator, Awaitable, Callable, List, Optional, Union, Tuple
+from nats.aio.errors import *
+from nats.errors import *
+
+
+class Subscription:
+    """
+    A Subscription represents interest in a particular subject.
+
+    A Subscription should not be constructed directly, rather
+    `connection.subscribe()` should be used to get a subscription.
+
+    ::
+
+        nc = nats.connect()
+
+        # Async Subscription
+        async def cb(msg):
+          print('Received', msg)
+        await nc.subscribe('foo', cb=cb)
+
+        # Sync Subscription
+        sub = nc.subscribe('foo')
+        msg = await sub.next_msg()
+        print('Received', msg)
+    
+    """
+    def __init__(
+        self,
+        conn: 'Client',
+        id: int = 0,
+        subject: str = '',
+        queue: str = '',
+        cb: Optional[Callable[['Msg'], None]] = None,
+        future: Optional[asyncio.Future] = None,
+        max_msgs: int = 0,
+        pending_msgs_limit: int = DEFAULT_SUB_PENDING_MSGS_LIMIT,
+        pending_bytes_limit: int = DEFAULT_SUB_PENDING_BYTES_LIMIT,
+    ):
+        self._conn = conn
+        self._id = id
+        self._subject = subject
+        self._queue = queue
+        self._max_msgs = max_msgs
+        self._received = 0
+        self._cb = cb
+        self._future = future
+        self._closed = False
+
+        # Per subscription message processor.
+        self._pending_msgs_limit = pending_msgs_limit
+        self._pending_bytes_limit = pending_bytes_limit
+        self._pending_queue = asyncio.Queue(maxsize=pending_msgs_limit)
+        self._pending_size = 0
+        self._wait_for_msgs_task = None
+        self._message_iterator = None
+
+    @property
+    def subject(self) -> str:
+        """
+        Returns the subject of the `Subscription`.
+        """
+        return self._subject
+
+    @property
+    def queue(self) -> str:
+        """
+        Returns the queue name of the `Subscription` if part of a queue group.
+        """
+        return self._queue
+
+    @property
+    def messages(self) -> AsyncIterator['Msg']:
+        """
+        Retrieves an async iterator for the messages from the subscription.
+
+        This is only available if a callback isn't provided when creating a
+        subscription.
+        """
+        if not self._message_iterator:
+            raise NatsError(
+                "cannot iterate over messages with a non iteration subscription type"
+            )
+
+        return self._message_iterator
+
+    @property
+    def pending_msgs(self) -> int:
+        return self._pending_queue.qsize()
+
+    async def next_msg(self, timeout: float = 1.0):
+        """
+        :params timeout: Time to wait for next message before
+        :raises nats.errors.TimeoutError:
+
+        next_msg can be used to retrieve the next message
+        from a stream of messages using await syntax, this
+        only works when not passing a callback on `subscribe`::
+
+            sub = await nc.subscribe('hello')
+            msg = await sub.next_msg(timeout=1)
+
+        """
+        future = asyncio.Future()
+
+        async def _next_msg():
+            msg = await self._pending_queue.get()
+            future.set_result(msg)
+
+        task = asyncio.get_running_loop().create_task(_next_msg())
+        try:
+            msg = await asyncio.wait_for(future, timeout)
+            return msg
+        except asyncio.TimeoutError:
+            future.cancel()
+            task.cancel()
+            raise ErrTimeout
+
+    def _start(self, error_cb):
+        """
+        Creates the resources for the subscription to start processing messages.
+        """
+        if self._cb:
+            if not asyncio.iscoroutinefunction(self._cb) and \
+                not (hasattr(self._cb, "func") and asyncio.iscoroutinefunction(self._cb.func)):
+                raise NatsError("nats: must use coroutine for subscriptions")
+
+            self._wait_for_msgs_task = asyncio.get_running_loop().create_task(
+                self._wait_for_msgs(error_cb)
+            )
+
+        elif self._future:
+            # Used to handle the single response from a request.
+            pass
+        else:
+            self._message_iterator = _SubscriptionMessageIterator(
+                self._pending_queue
+            )
+
+    async def drain(self):
+        """
+        Removes interest in a subject, but will process remaining messages.
+        """
+        if self._conn.is_closed:
+            raise ConnectionClosedError
+        if self._conn.is_draining:
+            raise ConnectionDrainingError
+        if self._closed:
+            raise BadSubscriptionError
+        await self._drain()
+
+    async def _drain(self):
+        try:
+            # Announce server that no longer want to receive more
+            # messages in this sub and just process the ones remaining.
+            await self._conn._send_unsubscribe(self._id)
+
+            # Roundtrip to ensure that the server has sent all messages.
+            await self._conn.flush()
+
+            if self._pending_queue:
+                # Wait until no more messages are left,
+                # then cancel the subscription task.
+                await self._pending_queue.join()
+
+            # stop waiting for messages
+            self._stop_processing()
+
+            # Subscription is done and won't be receiving further
+            # messages so can throw it away now.
+            self._conn._remove_sub(self._id)
+        except asyncio.CancelledError:
+            # In case draining of a connection times out then
+            # the sub per task will be canceled as well.
+            pass
+        finally:
+            self._closed = True
+
+    async def unsubscribe(self, limit: int = 0):
+        """
+        :param limit: Max number of messages to receive before unsubscribing.
+
+        Removes interest in a subject, remaining messages will be discarded.
+
+        If `limit` is greater than zero, interest is not immediately removed,
+        rather, interest will be automatically removed after `limit` messages
+        are received.
+        """
+        if self._conn.is_closed:
+            raise ConnectionClosedError
+        if self._conn.is_draining:
+            raise ConnectionDrainingError
+        if self._closed:
+            raise BadSubscriptionError
+
+        self._max_msgs = limit
+        if limit == 0 or self._received >= limit:
+            self._closed = True
+            self._stop_processing()
+            self._conn._remove_sub(self._id)
+
+        if not self._conn.is_reconnecting:
+            await self._conn._send_unsubscribe(self._id, limit=limit)
+
+    def _stop_processing(self):
+        """
+        Stops the subscription from processing new messages.
+        """
+        if self._wait_for_msgs_task and not self._wait_for_msgs_task.done():
+            self._wait_for_msgs_task.cancel()
+        if self._message_iterator:
+            self._message_iterator._cancel()
+
+    async def _wait_for_msgs(self, error_cb):
+        """
+        A coroutine to read and process messages if a callback is provided.
+
+        Should be called as a task.
+        """
+        while True:
+            try:
+                msg = await self._pending_queue.get()
+                self._pending_size -= len(msg.data)
+
+                try:
+                    # Invoke depending of type of handler.
+                    await self._cb(msg)
+                except asyncio.CancelledError:
+                    # In case the coroutine handler gets cancelled
+                    # then stop task loop and return.
+                    break
+                except Exception as e:
+                    # All errors from calling a handler
+                    # are async errors.
+                    if error_cb:
+                        await error_cb(e)
+                finally:
+                    # indicate the message finished processing so drain can continue
+                    self._pending_queue.task_done()
+
+            except asyncio.CancelledError:
+                break
+
+
+class _SubscriptionMessageIterator:
+    def __init__(self, queue):
+        self._queue = queue
+        self._unsubscribed_future = asyncio.Future()
+
+    def _cancel(self):
+        if not self._unsubscribed_future.done():
+            self._unsubscribed_future.set_result(True)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        get_task = asyncio.get_running_loop().create_task(self._queue.get())
+        finished, _ = await asyncio.wait([get_task, self._unsubscribed_future],
+                                         return_when=asyncio.FIRST_COMPLETED)
+        if get_task in finished:
+            self._queue.task_done()
+            return get_task.result()
+        elif self._unsubscribed_future.done():
+            get_task.cancel()
+
+        raise StopAsyncIteration

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -299,7 +299,7 @@ class ConsumerConfig(Base):
     description: Optional[str] = None
     deliver_subject: Optional[str] = None
     deliver_group: Optional[str] = None
-    deliver_policy: Optional[DeliverPolicy] = DeliverPolicy.last
+    deliver_policy: Optional[DeliverPolicy] = DeliverPolicy.all
     opt_start_seq: Optional[int] = None
     opt_start_time: Optional[int] = None
     ack_policy: Optional[AckPolicy] = AckPolicy.explicit

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -309,7 +309,7 @@ class ConsumerConfig(Base):
     replay_policy: Optional[ReplayPolicy] = ReplayPolicy.instant
     sample_freq: Optional[str] = None
     rate_limit_bps: Optional[int] = None
-    max_waiting: Optional[int] = 512
+    max_waiting: Optional[int] = None
     max_ack_pending: Optional[int] = None
     flow_control: Optional[bool] = None
     idle_heartbeat: Optional[int] = None

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -27,6 +27,30 @@ class JetStream:
     """
     JetStream returns a context that can be used to produce and consume
     messages from NATS JetStream.
+
+    :param conn: NATS Connection
+    :param prefix: Default JetStream API Prefix.
+    :param domain: Optional domain used by the JetStream API.
+    :param timeout: Timeout for all JS API actions.
+
+    ::
+
+        import asyncio
+        import nats
+
+        async def main():
+            nc = await nats.connect()
+            js = nc.jetstream()
+
+            await js.add_stream(name='hello', subjects=['hello'])
+            ack = await js.publish('hello', b'Hello JS!')
+            print(f'Ack: stream={ack.stream}, sequence={ack.seq}')
+            # Ack: stream=hello, sequence=1
+            await nc.close()
+
+        if __name__ == '__main__':
+            asyncio.run(main())
+
     """
     def __init__(
         self,
@@ -76,15 +100,98 @@ class JetStream:
 
         return api.PubAck.loads(**resp)
 
+    async def subscribe(
+        self,
+        subject: str,
+        queue: Optional[str] = None,
+        cb=None,
+        durable: Optional[str] = None,
+        stream: Optional[str] = None,
+        config: api.ConsumerConfig = None,
+        manual_ack = False,
+        ):
+        """
+        subscribe returns a `Subscription` that is bound to a push based consumer.
+
+        :param subject: Subject from a stream from JetStream.
+        :param queue: Deliver group name from a set a of queue subscribers.
+        :param durable: Name of the durable consumer to which the the subscription should be bound.
+        :param stream: Name of the stream to which the subscription should be bound.
+        :param manual_ack: Disables auto acking for async subscriptions.
+
+        ::
+
+            import asyncio
+            import nats
+
+            async def main():
+                nc = await nats.connect()
+                js = nc.jetstream()
+
+                await js.add_stream(name='hello', subjects=['hello'])
+                await js.publish('hello', b'Hello JS!')
+
+                async def greetings(msg):
+                  print('Received', msg)
+
+                await js.subscribe('hello', 'group', cb=greetings)
+
+            if __name__ == '__main__':
+                asyncio.run(main())
+
+        """
+        if stream is None:
+            stream = await self._jsm.find_stream_name_by_subject(subject)
+
+        deliver = None
+        try:
+            # TODO: Detect configuration drift with the consumer.
+            if queue is not None:
+                durable = queue
+            cinfo = await self._jsm.consumer_info(stream, durable)
+            config = cinfo.config
+
+        except nats.js.errors.NotFoundError:
+            # If not found then attempt to create a consumer.
+            if config is None:
+                # Defaults
+                config = api.ConsumerConfig(
+                    ack_policy=api.AckPolicy.explicit,
+                )             
+            elif isinstance(config, dict):
+                config = api.ConsumerConfig.loads(**config)
+            elif not isinstance(config, api.ConsumerConfig):
+                raise ValueError("nats: invalid ConsumerConfig")
+
+            if config.durable_name is None:
+                config.durable_name = durable
+            if config.deliver_group is None:
+                config.deliver_group = queue
+
+            deliver = self._nc.new_inbox()
+            config.deliver_subject = deliver
+
+            await self._jsm.add_consumer(stream, config=config)
+
+        if not manual_ack:
+            ocb = cb
+            async def new_cb(msg):
+                await ocb(msg)
+                await msg.ack()
+            cb = new_cb
+        
+        sub = await self._nc.subscribe(config.deliver_subject, config.deliver_group, cb=cb)
+        return sub
+
     async def pull_subscribe(
         self,
         subject: str,
         durable: str,
         stream: str = None,
-        config=None,
+        config: api.ConsumerConfig = None,
     ):
         """
-        pull_subscribe returns a Subscription that can be delivered messages
+        pull_subscribe returns a `PullSubscription` that can be delivered messages
         from a JetStream pull based consumer by calling `sub.fetch`.
 
         In case 'stream' is passed, there will not be a lookup of the stream

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -12,13 +12,16 @@
 # limitations under the License.
 #
 
-from nats.aio.errors import NatsError
+import nats.errors
 from nats.js import api
 
 
-class Error(NatsError):
+class Error(nats.errors.Error):
+    def __init__(self, description=None):
+        self.description = description
+
     def __str__(self):
-        return "nats: JetStream Error"
+        return f"nats: JetStream Error: {self.description}"
 
 
 class APIError(Error):

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -102,3 +102,19 @@ class NotJSMessageError(Error):
 class NoStreamResponseError(Error):
     def __str__(self):
         return "nats: no response from stream"
+
+
+class ConsumerSequenceMismatchError(Error):
+    def __init__(
+        self,
+        stream_resume_sequence=None,
+        consumer_sequence=None,
+        last_consumer_sequence=None
+    ):
+        self.stream_resume_sequence = stream_resume_sequence
+        self.consumer_sequence = consumer_sequence
+        self.last_consumer_sequence = last_consumer_sequence
+
+    def __str__(self):
+        gap = self.last_consumer_sequence - self.consumer_sequence
+        return f"nats: sequence mismatch for consumer at sequence {self.consumer_sequence} ({gap} sequences behind), should restart consumer from stream sequence {self.stream_resume_sequence}"

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -14,6 +14,7 @@
 
 import json
 from nats.js import api
+from nats.errors import *
 from nats.js.errors import *
 from nats.aio.errors import *
 from dataclasses import asdict
@@ -127,7 +128,11 @@ class JetStreamManager:
         flow_control: Optional[bool] = None,
         idle_heartbeat: Optional[int] = None,
         headers_only: Optional[bool] = None,
+        timeout=None,
     ):
+        if not timeout:
+            timeout = self._timeout
+
         if config is None:
             config = {
                 "durable_name": durable_name,
@@ -166,13 +171,13 @@ class JetStreamManager:
             resp = await self._api_request(
                 f"{self._prefix}.CONSUMER.DURABLE.CREATE.{stream}.{durable_name}",
                 req_data,
-                timeout=self._timeout
+                timeout=timeout
             )
         else:
             resp = await self._api_request(
                 f"{self._prefix}.CONSUMER.CREATE.{stream}",
                 req_data,
-                timeout=self._timeout
+                timeout=timeout
             )
         return api.ConsumerInfo.loads(**resp)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -449,3 +449,14 @@ def async_test(test_case_fun, timeout=5):
         )
 
     return wrapper
+
+
+def async_long_test(test_case_fun, timeout=10):
+    @wraps(test_case_fun)
+    def wrapper(test_case, *args, **kw):
+        asyncio.set_event_loop(test_case.loop)
+        return asyncio.run(
+            asyncio.wait_for(test_case_fun(test_case, *args, **kw), timeout)
+        )
+
+    return wrapper


### PR DESCRIPTION
Adds support to:

- Ephemeral Subscribe: 
  `js.subscribe("foo")`

- Durable 'Push Bound' Subscribe
 `js.subscribe("foo", durable="singleton")`

- Queue Subscribe with Deliver Group
 `js.subscribe("foo", "workers")`

- Ordered Consumer (ephemeral with max inflight=1 and auto resume)):
 `js.subscribe("foo", ordered_consumer=True)`

```python
            import asyncio
            import nats

            async def main():
                nc = await nats.connect()
                js = nc.jetstream()

                await js.add_stream(name='hello', subjects=['hello'])
                await js.publish('hello', b'Hello JS!')

                async def cb(msg):
                  print('Received:', msg)

                # Ephemeral Async Subscribe
                await js.subscribe('hello', cb=cb)

                # Durable Async Subscribe
                # NOTE: Only one subscription can be bound to a durable name. It also auto acks by default.
                await js.subscribe('hello', cb=cb, durable='foo')

                # Durable Sync Subscribe
                # NOTE: Sync subscribers do not auto ack.
                await js.subscribe('hello', durable='bar')

                # Queue Async Subscribe
                # NOTE: Here 'workers' becomes deliver_group, durable name and queue name.
                await js.subscribe('hello', 'workers', cb=cb)
```

Other changes:

- `nats.aio.client.Subscription` is moved to `nats.aio.subscription.Subscription` to avoid import cycles
- Fixes to headers parsing when there are inline headers + key value headers in a heartbeat
- Added `nc.new_inbox()` to get a new inbox for requests
- Implements flow control + idle_heartbeats protocols for JS push consumers