### PR TITLE
Fix minor type hinting including `Msg`

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -86,10 +86,10 @@ class Srv:
     """
     uri: str = ''
     reconnects: int = 0
-    last_attempt: float = None
+    last_attempt: Optional[float] = None
     did_connect: bool = False
     discovered: bool = False
-    tls_name: str = None
+    tls_name: Optional[str] = None
 
 
 async def _default_error_callback(ex):
@@ -926,7 +926,7 @@ class Client:
             raise TimeoutError
 
     @property
-    def connected_url(self) -> str:
+    def connected_url(self) -> Optional[str]:
         if self.is_connected:
             return self._current_server.uri
         else:

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -59,7 +59,7 @@ class Msg:
         self,
         subject: str = '',
         reply: str = '',
-        data: str = b'',
+        data: bytes = b'',
         sid: int = 0,
         client=None,
         headers: dict = None

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -416,11 +416,11 @@ class AccountInfo(Base):
 
 @dataclass
 class RawStreamMsg(Base):
-    subject: str = None
-    seq: int = None
-    data: bytes = None
-    hdrs: bytes = None
-    headers: dict = None
+    subject: Optional[str] = None
+    seq: Optional[int] = None
+    data: Optional[bytes] = None
+    hdrs: Optional[bytes] = None
+    headers: Optional[dict] = None
     # TODO: Add 'time'
 
     @property


### PR DESCRIPTION
`Msg` had a type hinting `str` for `data`. Which misled my understanding at some point.
I ran `mypy` and found similar errors and here's a small fix.
Thank you very much for your review.