### PR TITLE
Fix type errors in /nats/js/

### DIFF
--- a/nats/js/__init__.py
+++ b/nats/js/__init__.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-from .client import JetStream, JetStreamContext
+from .client import JetStreamContext
 from .manager import JetStreamManager
 
-__all__ = ["JetStream", "JetStreamManager", "JetStreamContext"]
+__all__ = ["JetStreamManager", "JetStreamContext"]

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -59,7 +59,7 @@ class Base:
             del opts[m]
         return klass(**opts)
 
-    def asjson(self):
+    def asjson(self) -> str:
         # Filter and remove any null values since invalid for Go.
         cfg = asdict(self)
         for k, v in dict(cfg).items():

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -26,7 +26,6 @@ from nats.js.headers import LAST_CONSUMER_SEQ_HDR
 from nats.js import api
 from typing import Awaitable, Optional, Callable
 
-
 NATS_HDR_LINE = bytearray(b'NATS/1.0\r\n')
 NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
 
@@ -59,7 +58,6 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
             asyncio.run(main())
 
     """
-
     def __init__(
         self,
         conn,
@@ -306,6 +304,7 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
                 await msg.ack()
             except nats.errors.MsgAlreadyAckdError:
                 pass
+
         return new_callback
 
     async def pull_subscribe(
@@ -374,7 +373,9 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
 
         consumer = durable
         sub = await self._nc.subscribe(deliver.decode())
-        return JetStreamContext.PullSubscription(self, sub, stream, consumer, deliver)
+        return JetStreamContext.PullSubscription(
+            self, sub, stream, consumer, deliver
+        )
 
     @classmethod
     def is_status_msg(cls, msg):
@@ -398,7 +399,10 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
         return timeout - (time.monotonic() - start_time)
 
     class _JSI():
-        def __init__(self, js: "JetStreamContext", conn, stream, ordered, psub, sub, ccreq) -> None:
+        def __init__(
+            self, js: "JetStreamContext", conn, stream, ordered, psub, sub,
+            ccreq
+        ) -> None:
             self._conn = conn
             self._js = js
             self._stream = stream
@@ -505,7 +509,6 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
         """
         PushSubscription is a subscription that is delivered messages.
         """
-
         def __init__(self, js, sub, stream, consumer) -> None:
             self._js = js
             self._stream = stream
@@ -542,7 +545,6 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
         """
         PullSubscription is a subscription that can fetch messages.
         """
-
         def __init__(self, js, sub, stream, consumer, deliver) -> None:
             # JS/JSM context
             self._js = js
@@ -701,7 +703,9 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
 
                 try:
                     for i in range(0, needed):
-                        deadline = JetStreamContext._time_until(timeout, start_time)
+                        deadline = JetStreamContext._time_until(
+                            timeout, start_time
+                        )
                         msg = await self._sub.next_msg(timeout=deadline)
                         status = JetStreamContext.is_status_msg(msg)
                         if status == api.NoMsgsStatus:
@@ -770,7 +774,9 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
             # Wait for the rest of the messages to be delivered to the internal pending queue.
             try:
                 for i in range(0, needed):
-                    deadline = JetStreamContext._time_until(timeout, start_time)
+                    deadline = JetStreamContext._time_until(
+                        timeout, start_time
+                    )
                     if deadline < 0:
                         return msgs
 

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -71,6 +71,7 @@ class KeyValue:
         """
         BucketStatus is the status of a KeyValue bucket.
         """
+
         def __init__(self) -> None:
             self._nfo = None
             self._bucket = None
@@ -207,13 +208,11 @@ class KeyValueManager:
         kv._js = self
         return kv
 
-    async def create_key_value(self, **config) -> KeyValue:
+    async def create_key_value(self, **params) -> KeyValue:
         """
         create_key_value takes an api.KeyValueConfig and creates a KV in JetStream.
         """
-        if not isinstance(config, api.KeyValueConfig):
-            config = api.KeyValueConfig.loads(**config)
-
+        config = api.KeyValueConfig.loads(**params)
         if not config.history:
             config.history = 1
         if not config.replicas:

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -72,7 +72,6 @@ class KeyValue:
         """
         BucketStatus is the status of a KeyValue bucket.
         """
-
         def __init__(self) -> None:
             self._nfo = None
             self._bucket = None

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -25,7 +25,6 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
-
     def __init__(
         self,
         conn,

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -13,33 +13,26 @@
 #
 
 import json
-import base64
 from nats.js import api
-from nats.errors import *
-from nats.js.errors import *
-from nats.aio.errors import *
+from nats.errors import NoRespondersError
+from nats.js.errors import ServiceUnavailableError, APIError
 from email.parser import BytesParser
 from dataclasses import asdict
 from typing import Optional
-
-NATS_HDR_LINE = bytearray(b'NATS/1.0\r\n')
-NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
 
 
 class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
+
     def __init__(
         self,
         conn,
         prefix: str = api.DefaultPrefix,
-        domain: str = None,
         timeout: float = 5,
     ) -> None:
         self._prefix = prefix
-        if domain is not None:
-            self._prefix = f"$JS.{domain}.API"
         self._nc = conn
         self._timeout = timeout
         self._hdr_parser = BytesParser()
@@ -79,13 +72,13 @@ class JetStreamManager:
             # Merge config and kwargs
             # In case of key collision, explicit key args (`params`) override config
             params = {**asdict(config), **params}
-        config = api.StreamConfig.loads(**params)
-        if config.name is None:
+        merged_config = api.StreamConfig.loads(**params)
+        if merged_config.name is None:
             raise ValueError("nats: stream name is required")
 
-        data = config.asjson()
+        data = merged_config.asjson()
         resp = await self._api_request(
-            f"{self._prefix}.STREAM.CREATE.{config.name}",
+            f"{self._prefix}.STREAM.CREATE.{merged_config.name}",
             data.encode(),
             timeout=self._timeout
         )
@@ -142,7 +135,7 @@ class JetStreamManager:
         # TODO: Convert from seconds into nanoseconds.
 
         if config is None:
-            config = {
+            config_dict = {
                 "durable_name": durable_name,
                 "description": description,
                 "deliver_subject": deliver_subject,
@@ -164,14 +157,14 @@ class JetStreamManager:
         elif isinstance(config, api.ConsumerConfig):
             # Try to transform the config.
             durable_name = config.durable_name
-            config = asdict(config)
+            config_dict = asdict(config)
 
         # Cleanup empty values.
         # FIXME: Make this part of Base
-        for k, v in dict(config).items():
+        for k, v in dict(config_dict).items():
             if v is None:
-                del config[k]
-        req = {"stream_name": stream, "config": config}
+                del config_dict[k]
+        req = {"stream_name": stream, "config": config_dict}
         req_data = json.dumps(req).encode()
 
         resp = None
@@ -197,34 +190,11 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def get_last_msg(
-        self,
-        stream_name: str,
-        subject: str,
-    ):
-        """
-        get_last_msg retrieves a message from a stream.
-        """
-        req_subject = f"{self._prefix}.STREAM.MSG.GET.{stream_name}"
-        req = {'last_by_subj': subject}
-        data = json.dumps(req)
-        resp = await self._api_request(req_subject, data.encode())
-        raw_msg = api.RawStreamMsg.loads(**resp['message'])
-        if raw_msg.hdrs:
-            hdrs = base64.b64decode(raw_msg.hdrs)
-            raw_headers = hdrs[len(NATS_HDR_LINE):]
-            parsed_headers = self._jsm._hdr_parser.parsebytes(raw_headers)
-            headers = {}
-            for k, v in parsed_headers.items():
-                headers[k] = v
-            raw_msg.headers = headers
-        return raw_msg
-
     async def _api_request(
         self,
         req_subject,
         req: bytes = b'',
-        timeout: str = 5,
+        timeout: float = 5,
     ):
         resp = None
         try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
+[tool:mypy]
+python_version=3.7
+ignore_missing_imports=true
+follow_imports=silent
+show_error_codes=true
+
 [tool:pytest]
 addopts=--cov=nats --cov-report html
 testpaths=tests


### PR DESCRIPTION
The PR makes `mypy ./nats/js/` pass without errors. The diff may seem scary but there should be no backward-incompatible changes, except merging the `JetStream` class into `JetStreamContext`.

I want to bring later more extensive type annotations.

BTW, flake8 now passes too.