### PR TITLE
Add subject, sid, and sub to SlowConsumerError for the ease of debugging

### DIFF
--- a/nats/errors.py
+++ b/nats/errors.py
@@ -71,7 +71,8 @@ class SlowConsumerError(Error):
         self.sub = sub
 
     def __str__(self):
-        return "nats: slow consumer, messages dropped"
+        return "nats: slow consumer, messages dropped subject: " \
+               f"{self.subject}, sid: {self.sid}, sub: {self.sub}"
 
 
 class BadTimeoutError(Error):

--- a/tests/test_client_async_await.py
+++ b/tests/test_client_async_await.py
@@ -135,6 +135,8 @@ class ClientAsyncAwaitTest(SingleServerTestCase):
         self.assertTrue(4 <= len(errors) <= 5)
         for e in errors:
             self.assertEqual(type(e), SlowConsumerError)
+            self.assertIn("foo", str(e))
+            self.assertNotIn("bar", str(e))
         self.assertEqual(errors[0].sid, 1)
         await nc.close()
 


### PR DESCRIPTION
Thank you very much maintainers for giving us such a wonderful project.

One day we happened to have multiple thousands of error messages of 
```
nats: slow consumer, messages dropped
```
while we using 2.0.0-rc3.

It was difficult to debug as the messages didn't have the subject and sid. This small change may save us in the future.