### PR TITLE
Improve type annotations in nats/js/

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -629,7 +629,7 @@ class Client:
         payload: bytes = b'',
         reply: str = '',
         headers: dict = None
-    ):
+    ) -> None:
         """
         Publishes a NATS message.
 
@@ -689,7 +689,7 @@ class Client:
 
     async def _send_publish(
         self, subject, reply, payload, payload_size, headers
-    ):
+    ) -> None:
         """
         Sends PUB command to the NATS server.
         """

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -22,7 +22,7 @@ from random import shuffle
 from urllib.parse import urlparse
 import sys
 import logging
-from typing import Awaitable, Callable, List, Optional, Tuple, Union
+from typing import Awaitable, Callable, List, Optional, Tuple, Type, Union
 from email.parser import BytesParser
 from dataclasses import dataclass
 
@@ -103,7 +103,7 @@ class Client:
     Asyncio based client for NATS.
     """
 
-    msg_class = Msg
+    msg_class: Type[Msg] = Msg
 
     # FIXME: Use an enum instead.
     DISCONNECTED = 0
@@ -1513,7 +1513,7 @@ class Client:
             reply=reply.decode(),
             data=data,
             headers=headers,
-            client=self
+            _client=self,
         )
 
     def _process_disconnect(self) -> None:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -131,7 +131,7 @@ class Client:
         self._bare_io_writer = None
         self._io_writer = None
         self._err = None
-        self._error_cb = None
+        self._error_cb = _default_error_callback
         self._disconnected_cb = None
         self._closed_cb = None
         self._discovered_server_cb = None

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional
 from nats.errors import Error, NotJSMessageError, MsgAlreadyAckdError
 
-
 if TYPE_CHECKING:
     from nats import NATS
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -14,6 +14,7 @@
 
 import datetime
 from dataclasses import dataclass
+from typing import Optional
 from nats.errors import Error, NotJSMessageError, MsgAlreadyAckdError
 
 
@@ -51,7 +52,8 @@ class Msg:
         V1TokenCount = 9
 
         # Subject with domain:
-        # $JS.ACK.<domain>.<account hash>.<stream>.<consumer>.<delivered>.<sseq>.<cseq>.<tm>.<pending>.<a token with a random value>
+        # $JS.ACK.<domain>.<account hash>.<stream>.<consumer>.<delivered>.<sseq>.
+        #   <cseq>.<tm>.<pending>.<a token with a random value>
         #
         V2TokenCount = 12
 
@@ -74,7 +76,7 @@ class Msg:
         self._ackd = False
 
     @property
-    def header(self):
+    def header(self) -> Optional[dict]:
         """
         header returns the headers from a message.
         """
@@ -228,4 +230,5 @@ class Msg:
             return tokens
 
         def __repr__(self) -> str:
-            return f"<{self.__class__.__name__}: stream='{self.stream}' consumer='{self.consumer}' sequence=({self.sequence.stream}, {self.sequence.consumer}) timestamp={self.timestamp}>"
+            attrs = f"stream='{self.stream}' consumer='{self.consumer}' sequence=({self.sequence.stream}, {self.sequence.consumer}) timestamp={self.timestamp}"  # noqa
+            return f"<{self.__class__.__name__}: {attrs}>"

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -16,8 +16,12 @@
 from nats.aio.msg import Msg
 from nats.errors import *
 from nats.aio.errors import *
-from typing import AsyncIterator, Callable, Optional
+from typing import TYPE_CHECKING, AsyncIterator, Callable, Optional
 import asyncio
+
+if TYPE_CHECKING:
+    from nats.js import JetStreamContext
+
 
 DEFAULT_SUB_PENDING_MSGS_LIMIT = 512 * 1024
 DEFAULT_SUB_PENDING_BYTES_LIMIT = 128 * 1024 * 1024
@@ -45,6 +49,7 @@ class Subscription:
         print('Received', msg)
 
     """
+
     def __init__(
         self,
         conn,
@@ -76,7 +81,7 @@ class Subscription:
         self._message_iterator = None
 
         # For JetStream enabled subscriptions.
-        self._jsi = None
+        self._jsi: Optional["JetStreamContext._JSI"] = None
 
     @property
     def subject(self) -> str:

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -22,7 +22,6 @@ import asyncio
 if TYPE_CHECKING:
     from nats.js import JetStreamContext
 
-
 DEFAULT_SUB_PENDING_MSGS_LIMIT = 512 * 1024
 DEFAULT_SUB_PENDING_BYTES_LIMIT = 128 * 1024 * 1024
 
@@ -49,7 +48,6 @@ class Subscription:
         print('Received', msg)
 
     """
-
     def __init__(
         self,
         conn,

--- a/nats/js/__init__.py
+++ b/nats/js/__init__.py
@@ -12,7 +12,8 @@
 # limitations under the License.
 #
 
+from . import api
 from .client import JetStreamContext
 from .manager import JetStreamManager
 
-__all__ = ["JetStreamManager", "JetStreamContext"]
+__all__ = ["api", "JetStreamManager", "JetStreamContext"]

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -345,6 +345,7 @@ class ConsumerInfo(Base):
     """
     ConsumerInfo represents the info about the consumer.
     """
+    name: str
     stream_name: str
     config: ConsumerConfig
     # FIXME: Do not handle dates for now.
@@ -355,7 +356,6 @@ class ConsumerInfo(Base):
     num_redelivered: Optional[int] = None
     num_waiting: Optional[int] = None
     num_pending: Optional[int] = None
-    name: Optional[str] = None
     cluster: Optional[ClusterInfo] = None
     push_bound: Optional[bool] = None
 

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -434,7 +434,7 @@ class KeyValueConfig(Base):
     """
     KeyValueConfig is the configurigation of a KeyValue store.
     """
-    bucket: Optional[str] = None
+    bucket: str
     description: Optional[str] = None
     max_value_size: Optional[int] = None
     history: Optional[int] = None

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -883,10 +883,3 @@ class JetStreamContext(JetStreamManager):
             pre=f"$KV.{config.bucket}.",
             js=self,
         )
-
-    async def delete_key_value(self, bucket: str):
-        """
-        delete_key_value deletes a JetStream KeyValue store by destroying
-        the associated stream.
-        """
-        return await self.delete_stream(bucket)

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -551,7 +551,7 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
         PullSubscription is a subscription that can fetch messages.
         """
 
-        def __init__(self, js, sub, stream, consumer, deliver) -> None:
+        def __init__(self, js, sub, stream: str, consumer: str, deliver: bytes) -> None:
             # JS/JSM context
             self._js = js
             self._nc = js._nc
@@ -802,7 +802,7 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
         self,
         stream_name: str,
         subject: str,
-    ):
+    ) -> api.RawStreamMsg:
         """
         get_last_msg retrieves a message from a stream.
         """
@@ -820,18 +820,3 @@ class JetStreamContext(JetStreamManager, KeyValueManager):
                 headers[k] = v
             raw_msg.headers = headers
         return raw_msg
-
-    class _JS():
-        def __init__(
-            self,
-            conn=None,
-            prefix=None,
-            stream=None,
-            consumer=None,
-            nms=None,
-        ) -> None:
-            self._prefix = prefix
-            self._nc = conn
-            self._stream = stream
-            self._consumer = consumer
-            self._nms = nms

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -64,7 +64,6 @@ class JetStreamContext(JetStreamManager):
             asyncio.run(main())
 
     """
-
     def __init__(
         self,
         conn: "NATS",
@@ -532,7 +531,6 @@ class JetStreamContext(JetStreamManager):
         """
         PushSubscription is a subscription that is delivered messages.
         """
-
         def __init__(
             self,
             js: "JetStreamContext",
@@ -576,7 +574,6 @@ class JetStreamContext(JetStreamManager):
         """
         PullSubscription is a subscription that can fetch messages.
         """
-
         def __init__(
             self,
             js: "JetStreamContext",

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -27,10 +27,8 @@ from nats.js import api
 from typing import TYPE_CHECKING, Awaitable, List, Optional, Callable
 from nats.js.errors import NotFoundError, BucketNotFoundError, BadBucketError
 
-
 if TYPE_CHECKING:
     from nats import NATS
-
 
 NATS_HDR_LINE = bytearray(b'NATS/1.0\r\n')
 NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
@@ -64,7 +62,6 @@ class JetStreamContext(JetStreamManager):
             asyncio.run(main())
 
     """
-
     def __init__(
         self,
         conn: "NATS",
@@ -412,7 +409,10 @@ class JetStreamContext(JetStreamManager):
 
     class _JSI():
         def __init__(
-            self, js: "JetStreamContext", conn: "NATS", stream: str,
+            self,
+            js: "JetStreamContext",
+            conn: "NATS",
+            stream: str,
             ordered: Optional[bool],
             psub: "JetStreamContext.PushSubscription",
             sub: Subscription,
@@ -439,7 +439,8 @@ class JetStreamContext(JetStreamManager):
         def schedule_flow_control_response(self, reply: str) -> None:
             pass
 
-        async def check_for_sequence_mismatch(self, msg: Msg) -> Optional[bool]:
+        async def check_for_sequence_mismatch(self,
+                                              msg: Msg) -> Optional[bool]:
             self._active = True
             if not self._cmeta:
                 return None
@@ -528,10 +529,12 @@ class JetStreamContext(JetStreamManager):
         """
         PushSubscription is a subscription that is delivered messages.
         """
-
         def __init__(
-            self, js: "JetStreamContext", sub: Subscription,
-            stream: str, consumer: str,
+            self,
+            js: "JetStreamContext",
+            sub: Subscription,
+            stream: str,
+            consumer: str,
         ) -> None:
             self._js = js
             self._stream = stream
@@ -560,7 +563,8 @@ class JetStreamContext(JetStreamManager):
             consumer_info gets the current info of the consumer from this subscription.
             """
             info = await self._js._jsm.consumer_info(
-                self._stream, self._consumer,
+                self._stream,
+                self._consumer,
             )
             return info
 
@@ -568,10 +572,13 @@ class JetStreamContext(JetStreamManager):
         """
         PullSubscription is a subscription that can fetch messages.
         """
-
         def __init__(
-            self, js: "JetStreamContext", sub: Subscription,
-            stream: str, consumer: str, deliver: bytes,
+            self,
+            js: "JetStreamContext",
+            sub: Subscription,
+            stream: str,
+            consumer: str,
+            deliver: bytes,
         ) -> None:
             # JS/JSM context
             self._js = js
@@ -648,7 +655,9 @@ class JetStreamContext(JetStreamManager):
             msgs = await self._fetch_n(batch, expires, timeout)
             return msgs
 
-        async def _fetch_one(self, batch: int, expires: int, timeout: int) -> Msg:
+        async def _fetch_one(
+            self, batch: int, expires: int, timeout: int
+        ) -> Msg:
             queue = self._sub._pending_queue
 
             # Check the next message in case there are any.
@@ -685,7 +694,8 @@ class JetStreamContext(JetStreamManager):
                 return msg
             raise nats.js.errors.APIError.from_msg(msg)
 
-        async def _fetch_n(self, batch: int, expires: int, timeout: int) -> List[Msg]:
+        async def _fetch_n(self, batch: int, expires: int,
+                           timeout: int) -> List[Msg]:
             msgs = []
             queue = self._sub._pending_queue
             start_time = time.monotonic()

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -25,7 +25,6 @@ class Error(nats.errors.Error):
     """
     An Error raised by the NATS client when using JetStream.
     """
-
     def __init__(self, description: Optional[str] = None) -> None:
         self.description = description
 
@@ -122,7 +121,6 @@ class NoStreamResponseError(Error):
     """
     Raised if the client gets a 503 when publishing a message.
     """
-
     def __str__(self) -> str:
         return "nats: no response from stream"
 
@@ -132,7 +130,6 @@ class ConsumerSequenceMismatchError(Error):
     Async error raised by the client with idle_heartbeat mode enabled
     when one of the message sequences is not the expected one.
     """
-
     def __init__(
         self,
         stream_resume_sequence=None,
@@ -163,7 +160,6 @@ class KeyDeletedError(Error):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
-
     def __init__(self, entry=None, op=None) -> None:
         self.entry = entry
         self.op = op

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-from typing import TYPE_CHECKING, NoReturn, Optional
+from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional
 import nats.errors
 from nats.js import api
 from dataclasses import dataclass
@@ -26,7 +26,7 @@ class Error(nats.errors.Error):
     An Error raised by the NATS client when using JetStream.
     """
 
-    def __init__(self, description=None) -> None:
+    def __init__(self, description: Optional[str] = None) -> None:
         self.description = description
 
     def __str__(self) -> str:
@@ -50,10 +50,10 @@ class APIError(Error):
     def __init__(
         self,
         code: int = None,
-        description=None,
-        err_code=None,
-        stream=None,
-        seq=None
+        description: Optional[str] = None,
+        err_code: Optional[int] = None,
+        stream: Optional[str] = None,
+        seq: Optional[int] = None
     ) -> None:
         self.code = code
         self.err_code = err_code
@@ -73,7 +73,7 @@ class APIError(Error):
             raise APIError(code=int(code), description=desc)
 
     @classmethod
-    def from_error(cls, err):
+    def from_error(cls, err: Dict[str, Any]):
         code = err['code']
         if code == 503:
             raise ServiceUnavailableError(**err)

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -177,3 +177,8 @@ class KeyValue:
         """
         info = await self._js.stream_info(self._stream)
         return KeyValue.BucketStatus(stream_info=info, bucket=self._name)
+
+    async def destroy(self):
+        """Destroy the KeyValue storage and the associated stream.
+        """
+        return await self._js.delete_stream(self._name)

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -178,7 +178,7 @@ class KeyValue:
         info = await self._js.stream_info(self._stream)
         return KeyValue.BucketStatus(stream_info=info, bucket=self._name)
 
-    async def destroy(self):
+    async def destroy(self) -> bool:
         """Destroy the KeyValue storage and the associated stream.
         """
         return await self._js.delete_stream(self._name)

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -22,7 +22,6 @@ import base64
 if TYPE_CHECKING:
     from nats.js import JetStreamContext
 
-
 KV_OP = "KV-Operation"
 KV_DEL = "DEL"
 KV_PURGE = "PURGE"
@@ -103,8 +102,11 @@ class KeyValue:
             return self.stream_info.config.max_age / 1_000_000_000
 
     def __init__(
-        self, name: str, stream: str,
-        pre: str, js: "JetStreamContext",
+        self,
+        name: str,
+        stream: str,
+        pre: str,
+        js: "JetStreamContext",
     ) -> None:
         self._name = name
         self._stream = stream

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -72,9 +72,10 @@ class KeyValue:
         """
         BucketStatus is the status of a KeyValue bucket.
         """
-        def __init__(self) -> None:
-            self._nfo = None
-            self._bucket = None
+
+        def __init__(self, info: api.StreamInfo, bucket: str) -> None:
+            self._nfo = info
+            self._bucket = bucket
 
         @property
         def bucket(self):
@@ -183,10 +184,7 @@ class KeyValue:
         status retrieves the status and configuration of a bucket.
         """
         info = await self._js.stream_info(self._stream)
-        kvs = KeyValue.BucketStatus()
-        kvs._nfo = info
-        kvs._bucket = self._name
-        return kvs
+        return KeyValue.BucketStatus(info=info, bucket=self._name)
 
 
 class KeyValueManager(ABC):

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -179,8 +179,3 @@ class KeyValue:
         """
         info = await self._js.stream_info(self._stream)
         return KeyValue.BucketStatus(stream_info=info, bucket=self._name)
-
-    async def destroy(self) -> bool:
-        """Destroy the KeyValue storage and the associated stream.
-        """
-        return await self._js.delete_stream(self._name)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -20,7 +20,6 @@ from email.parser import BytesParser
 from dataclasses import asdict
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
-
 if TYPE_CHECKING:
     from nats import NATS
 
@@ -29,7 +28,6 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
-
     def __init__(
         self,
         conn: "NATS",
@@ -68,7 +66,9 @@ class JetStreamManager:
         )
         return api.StreamInfo.loads(**resp)
 
-    async def add_stream(self, config: api.StreamConfig = None, **params) -> api.StreamInfo:
+    async def add_stream(
+        self, config: api.StreamConfig = None, **params
+    ) -> api.StreamInfo:
         """
         add_stream creates a stream.
         """
@@ -97,7 +97,9 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def consumer_info(self, stream: str, consumer: str, timeout: Optional[float] = None):
+    async def consumer_info(
+        self, stream: str, consumer: str, timeout: Optional[float] = None
+    ):
         # TODO: Validate the stream and consumer names.
         if timeout is None:
             timeout = self._timeout

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -18,7 +18,7 @@ from nats.errors import NoRespondersError
 from nats.js.errors import ServiceUnavailableError, APIError
 from email.parser import BytesParser
 from dataclasses import asdict
-from typing import Optional
+from typing import Any, Dict, Optional
 
 
 class JetStreamManager:
@@ -195,8 +195,7 @@ class JetStreamManager:
         req_subject,
         req: bytes = b'',
         timeout: float = 5,
-    ):
-        resp = None
+    ) -> Dict[str, Any]:
         try:
             msg = await self._nc.request(req_subject, req, timeout=timeout)
             resp = json.loads(msg.data)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -25,6 +25,7 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
+
     def __init__(
         self,
         conn,
@@ -54,7 +55,7 @@ class JetStreamManager:
         )
         return info['streams'][0]
 
-    async def stream_info(self, name):
+    async def stream_info(self, name) -> api.StreamInfo:
         """
         Get the latest StreamInfo by stream name.
         """

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -84,7 +84,7 @@ class JetStreamManager:
         )
         return api.StreamInfo.loads(**resp)
 
-    async def delete_stream(self, name):
+    async def delete_stream(self, name: str):
         """
         Delete a stream by name.
         """

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -18,7 +18,11 @@ from nats.errors import NoRespondersError
 from nats.js.errors import ServiceUnavailableError, APIError
 from email.parser import BytesParser
 from dataclasses import asdict
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+
+if TYPE_CHECKING:
+    from nats import NATS
 
 
 class JetStreamManager:
@@ -28,7 +32,7 @@ class JetStreamManager:
 
     def __init__(
         self,
-        conn,
+        conn: "NATS",
         prefix: str = api.DefaultPrefix,
         timeout: float = 5,
     ) -> None:
@@ -37,13 +41,13 @@ class JetStreamManager:
         self._timeout = timeout
         self._hdr_parser = BytesParser()
 
-    async def account_info(self):
+    async def account_info(self) -> api.AccountInfo:
         info = await self._api_request(
             f"{self._prefix}.INFO", b'', timeout=self._timeout
         )
         return api.AccountInfo.loads(**info)
 
-    async def find_stream_name_by_subject(self, subject: str):
+    async def find_stream_name_by_subject(self, subject: str) -> str:
         """
         Find the stream to which a subject belongs in an account.
         """
@@ -55,7 +59,7 @@ class JetStreamManager:
         )
         return info['streams'][0]
 
-    async def stream_info(self, name) -> api.StreamInfo:
+    async def stream_info(self, name: str) -> api.StreamInfo:
         """
         Get the latest StreamInfo by stream name.
         """
@@ -64,7 +68,7 @@ class JetStreamManager:
         )
         return api.StreamInfo.loads(**resp)
 
-    async def add_stream(self, config: api.StreamConfig = None, **params):
+    async def add_stream(self, config: api.StreamConfig = None, **params) -> api.StreamInfo:
         """
         add_stream creates a stream.
         """
@@ -84,7 +88,7 @@ class JetStreamManager:
         )
         return api.StreamInfo.loads(**resp)
 
-    async def delete_stream(self, name: str):
+    async def delete_stream(self, name: str) -> bool:
         """
         Delete a stream by name.
         """
@@ -93,7 +97,7 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def consumer_info(self, stream, consumer, timeout=None):
+    async def consumer_info(self, stream: str, consumer: str, timeout: Optional[float] = None):
         # TODO: Validate the stream and consumer names.
         if timeout is None:
             timeout = self._timeout
@@ -112,14 +116,14 @@ class JetStreamManager:
         description: Optional[str] = None,
         deliver_subject: Optional[str] = None,
         deliver_group: Optional[str] = None,
-        deliver_policy: Optional[api.DeliverPolicy] = api.DeliverPolicy.last,
+        deliver_policy: api.DeliverPolicy = api.DeliverPolicy.last,
         opt_start_seq: Optional[int] = None,
         opt_start_time: Optional[int] = None,
-        ack_policy: Optional[api.AckPolicy] = api.AckPolicy.explicit,
+        ack_policy: api.AckPolicy = api.AckPolicy.explicit,
         ack_wait: Optional[int] = None,
         max_deliver: Optional[int] = None,
         filter_subject: Optional[str] = None,
-        replay_policy: Optional[api.ReplayPolicy] = api.ReplayPolicy.instant,
+        replay_policy: api.ReplayPolicy = api.ReplayPolicy.instant,
         sample_freq: Optional[str] = None,
         rate_limit_bps: Optional[int] = None,
         max_waiting: Optional[int] = None,
@@ -128,7 +132,7 @@ class JetStreamManager:
         idle_heartbeat: Optional[int] = None,
         headers_only: Optional[bool] = None,
         timeout=None,
-    ):
+    ) -> api.ConsumerInfo:
         if not timeout:
             timeout = self._timeout
 
@@ -182,7 +186,7 @@ class JetStreamManager:
             )
         return api.ConsumerInfo.loads(**resp)
 
-    async def delete_consumer(self, stream=None, consumer=None):
+    async def delete_consumer(self, stream: str, consumer: str) -> bool:
         resp = await self._api_request(
             f"{self._prefix}.CONSUMER.DELETE.{stream}.{consumer}",
             b'',
@@ -192,7 +196,7 @@ class JetStreamManager:
 
     async def _api_request(
         self,
-        req_subject,
+        req_subject: str,
         req: bytes = b'',
         timeout: float = 5,
     ) -> Dict[str, Any]:

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -177,7 +177,6 @@ class Parser:
 
             elif self.state == AWAITING_MSG_PAYLOAD:
                 if len(self.buf) >= self.needed + CRLF_SIZE:
-                    sid = None
                     hdr = None
                     subject = self.msg_arg["subject"]
                     sid = self.msg_arg["sid"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
-[tool:mypy]
+[mypy]
+files=nats/js,nats/protocol
 python_version=3.7
 ignore_missing_imports=true
 follow_imports=silent

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1113,7 +1113,7 @@ class OrderedConsumerTest(SingleJetStreamServerTestCase):
                 reply=reply.decode(),
                 data=data,
                 headers=headers,
-                client=nc
+                _client=nc,
             )
 
         # Override to introduce arbitrary loss.


### PR DESCRIPTION
1. Add all missed type annotations
2. Convert some classes into `dataclass`
3. replace `JetStreamContext.delete_key_value` by `KeyValue.destroy`
4. Merge `KeyValueManager` into `JetStreamContext`. It uses a lot of things from `JetStreamContext` and so cannot exist on its own. I'd decouple some bits of `JetStreamContext` but it needs an actual decoupling, probably with a smart composition.
5. Remove `class _JS()`, it's not used anywhere.

