### PR TITLE
Fixed NUID generator to produce the same value in subsequent calls

### DIFF
--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -53,7 +53,7 @@ class NUID:
         suffix = bytearray(SEQ_LENGTH)
         for i in reversed(range(SEQ_LENGTH)):
             suffix[i] = DIGITS[int(l) % BASE]
-            l /= BASE
+            l //= BASE
 
         prefix.extend(suffix)
         return prefix

--- a/tests/test_nuid.py
+++ b/tests/test_nuid.py
@@ -16,7 +16,7 @@ import sys
 import unittest
 from collections import Counter
 
-from nats.nuid import NUID, MAX_SEQ, PREFIX_LENGTH, TOTAL_LENGTH
+from nats.nuid import BASE, NUID, MAX_SEQ, PREFIX_LENGTH, TOTAL_LENGTH
 
 
 class NUIDTest(unittest.TestCase):
@@ -44,6 +44,15 @@ class NUIDTest(unittest.TestCase):
             entry for entry, count in counted_entries.items() if count > 1
         ]
         self.assertEqual(len(repeated), 0)
+
+    def test_subsequent_nuid_equal(self):
+        n_tests = 10000
+        for i in range(n_tests):
+            nuid = NUID()
+            nuid._seq = MAX_SEQ - i - 10
+            nuid._inc = BASE
+
+            self.assertTrue(nuid.next() != nuid.next())
 
     def test_nuid_sequence_rollover(self):
         nuid = NUID()


### PR DESCRIPTION
The issue is that for `seq` being large enough (close to `MAX_SEQ`) with `inc` being equal to 62 (for 62x2 it works as well, but for 62xK for K > 2 the minimum required value for `seq` to reproduce the issue is more than `MAX_SEQ`) two subsequent calls to `NUID.next` produce the same value. This happens due to float division losing precision.