### PR TITLE
Improve type annotations

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 #
 
-import asyncio
 from .aio.client import Client as NATS
 
 

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -506,7 +506,7 @@ class Client:
         """
         await self._close(Client.CLOSED)
 
-    async def _close(self, status, do_cbs=True) -> None:
+    async def _close(self, status, do_cbs: bool=True) -> None:
         if self.is_closed:
             self._status = status
             return
@@ -764,7 +764,7 @@ class Client:
         await self._send_subscribe(sub)
         return sub
 
-    def _remove_sub(self, sid, max_msgs=0) -> None:
+    def _remove_sub(self, sid, max_msgs: int=0) -> None:
         self._subs.pop(sid, None)
 
     async def _send_subscribe(self, sub) -> None:
@@ -828,7 +828,7 @@ class Client:
         return msg
 
     async def _request_new_style(
-        self, subject, payload, timeout=1, headers=None
+        self, subject, payload, timeout: int=1, headers=None
     ):
         if self.is_draining_pubs:
             raise ConnectionDrainingError
@@ -871,7 +871,7 @@ class Client:
         next_inbox.extend(self._nuid.next())
         return next_inbox.decode()
 
-    async def _request_old_style(self, subject, payload, timeout=1):
+    async def _request_old_style(self, subject, payload, timeout: int=1):
         """
         Implements the request/response pattern via pub/sub
         using an ephemeral subscription which will be published
@@ -896,7 +896,7 @@ class Client:
             future.cancel()
             raise TimeoutError
 
-    async def _send_unsubscribe(self, sid, limit=1) -> None:
+    async def _send_unsubscribe(self, sid, limit: int=1) -> None:
         unsub_cmd = prot_command.unsub_cmd(sid, limit)
         await self._send_command(unsub_cmd)
         await self._flush_pending()
@@ -997,7 +997,7 @@ class Client:
     def is_draining_pubs(self) -> bool:
         return self._status == Client.DRAINING_PUBS
 
-    async def _send_command(self, cmd, priority=False) -> None:
+    async def _send_command(self, cmd, priority: bool=False) -> None:
         if priority:
             self._pending.insert(0, cmd)
         else:
@@ -1514,7 +1514,7 @@ class Client:
         """
         self._status = Client.DISCONNECTED
 
-    def _process_info(self, info, initial_connection=False) -> None:
+    def _process_info(self, info, initial_connection: bool=False) -> None:
         """
         Process INFO lines sent by the server to reconfigure client
         with latest updates from cluster to enable server discovery.

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -506,7 +506,7 @@ class Client:
         """
         await self._close(Client.CLOSED)
 
-    async def _close(self, status, do_cbs: bool=True) -> None:
+    async def _close(self, status, do_cbs: bool = True) -> None:
         if self.is_closed:
             self._status = status
             return
@@ -764,7 +764,7 @@ class Client:
         await self._send_subscribe(sub)
         return sub
 
-    def _remove_sub(self, sid, max_msgs: int=0) -> None:
+    def _remove_sub(self, sid, max_msgs: int = 0) -> None:
         self._subs.pop(sid, None)
 
     async def _send_subscribe(self, sub) -> None:
@@ -828,7 +828,7 @@ class Client:
         return msg
 
     async def _request_new_style(
-        self, subject, payload, timeout: int=1, headers=None
+        self, subject, payload, timeout: int = 1, headers=None
     ):
         if self.is_draining_pubs:
             raise ConnectionDrainingError
@@ -871,7 +871,7 @@ class Client:
         next_inbox.extend(self._nuid.next())
         return next_inbox.decode()
 
-    async def _request_old_style(self, subject, payload, timeout: int=1):
+    async def _request_old_style(self, subject, payload, timeout: int = 1):
         """
         Implements the request/response pattern via pub/sub
         using an ephemeral subscription which will be published
@@ -896,7 +896,7 @@ class Client:
             future.cancel()
             raise TimeoutError
 
-    async def _send_unsubscribe(self, sid, limit: int=1) -> None:
+    async def _send_unsubscribe(self, sid, limit: int = 1) -> None:
         unsub_cmd = prot_command.unsub_cmd(sid, limit)
         await self._send_command(unsub_cmd)
         await self._flush_pending()
@@ -997,7 +997,7 @@ class Client:
     def is_draining_pubs(self) -> bool:
         return self._status == Client.DRAINING_PUBS
 
-    async def _send_command(self, cmd, priority: bool=False) -> None:
+    async def _send_command(self, cmd, priority: bool = False) -> None:
         if priority:
             self._pending.insert(0, cmd)
         else:
@@ -1514,7 +1514,7 @@ class Client:
         """
         self._status = Client.DISCONNECTED
 
-    def _process_info(self, info, initial_connection: bool=False) -> None:
+    def _process_info(self, info, initial_connection: bool = False) -> None:
         """
         Process INFO lines sent by the server to reconfigure client
         with latest updates from cluster to enable server discovery.

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -18,14 +18,13 @@ import time
 import ssl
 import ipaddress
 import base64
-import datetime
 from random import shuffle
 from urllib.parse import urlparse
 import sys
 import logging
-from typing import AsyncIterator, Awaitable, Callable, List, Optional, Union, Tuple
+from typing import Awaitable, Callable, List, Optional, Tuple, Union
 from email.parser import BytesParser
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from nats.errors import *
 from nats.aio.errors import *
@@ -35,8 +34,7 @@ from nats.aio.msg import Msg
 from nats.aio.subscription import *
 from nats.protocol.parser import *
 from nats.protocol import command as prot_command
-from nats.js import JetStream, JetStreamContext, JetStreamManager
-from nats.js import api
+from nats.js import JetStreamContext, JetStreamManager
 
 __version__ = '2.0.0rc5'
 __lang__ = 'python3'

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1018,7 +1018,7 @@ class Client:
             pass
 
     def _setup_server_pool(self, connect_url):
-        if type(connect_url) is str:
+        if isinstance(connect_url, str):
             try:
                 if "nats://" in connect_url or "tls://" in connect_url:
                     # Closer to how the Go client handles this.
@@ -1043,7 +1043,7 @@ class Client:
             if uri.hostname is None or uri.hostname == "none":
                 raise Error("nats: invalid hostname in connect url")
             self._server_pool.append(Srv(uri))
-        elif type(connect_url) is list:
+        elif isinstance(connect_url, list):
             try:
                 for server in connect_url:
                     uri = urlparse(server)
@@ -1218,7 +1218,8 @@ class Client:
                 for sid, sub in self._subs.items():
                     max_msgs = 0
                     if sub._max_msgs > 0:
-                        # If we already hit the message limit, remove the subscription and don't resubscribe
+                        # If we already hit the message limit, remove the subscription and don't
+                        # resubscribe
                         if sub._received >= sub._max_msgs:
                             subs_to_remove.append(sid)
                             continue
@@ -1535,7 +1536,7 @@ class Client:
 
                     # Check whether we should reuse the original hostname.
                     if 'tls_required' in self._server_info and self._server_info['tls_required'] \
-                           and self._host_is_ip(uri.hostname):
+                            and self._host_is_ip(uri.hostname):
                         srv.tls_name = self._current_server.uri.hostname
 
                     # Filter for any similar server in the server pool already.
@@ -1558,7 +1559,7 @@ class Client:
         try:
             ipaddress.ip_address(connect_url)
             return True
-        except:
+        except Exception:
             return False
 
     async def _process_connect_init(self):
@@ -1582,7 +1583,7 @@ class Client:
 
         try:
             srv_info = json.loads(info.decode())
-        except:
+        except Exception:
             raise Error("nats: info message, json parse error")
 
         self._server_info = srv_info

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -114,7 +114,7 @@ class Client:
     DRAINING_SUBS = 5
     DRAINING_PUBS = 6
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<nats client v{__version__}>"
 
     def __init__(self) -> None:
@@ -1554,7 +1554,7 @@ class Client:
                 if not initial_connection and connect_urls and self._discovered_server_cb:
                     self._discovered_server_cb()
 
-    def _host_is_ip(self, connect_url):
+    def _host_is_ip(self, connect_url) -> bool:
         try:
             ipaddress.ip_address(connect_url)
             return True

--- a/nats/aio/errors.py
+++ b/nats/aio/errors.py
@@ -27,7 +27,7 @@ class NatsError(nats.errors.Error):
 
 class ErrConnectionClosed(nats.errors.ConnectionClosedError):
     """
-    
+
     .. deprecated:: v2.0.0
 
     Please use `nats.errors.ConnectionClosedError` instead.
@@ -37,7 +37,7 @@ class ErrConnectionClosed(nats.errors.ConnectionClosedError):
 
 class ErrDrainTimeout(nats.errors.DrainTimeoutError):
     """
-    
+
     .. deprecated:: v2.0.0
 
     Please use `nats.errors.DrainTimeoutError` instead.
@@ -47,7 +47,7 @@ class ErrDrainTimeout(nats.errors.DrainTimeoutError):
 
 class ErrInvalidUserCredentials(nats.errors.InvalidUserCredentialsError):
     """
-    
+
     .. deprecated:: v2.0.0
 
     Please use `nats.errors.InvalidUserCredentialsError` instead.

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -63,7 +63,7 @@ class Msg:
         sid: int = 0,
         client=None,
         headers: dict = None
-    ):
+    ) -> None:
         self.subject = subject
         self.reply = reply
         self.data = data
@@ -91,7 +91,7 @@ class Msg:
 
         await self._client.publish(self.reply, data, headers=self.headers)
 
-    async def ack(self):
+    async def ack(self) -> None:
         """
         ack acknowledges a message delivered by JetStream.
         """
@@ -108,7 +108,7 @@ class Msg:
         self._ackd = True
         return resp
 
-    async def nak(self):
+    async def nak(self) -> None:
         """
         nak negatively acknowledges a message delivered by JetStream triggering a redelivery.
         """
@@ -125,7 +125,7 @@ class Msg:
             raise NotJSMessageError
         await self._client.publish(self.reply, Msg.Ack.Progress)
 
-    async def term(self):
+    async def term(self) -> None:
         """
         term terminates a message delivered by JetStream and disables redeliveries.
         """
@@ -207,7 +207,7 @@ class Msg:
             timestamp: str = None,
             stream: str = None,
             consumer: str = None,
-        ):
+        ) -> None:
             self.sequence = sequence
             self.num_pending = num_pending
             self.num_delivered = num_delivered

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -221,8 +221,8 @@ class Msg:
                 raise NotJSMessageError
             tokens = reply.split('.')
             if len(tokens) != Msg.Ack.V1TokenCount or \
-                   tokens[0] != Msg.Ack.Prefix0 or \
-                   tokens[1] != Msg.Ack.Prefix1:
+                    tokens[0] != Msg.Ack.Prefix0 or \
+                    tokens[1] != Msg.Ack.Prefix1:
                 raise NotJSMessageError
             return tokens
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -164,7 +164,7 @@ class Msg:
     def _get_metadata_fields(self, reply):
         return Msg.Metadata._get_metadata_fields(reply)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}(subject='{self.subject}' reply='{self.reply}')"
 
     def _check_reply(self):
@@ -226,5 +226,5 @@ class Msg:
                 raise NotJSMessageError
             return tokens
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return f"<{self.__class__.__name__}: stream='{self.stream}' consumer='{self.consumer}' sequence=({self.sequence.stream}, {self.sequence.consumer}) timestamp={self.timestamp}>"

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -13,7 +13,7 @@
 #
 
 import datetime
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from nats.errors import Error, NotJSMessageError, MsgAlreadyAckdError
 
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -150,7 +150,8 @@ class Msg:
         t = datetime.datetime.fromtimestamp(int(tokens[7]) / 1_000_000_000.0)
         metadata = Msg.Metadata(
             sequence=Msg.Metadata.SequencePair(
-                stream=int(tokens[5]), consumer=int(tokens[6])
+                stream=int(tokens[5]),
+                consumer=int(tokens[6]),
             ),
             num_delivered=int(tokens[4]),
             num_pending=int(tokens[8]),

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -13,14 +13,13 @@
 #
 
 # Default Pending Limits of Subscriptions
+from nats.aio.msg import Msg
+from nats.errors import *
+from nats.aio.errors import *
+from typing import AsyncIterator, Callable, Optional
+import asyncio
 DEFAULT_SUB_PENDING_MSGS_LIMIT = 512 * 1024
 DEFAULT_SUB_PENDING_BYTES_LIMIT = 128 * 1024 * 1024
-
-import asyncio
-from typing import AsyncIterator, Callable, Optional
-from nats.aio.errors import *
-from nats.errors import *
-from nats.aio.msg import Msg
 
 
 class Subscription:
@@ -156,7 +155,7 @@ class Subscription:
         """
         if self._cb:
             if not asyncio.iscoroutinefunction(self._cb) and \
-                not (hasattr(self._cb, "func") and asyncio.iscoroutinefunction(self._cb.func)):
+                    not (hasattr(self._cb, "func") and asyncio.iscoroutinefunction(self._cb.func)):
                 raise Error("nats: must use coroutine for subscriptions")
 
             self._wait_for_msgs_task = asyncio.get_running_loop().create_task(

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -56,7 +56,7 @@ class Subscription:
         max_msgs: int = 0,
         pending_msgs_limit: int = DEFAULT_SUB_PENDING_MSGS_LIMIT,
         pending_bytes_limit: int = DEFAULT_SUB_PENDING_BYTES_LIMIT,
-    ):
+    ) -> None:
         self._conn = conn
         self._id = id
         self._subject = subject
@@ -137,7 +137,7 @@ class Subscription:
         """
         future = asyncio.Future()
 
-        async def _next_msg():
+        async def _next_msg() -> None:
             msg = await self._pending_queue.get()
             future.set_result(msg)
 
@@ -183,7 +183,7 @@ class Subscription:
             raise BadSubscriptionError
         await self._drain()
 
-    async def _drain(self):
+    async def _drain(self) -> None:
         try:
             # Announce server that no longer want to receive more
             # messages in this sub and just process the ones remaining.
@@ -236,7 +236,7 @@ class Subscription:
         if not self._conn.is_reconnecting:
             await self._conn._send_unsubscribe(self._id, limit=limit)
 
-    def _stop_processing(self):
+    def _stop_processing(self) -> None:
         """
         Stops the subscription from processing new messages.
         """
@@ -245,7 +245,7 @@ class Subscription:
         if self._message_iterator:
             self._message_iterator._cancel()
 
-    async def _wait_for_msgs(self, error_cb):
+    async def _wait_for_msgs(self, error_cb) -> None:
         """
         A coroutine to read and process messages if a callback is provided.
 
@@ -277,11 +277,11 @@ class Subscription:
 
 
 class _SubscriptionMessageIterator:
-    def __init__(self, queue):
+    def __init__(self, queue) -> None:
         self._queue = queue
         self._unsubscribed_future = asyncio.Future()
 
-    def _cancel(self):
+    def _cancel(self) -> None:
         if not self._unsubscribed_future.done():
             self._unsubscribed_future.set_result(True)
 

--- a/nats/errors.py
+++ b/nats/errors.py
@@ -20,47 +20,47 @@ class Error(Exception):
 
 
 class TimeoutError(asyncio.TimeoutError):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: timeout"
 
 
 class NoRespondersError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: no responders available for request"
 
 
 class StaleConnectionError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: stale connection"
 
 
 class ConnectionClosedError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: connection closed"
 
 
 class SecureConnRequiredError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: secure connection required"
 
 
 class SecureConnWantedError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: secure connection not available"
 
 
 class SecureConnFailedError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: secure connection failed"
 
 
 class BadSubscriptionError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: invalid subscription"
 
 
 class BadSubjectError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: invalid subject"
 
 
@@ -70,63 +70,63 @@ class SlowConsumerError(Error):
         self.sid = sid
         self.sub = sub
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: slow consumer, messages dropped subject: " \
                f"{self.subject}, sid: {self.sid}, sub: {self.sub}"
 
 
 class BadTimeoutError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: timeout invalid"
 
 
 class AuthorizationError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: authorization failed"
 
 
 class NoServersError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: no servers available for connection"
 
 
 class JsonParseError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: connect message, json parse err"
 
 
 class MaxPayloadError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: maximum payload exceeded"
 
 
 class DrainTimeoutError(TimeoutError):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: draining connection timed out"
 
 
 class ConnectionDrainingError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: connection draining"
 
 
 class ConnectionReconnectingError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: connection reconnecting"
 
 
 class InvalidUserCredentialsError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: invalid user credentials"
 
 
 class InvalidCallbackTypeError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: callbacks must be coroutine functions"
 
 
 class ProtocolError(Error):
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: protocol error"
 
 
@@ -135,7 +135,7 @@ class NotJSMessageError(Error):
     When it is attempted to use an API meant for JetStream on a message
     that does not belong to a stream.
     """
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: not a JetStream message"
 
 
@@ -143,5 +143,5 @@ class MsgAlreadyAckdError(Error):
     def __init__(self, msg=None) -> None:
         self._msg = msg
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"nats: message was already acknowledged: {self._msg}"

--- a/nats/errors.py
+++ b/nats/errors.py
@@ -65,7 +65,7 @@ class BadSubjectError(Error):
 
 
 class SlowConsumerError(Error):
-    def __init__(self, subject=None, sid=None, sub=None):
+    def __init__(self, subject=None, sid=None, sub=None) -> None:
         self.subject = subject
         self.sid = sid
         self.sub = sub
@@ -140,7 +140,7 @@ class NotJSMessageError(Error):
 
 
 class MsgAlreadyAckdError(Error):
-    def __init__(self, msg=None):
+    def __init__(self, msg=None) -> None:
         self._msg = msg
 
     def __str__(self):

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -436,7 +436,7 @@ class KeyValueConfig(Base):
     description: Optional[str] = None
     max_value_size: Optional[int] = None
     history: Optional[int] = None
-    ttl: int = None  # in seconds
+    ttl: Optional[int] = None  # in seconds
     max_bytes: Optional[int] = None
     storage: Optional[StorageType] = None
     replicas: Optional[int] = None

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -12,8 +12,7 @@
 # limitations under the License.
 #
 
-from dataclasses import dataclass, field, fields, asdict
-from datetime import datetime, timezone
+from dataclasses import asdict, dataclass, fields
 from enum import Enum
 from typing import Any, Dict, List, Optional
 import json

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -102,7 +102,7 @@ class StreamSource(Base):
     filter_subject: Optional[str] = None
     external: Optional[ExternalStream] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.external, dict):
             self.external = ExternalStream.loads(**self.external)
 
@@ -132,7 +132,7 @@ class StreamState(Base):
     num_deleted: Optional[int] = None
     lost: Optional[LostStreamData] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.lost, dict):
             self.lost = LostStreamData.loads(**self.lost)
 
@@ -188,7 +188,7 @@ class StreamConfig(Base):
     deny_purge: Optional[bool] = False
     allow_rollup_hdrs: Optional[bool] = False
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.placement, dict):
             self.placement = Placement.loads(**self.placement)
         if isinstance(self.mirror, dict):
@@ -215,7 +215,7 @@ class ClusterInfo(Base):
     name: Optional[str] = None
     replicas: Optional[List[PeerInfo]] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.replicas:
             self.replicas = [
                 PeerInfo.loads(**item) if isinstance(item, dict) else item
@@ -235,7 +235,7 @@ class StreamInfo(Base):
     cluster: Optional[ClusterInfo] = None
     did_create: Optional[bool] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.config, dict):
             self.config = StreamConfig.loads(**self.config)
         if isinstance(self.state, dict):
@@ -325,7 +325,7 @@ class ConsumerConfig(Base):
     idle_heartbeat: Optional[int] = None
     headers_only: Optional[bool] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.ack_wait:
             self.ack_wait = self.ack_wait // 1_000_000_000
 
@@ -357,7 +357,7 @@ class ConsumerInfo(Base):
     cluster: Optional[ClusterInfo] = None
     push_bound: Optional[bool] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.delivered, dict):
             self.delivered = SequenceInfo.loads(**self.delivered)
         if isinstance(self.ack_floor, dict):
@@ -406,7 +406,7 @@ class AccountInfo(Base):
     api: APIStats
     domain: Optional[str] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if isinstance(self.limits, dict):
             self.limits = AccountLimits.loads(**self.limits)
         if isinstance(self.api, dict):

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -55,6 +55,7 @@ class JetStream:
             asyncio.run(main())
 
     """
+
     def __init__(
         self,
         conn,
@@ -505,6 +506,7 @@ class JetStream:
         """
         PushSubscription is a subscription that is delivered messages.
         """
+
         def __init__(self, js, sub, stream, consumer) -> None:
             self._js = js
             self._stream = stream
@@ -541,6 +543,7 @@ class JetStream:
         """
         PullSubscription is a subscription that can fetch messages.
         """
+
         def __init__(self, js, sub, stream, consumer, deliver) -> None:
             # JS/JSM context
             self._js = js
@@ -631,7 +634,7 @@ class JetStream:
                         # for other fetch requests.
                         continue
                     return msg
-                except:
+                except Exception:
                     # Fallthrough to make request in case this failed.
                     pass
 
@@ -673,7 +676,7 @@ class JetStream:
                         continue
                     needed -= 1
                     msgs.append(msg)
-                except:
+                except Exception:
                     pass
 
             # First request: Use no_wait to synchronously get as many available
@@ -805,5 +808,6 @@ class JetStreamContext(JetStream, JetStreamManager, KeyValueManager):
     JetStreamContext includes the fully featured context for interacting
     with JetStream.
     """
+
     def __init__(self, conn, **opts) -> None:
         super().__init__(conn, **opts)

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -60,7 +60,7 @@ class JetStream:
         conn,
         prefix=api.DefaultPrefix,
         domain=None,
-        timeout=5,
+        timeout: int=5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -21,10 +21,9 @@ from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 from nats.js.manager import JetStreamManager
 from nats.js.kv import KeyValueManager
-from nats.js.headers import *
+from nats.js.headers import LAST_CONSUMER_SEQ_HDR
 from nats.js import api
 from typing import Optional, Callable
-from dataclasses import asdict
 
 
 class JetStream:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -61,7 +61,7 @@ class JetStream:
         prefix=api.DefaultPrefix,
         domain=None,
         timeout=5,
-    ):
+    ) -> None:
         self._prefix = prefix
         if domain is not None:
             self._prefix = f"$JS.{domain}.API"
@@ -274,7 +274,7 @@ class JetStream:
         if cb and not manual_ack:
             ocb = cb
 
-            async def new_cb(msg):
+            async def new_cb(msg) -> None:
                 await ocb(msg)
                 try:
                     await msg.ack()
@@ -389,7 +389,7 @@ class JetStream:
         return timeout - (time.monotonic() - start_time)
 
     class _JSI():
-        def __init__(self):
+        def __init__(self) -> None:
             self._stream = None
             self._ordered = None
             self._conn = None
@@ -410,11 +410,11 @@ class JetStream:
             # background task that resets an ordered consumer
             self._reset_task = None
 
-        def track_sequences(self, reply):
+        def track_sequences(self, reply) -> None:
             self._fciseq += 1
             self._cmeta = reply
 
-        def schedule_flow_control_response(self, reply):
+        def schedule_flow_control_response(self, reply) -> None:
             self._fcr = reply
             self._fcd = self._fciseq
 
@@ -490,7 +490,7 @@ class JetStream:
 
             return True
 
-        async def recreate_consumer(self):
+        async def recreate_consumer(self) -> None:
             try:
                 cinfo = await self._js._jsm.add_consumer(
                     self._stream,
@@ -505,7 +505,7 @@ class JetStream:
         """
         PushSubscription is a subscription that is delivered messages.
         """
-        def __init__(self, js, sub, stream, consumer):
+        def __init__(self, js, sub, stream, consumer) -> None:
             self._js = js
             self._stream = stream
             self._consumer = consumer
@@ -541,7 +541,7 @@ class JetStream:
         """
         PullSubscription is a subscription that can fetch messages.
         """
-        def __init__(self, js, sub, stream, consumer, deliver):
+        def __init__(self, js, sub, stream, consumer, deliver) -> None:
             # JS/JSM context
             self._js = js
             self._nc = js._nc
@@ -792,7 +792,7 @@ class JetStream:
             stream=None,
             consumer=None,
             nms=None,
-        ):
+        ) -> None:
             self._prefix = prefix
             self._nc = conn
             self._stream = stream
@@ -805,5 +805,5 @@ class JetStreamContext(JetStream, JetStreamManager, KeyValueManager):
     JetStreamContext includes the fully featured context for interacting
     with JetStream.
     """
-    def __init__(self, conn, **opts):
+    def __init__(self, conn, **opts) -> None:
         super().__init__(conn, **opts)

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -60,7 +60,7 @@ class JetStream:
         conn,
         prefix=api.DefaultPrefix,
         domain=None,
-        timeout: int=5,
+        timeout: int = 5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -375,7 +375,7 @@ class JetStream:
             return msg.header[api.StatusHdr]
 
     @classmethod
-    def _is_processable_msg(cls, status, msg):
+    def _is_processable_msg(cls, status, msg) -> bool:
         if not status:
             return True
         # FIXME: Skip any other 4XX errors?
@@ -445,7 +445,7 @@ class JetStream:
                         await self._conn._error_cb(ecs)
             return did_reset
 
-        async def reset_ordered_consumer(self, sseq):
+        async def reset_ordered_consumer(self, sseq) -> bool:
             # FIXME: Handle AUTO_UNSUB called previously to this.
 
             # Replace current subscription.

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -55,13 +55,12 @@ class JetStream:
             asyncio.run(main())
 
     """
-
     def __init__(
         self,
         conn,
-        prefix=api.DefaultPrefix,
-        domain=None,
-        timeout: int = 5,
+        prefix: str = api.DefaultPrefix,
+        domain: Optional[str] = None,
+        timeout: float = 5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:
@@ -506,7 +505,6 @@ class JetStream:
         """
         PushSubscription is a subscription that is delivered messages.
         """
-
         def __init__(self, js, sub, stream, consumer) -> None:
             self._js = js
             self._stream = stream
@@ -543,7 +541,6 @@ class JetStream:
         """
         PullSubscription is a subscription that can fetch messages.
         """
-
         def __init__(self, js, sub, stream, consumer, deliver) -> None:
             # JS/JSM context
             self._js = js
@@ -808,6 +805,5 @@ class JetStreamContext(JetStream, JetStreamManager, KeyValueManager):
     JetStreamContext includes the fully featured context for interacting
     with JetStream.
     """
-
     def __init__(self, conn, **opts) -> None:
         super().__init__(conn, **opts)

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -21,7 +21,7 @@ class Error(nats.errors.Error):
     """
     An Error raised by the NATS client when using JetStream.
     """
-    def __init__(self, description=None):
+    def __init__(self, description=None) -> None:
         self.description = description
 
     def __str__(self):
@@ -49,7 +49,7 @@ class APIError(Error):
         err_code=None,
         stream=None,
         seq=None
-    ):
+    ) -> None:
         self.code = code
         self.err_code = err_code
         self.description = description
@@ -129,7 +129,7 @@ class ConsumerSequenceMismatchError(Error):
         stream_resume_sequence=None,
         consumer_sequence=None,
         last_consumer_sequence=None
-    ):
+    ) -> None:
         self.stream_resume_sequence = stream_resume_sequence
         self.consumer_sequence = consumer_sequence
         self.last_consumer_sequence = last_consumer_sequence
@@ -154,7 +154,7 @@ class KeyDeletedError(Error):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
-    def __init__(self, entry=None, op=None):
+    def __init__(self, entry=None, op=None) -> None:
         self.entry = entry
         self.op = op
 

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -24,7 +24,7 @@ class Error(nats.errors.Error):
     def __init__(self, description=None) -> None:
         self.description = description
 
-    def __str__(self):
+    def __str__(self) -> str:
         desc = ''
         if self.description:
             desc = self.description
@@ -79,7 +79,7 @@ class APIError(Error):
         else:
             raise APIError(**err)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"nats: {self.__class__.__name__}: code={self.code} err_code={self.err_code} description='{self.description}'"
 
 
@@ -115,7 +115,7 @@ class NoStreamResponseError(Error):
     """
     Raised if the client gets a 503 when publishing a message.
     """
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: no response from stream"
 
 
@@ -134,7 +134,7 @@ class ConsumerSequenceMismatchError(Error):
         self.consumer_sequence = consumer_sequence
         self.last_consumer_sequence = last_consumer_sequence
 
-    def __str__(self):
+    def __str__(self) -> str:
         gap = self.last_consumer_sequence - self.consumer_sequence
         return f"nats: sequence mismatch for consumer at sequence {self.consumer_sequence} ({gap} sequences behind), should restart consumer from stream sequence {self.stream_resume_sequence}"
 
@@ -158,5 +158,5 @@ class KeyDeletedError(Error):
         self.entry = entry
         self.op = op
 
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: key was deleted"

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -234,7 +234,7 @@ class KeyValueManager:
             allow_rollup_hdrs=True,
             deny_delete=True,
         )
-        resp = await self.add_stream(stream)
+        await self.add_stream(stream)
 
         kv = KeyValue()
         kv._name = config.bucket

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -12,13 +12,11 @@
 # limitations under the License.
 #
 
-import json
 from nats.js import api
 from nats.errors import *
 from nats.js.errors import *
 from nats.js.headers import *
-from dataclasses import dataclass, asdict
-from typing import Any, Dict, List, Optional
+from dataclasses import dataclass
 import base64
 
 KV_OP = "KV-Operation"

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -71,7 +71,7 @@ class KeyValue:
         """
         BucketStatus is the status of a KeyValue bucket.
         """
-        def __init__(self):
+        def __init__(self) -> None:
             self._nfo = None
             self._bucket = None
 
@@ -110,7 +110,7 @@ class KeyValue:
         def __repr__(self):
             return f"<KeyValue.{self.__class__.__name__}: bucket={self.bucket} values={self.values} history={self.history} ttl={self.ttl}>"
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._name = None
         self._stream = None
         self._pre = None

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -107,7 +107,7 @@ class KeyValue:
         def stream_info(self):
             return self._nfo
 
-        def __repr__(self):
+        def __repr__(self) -> str:
             return f"<KeyValue.{self.__class__.__name__}: bucket={self.bucket} values={self.values} history={self.history} ttl={self.ttl}>"
 
     def __init__(self) -> None:
@@ -157,7 +157,7 @@ class KeyValue:
         pa = await self._js.publish(f"{self._pre}{key}", value, headers=hdrs)
         return pa.sequence
 
-    async def delete(self, key: str):
+    async def delete(self, key: str) -> bool:
         """
         delete will place a delete marker and remove all previous revisions.
         """
@@ -166,7 +166,7 @@ class KeyValue:
         await self._js.publish(f"{self._pre}{key}", headers=hdrs)
         return True
 
-    async def purge(self, key: str):
+    async def purge(self, key: str) -> bool:
         """
         purge will remove the key and all revisions.
         """

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -31,7 +31,7 @@ class KeyValue:
     KeyValue uses the JetStream KeyValue functionality.
 
     .. note::
-       This functionality is EXPERIMENTAL and may be changed in later releases.   
+       This functionality is EXPERIMENTAL and may be changed in later releases.
 
     ::
 
@@ -60,7 +60,7 @@ class KeyValue:
     @dataclass
     class Entry:
         """
-        An entry from a KeyValue store in JetStream.       
+        An entry from a KeyValue store in JetStream.
         """
         bucket: str
         key: str

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -102,7 +102,6 @@ class JetStreamManager:
 
     async def consumer_info(self, stream, consumer, timeout=None):
         # TODO: Validate the stream and consumer names.
-        msg = None
         if timeout is None:
             timeout = self._timeout
         resp = await self._api_request(

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -33,9 +33,9 @@ class JetStreamManager:
     def __init__(
         self,
         conn,
-        prefix=api.DefaultPrefix,
-        domain=None,
-        timeout: int = 5,
+        prefix: str = api.DefaultPrefix,
+        domain: str = None,
+        timeout: float = 5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:
@@ -221,7 +221,10 @@ class JetStreamManager:
         return raw_msg
 
     async def _api_request(
-        self, req_subject, req: bytes = b'', timeout: int = 5
+        self,
+        req_subject,
+        req: bytes = b'',
+        timeout: str = 5,
     ):
         resp = None
         try:

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -19,8 +19,8 @@ from nats.errors import *
 from nats.js.errors import *
 from nats.aio.errors import *
 from email.parser import BytesParser
-from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict
+from typing import Optional
 
 NATS_HDR_LINE = bytearray(b'NATS/1.0\r\n')
 NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -36,7 +36,7 @@ class JetStreamManager:
         conn,
         prefix=api.DefaultPrefix,
         domain=None,
-        timeout=5,
+        timeout: int=5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:
@@ -221,7 +221,7 @@ class JetStreamManager:
             raw_msg.headers = headers
         return raw_msg
 
-    async def _api_request(self, req_subject, req=b'', timeout=5):
+    async def _api_request(self, req_subject, req: bytes=b'', timeout: int=5):
         resp = None
         try:
             msg = await self._nc.request(req_subject, req, timeout=timeout)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -30,13 +30,12 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
-
     def __init__(
         self,
         conn,
         prefix=api.DefaultPrefix,
         domain=None,
-        timeout: int=5,
+        timeout: int = 5,
     ) -> None:
         self._prefix = prefix
         if domain is not None:
@@ -221,7 +220,9 @@ class JetStreamManager:
             raw_msg.headers = headers
         return raw_msg
 
-    async def _api_request(self, req_subject, req: bytes=b'', timeout: int=5):
+    async def _api_request(
+        self, req_subject, req: bytes = b'', timeout: int = 5
+    ):
         resp = None
         try:
             msg = await self._nc.request(req_subject, req, timeout=timeout)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -30,13 +30,14 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
+
     def __init__(
         self,
         conn,
         prefix=api.DefaultPrefix,
         domain=None,
         timeout=5,
-    ):
+    ) -> None:
         self._prefix = prefix
         if domain is not None:
             self._prefix = f"$JS.{domain}.API"

--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -36,7 +36,7 @@ class NUID:
         self._prand = Random(self._srand.randint(0, MaxInt))
         self._seq = self._prand.randint(0, MAX_SEQ)
         self._inc = MIN_INC + self._prand.randint(BASE + 1, INC)
-        self._prefix = b''
+        self._prefix = bytearray()
         self.randomize_prefix()
 
     def next(self) -> bytearray:

--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -31,7 +31,7 @@ class NUID:
     NUID is an implementation of the approach for fast generation of
     unique identifiers used for inboxes in NATS.
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self._srand = SystemRandom()
         self._prand = Random(self._srand.randint(0, MaxInt))
         self._seq = self._prand.randint(0, MAX_SEQ)
@@ -58,12 +58,12 @@ class NUID:
         prefix.extend(suffix)
         return prefix
 
-    def randomize_prefix(self):
+    def randomize_prefix(self) -> None:
         random_bytes = (
             self._srand.getrandbits(8) for i in range(PREFIX_LENGTH)
         )
         self._prefix = bytearray(DIGITS[c % BASE] for c in random_bytes)
 
-    def reset_sequential(self):
+    def reset_sequential(self) -> None:
         self._seq = self._prand.randint(0, MAX_SEQ)
         self._inc = MIN_INC + self._prand.randint(0, INC)

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -105,7 +105,7 @@ class Parser:
                         del self.buf[:msg.end()]
                         self.state = AWAITING_MSG_PAYLOAD
                         continue
-                    except:
+                    except Exception:
                         raise ProtocolError("nats: malformed MSG")
 
                 msg = HMSG_RE.match(self.buf)
@@ -124,7 +124,7 @@ class Parser:
                         del self.buf[:msg.end()]
                         self.state = AWAITING_MSG_PAYLOAD
                         continue
-                    except:
+                    except Exception:
                         raise ProtocolError("nats: malformed MSG")
 
                 ok = OK_RE.match(self.buf)
@@ -208,5 +208,6 @@ class ErrProtocol(ProtocolError):
     """
     .. deprecated:: v2.0.0
     """
+
     def __str__(self) -> str:
         return "nats: Protocol Error"

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -17,6 +17,7 @@ NATS network protocol parser.
 
 import re
 import json
+from typing import Any, Dict
 
 from nats.errors import ProtocolError
 
@@ -81,7 +82,7 @@ class Parser:
         self.state = AWAITING_CONTROL_LINE
         self.needed = 0
         self.header_needed = 0
-        self.msg_arg = {}
+        self.msg_arg: Dict[str, Any] = {}
 
     async def parse(self, data: bytes = b''):
         """
@@ -208,6 +209,5 @@ class ErrProtocol(ProtocolError):
     """
     .. deprecated:: v2.0.0
     """
-
     def __str__(self) -> str:
         return "nats: Protocol Error"

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -83,7 +83,7 @@ class Parser:
         self.header_needed = 0
         self.msg_arg = {}
 
-    async def parse(self, data: bytes=b''):
+    async def parse(self, data: bytes = b''):
         """
         Parses the wire protocol from NATS for the client
         and dispatches the subscription callbacks.

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -73,7 +73,7 @@ class Parser:
         self.nc = nc
         self.reset()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<nats protocol parser state={self.state}>"
 
     def reset(self) -> None:
@@ -208,5 +208,5 @@ class ErrProtocol(ProtocolError):
     """
     .. deprecated:: v2.0.0
     """
-    def __str__(self):
+    def __str__(self) -> str:
         return "nats: Protocol Error"

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -69,14 +69,14 @@ PERMISSIONS_ERR = "permissions violation"
 
 
 class Parser:
-    def __init__(self, nc=None):
+    def __init__(self, nc=None) -> None:
         self.nc = nc
         self.reset()
 
     def __repr__(self):
         return f"<nats protocol parser state={self.state}>"
 
-    def reset(self):
+    def reset(self) -> None:
         self.buf = bytearray()
         self.state = AWAITING_CONTROL_LINE
         self.needed = 0

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -83,7 +83,7 @@ class Parser:
         self.header_needed = 0
         self.msg_arg = {}
 
-    async def parse(self, data=b''):
+    async def parse(self, data: bytes=b''):
         """
         Parses the wire protocol from NATS for the client
         and dispatches the subscription callbacks.

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ async def main():
     nc = await nats.connect("nats://demo.nats.io:4222")
 
     # You can also use the following for TLS against the demo server.
-    # 
+    #
     # nc = await nats.connect("tls://demo.nats.io:4443")
 
     async def message_handler(msg):
@@ -115,7 +115,7 @@ async def main():
     psub = await js.pull_subscribe("foo", "psub")
 
     # Fetch and ack messagess from consumer.
-    for i in range(0, 10):    
+    for i in range(0, 10):
         msgs = await psub.fetch(1)
         for msg in msgs:
             print(msg)
@@ -190,7 +190,7 @@ async def run():
 
 *Note*: If getting SSL certificate errors in OS X, try first installing the `certifi` certificate bundle. If using Python 3.7 for example, then run:
 
-```
+```ps
 $ /Applications/Python\ 3.7/Install\ Certificates.command
  -- pip install --upgrade certifi
 Collecting certifi
@@ -207,7 +207,7 @@ Since [v0.9.0](https://github.com/nats-io/nats.py/releases/tag/v0.9.0) release,
 you can also optionally install [NKEYS](https://github.com/nats-io/nkeys.py) in order to use
 the new NATS v2.0 auth features:
 
-```
+```sh
 pip install nats-py[nkeys]
 ```
 
@@ -219,12 +219,10 @@ await nats.connect("tls://connect.ngs.global:4222", user_credentials="/path/to/s
 
 ## Development
 
-To run the tests:
-
-```sh
-python3 -m pipenv install
-python3 -m pytest 
-```
+1. [Install nats server](https://docs.nats.io/running-a-nats-service/introduction/installation).
+1. Make sure the server is available in your PATH: `nats-server -v`.
+1. Install dependencies: `python3 -m pipenv install`.
+1. Run tests: `python3 -m pytest`.
 
 ## License
 


### PR DESCRIPTION
1. Add some simple type annotations
2. Fix some type errors as reported by mypy. 139 more remains.
3. Remove unused imports, expand a few simple star imports.
4. Autoformat the code with autopep8. And on top of it reformat with yapf again to keep compatibility with what you have.

See commits for each change. 

My motivation is that I started to use the upcoming JetStream support and it's pretty raw so far. It has some type errors and issues with the API. I hope to fix it in future PRs if this one goes well.

Also, it would be great to have flake8 passing but oh well, not all at once. I hope to find time for this one too.