### PR TITLE
Add reply attribute on SlowConsumerError

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1474,13 +1474,20 @@ class Client:
                     sub._pending_size -= payload_size
 
                     await self._error_cb(
-                        SlowConsumerError(subject=subject, sid=sid, sub=sub)
+                        SlowConsumerError(
+                            subject=msg.subject,
+                            reply=msg.reply,
+                            sid=sid,
+                            sub=sub
+                        )
                     )
                     return
                 sub._pending_queue.put_nowait(msg)
             except asyncio.QueueFull:
                 await self._error_cb(
-                    SlowConsumerError(subject=subject, sid=sid, sub=sub)
+                    SlowConsumerError(
+                        subject=msg.subject, reply=msg.reply, sid=sid, sub=sub
+                    )
                 )
 
             # Store the ACK metadata from the message to

--- a/nats/errors.py
+++ b/nats/errors.py
@@ -11,8 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+from __future__ import annotations
 import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nats.aio.subscription import Subscription
 
 
 class Error(Exception):
@@ -65,8 +69,11 @@ class BadSubjectError(Error):
 
 
 class SlowConsumerError(Error):
-    def __init__(self, subject=None, sid=None, sub=None) -> None:
+    def __init__(
+        self, subject: str, reply: str, sid: int, sub: Subscription
+    ) -> None:
         self.subject = subject
+        self.reply = reply
         self.sid = sid
         self.sub = sub
 

--- a/tests/test_client_async_await.py
+++ b/tests/test_client_async_await.py
@@ -187,7 +187,7 @@ class ClientAsyncAwaitTest(SingleServerTestCase):
             self.assertEqual(type(e), SlowConsumerError)
         self.assertEqual(errors[0].sid, 1)
         self.assertEqual(errors[0].sub._id, 1)
-
+        self.assertEqual(errors[0].reply, "")
         # Try again a few seconds later and it should have recovered
         await asyncio.sleep(3)
         response = await nc.request("foo", b'B', 1)


### PR DESCRIPTION
# Main goal of the PR

This PR proposes to add the `.reply` attribute on `SlowConsumerError`.

# Motivation

`SlowConsumerError` is defined as follow:

```python
class SlowConsumerError(Error):
    def __init__(self, subject=None, sid=None, sub=None):
        self.subject = subject
        self.sid = sid
        self.sub = sub
```

It's easy to catch a `SlowConsumerError` using `error_cb` argument:

```python
async def error_cb(error: Exception) -> None:
    if isinstance(error, nats.errors.SlowConsumerError):
        logger.error(
            f"Slow consumer on detected on subscription {error.sid}"
        )
```

In this callback, it's possible to access the subject the message was sent to, as well as the subscription that should have receive the message, but it's no longer possible to get the `reply` field of the message.

Accessing the `reply` field would allow me to publish back to the requester some message indicating a failure. The requester could then reduce/stop sending messages.

Something like the following:

```python
# Let's say "nc" variable is available in the callback scope
async def error_cb(error: Exception) -> None:
    if isinstance(error, nats.errors.SlowConsumerError):
        await nc.publish(error.reply, headers={"error": "SlowConsumerError", "retry-after": "2s"}
```

## Implementation

`SlowConsumerError` is used only twice in the whole codebase. Adding the field is easy as a `Msg` instance already exists before creating an error instance. It's possible to fetch both the reply and the subject from the message instance being dropped.

## Breaking change

I think that `SlowConsumerError.subject` is of type `bytes` today, and this PR uses a type `str`

## Minor changes

`SlowConsumerError` attributes are typed

## Questions

- Are there any other way to achieve this easily ?

- Are there any downside to forwarding the reply to the error ?

- Should `SlowConsumerError.subject` be typed as `Optional` since it is always defined ?