### PR TITLE
Accept config and parameters in add_stream

### DIFF
--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -75,9 +75,11 @@ class JetStreamManager:
         """
         add_stream creates a stream.
         """
-        if not config:
-            config = api.StreamConfig.loads(**params)
-
+        if config:
+            # Merge config and kwargs
+            # In case of key collision, explicit key args (`params`) override config
+            params = {**asdict(config), **params}
+        config = api.StreamConfig.loads(**params)
         if config.name is None:
             raise ValueError("nats: stream name is required")
 

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -600,6 +600,18 @@ class JSMTest(SingleJetStreamServerTestCase):
         self.assertEqual(stream.config.name, "hello")
         self.assertIsInstance(stream.state, nats.js.api.StreamState)
 
+        # Create without name
+        with self.assertRaises(ValueError):
+            await jsm.add_stream(subjects=["hello", "world", "hello.>"])
+        # Create with config, but without name
+        with self.assertRaises(ValueError):
+            await jsm.add_stream(nats.js.api.StreamConfig())
+        # Create with config, name is provided as kwargs
+        stream_with_name = await jsm.add_stream(
+            nats.js.api.StreamConfig(), name="hi"
+        )
+        self.assertEqual(stream_with_name.config.name, "hi")
+
         # Get info
         current = await jsm.stream_info("hello")
         stream.did_create = None


### PR DESCRIPTION
This change make add_stream accept both `config` and `params`.
Current code expects only one side, so it caused unexpected
behavior. For example,
```python
>>> await add_stream(config=common_config, name="this_subject")

ValueError("nats: stream name is required")
```

This change allows the above code.

Thank you for your review maintainers.