### PR TITLE
Run flake8 and mypy on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ test:
 	yapf --recursive --diff $(SOURCE_CODE)
 	yapf --recursive --diff tests
 	mypy
+	flake8 ./nats/js/
 	pytest
 
 
@@ -36,6 +37,7 @@ ci: deps
 	pipenv run yapf --recursive --diff $(SOURCE_CODE)
 	pipenv run yapf --recursive --diff tests
 	pipenv run mypy
+	pipenv run flake8 ./nats/js/
 	pipenv run pytest --verbose
 
 watch:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_NAME=nats.py
 SOURCE_CODE=nats
 
 
-help: 
+help:
 	@cat $(MAKEFILE_LIST) | \
 	grep -E '^[a-zA-Z_-]+:.*?##' | \
 	sed "s/local-//" | \
@@ -28,13 +28,15 @@ format:
 test:
 	yapf --recursive --diff $(SOURCE_CODE)
 	yapf --recursive --diff tests
+	mypy
 	pytest
 
 
 ci: deps
 	pipenv run yapf --recursive --diff $(SOURCE_CODE)
 	pipenv run yapf --recursive --diff tests
-	pipenv run pytest --verbose 
+	pipenv run mypy
+	pipenv run pytest --verbose
 
 watch:
 	while true; do pipenv run pytest -v -s -x; sleep 10; done

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+mypy = "*"
 pytest = "*"
 pytest-cov = "*"
 yapf = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+flake8 = "*"
 mypy = "*"
 pytest = "*"
 pytest-cov = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d173dc3c4beada1bf46349a504708adce502f3cc8f30718a609670fd8449817a"
+            "sha256": "48c5c9bec5c28d5f71b9bbb03545ccffd9cbbe7107c8b4127175904d7016bb44"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -31,69 +31,67 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
-                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.2.0"
+            "version": "==21.4.0"
         },
         "coverage": {
-            "hashes": [
-                "sha256:004d1880bed2d97151facef49f08e255a20ceb6f9432df75f4eef018fdd5a78c",
-                "sha256:01d84219b5cdbfc8122223b39a954820929497a1cb1422824bb86b07b74594b6",
-                "sha256:040af6c32813fa3eae5305d53f18875bedd079960822ef8ec067a66dd8afcd45",
-                "sha256:06191eb60f8d8a5bc046f3799f8a07a2d7aefb9504b0209aff0b47298333302a",
-                "sha256:13034c4409db851670bc9acd836243aeee299949bd5673e11844befcb0149f03",
-                "sha256:13c4ee887eca0f4c5a247b75398d4114c37882658300e153113dafb1d76de529",
-                "sha256:184a47bbe0aa6400ed2d41d8e9ed868b8205046518c52464fde713ea06e3a74a",
-                "sha256:18ba8bbede96a2c3dde7b868de9dcbd55670690af0988713f0603f037848418a",
-                "sha256:1aa846f56c3d49205c952d8318e76ccc2ae23303351d9270ab220004c580cfe2",
-                "sha256:217658ec7187497e3f3ebd901afdca1af062b42cfe3e0dafea4cced3983739f6",
-                "sha256:24d4a7de75446be83244eabbff746d66b9240ae020ced65d060815fac3423759",
-                "sha256:2910f4d36a6a9b4214bb7038d537f015346f413a975d57ca6b43bf23d6563b53",
-                "sha256:2949cad1c5208b8298d5686d5a85b66aae46d73eec2c3e08c817dd3513e5848a",
-                "sha256:2a3859cb82dcbda1cfd3e6f71c27081d18aa251d20a17d87d26d4cd216fb0af4",
-                "sha256:2cafbbb3af0733db200c9b5f798d18953b1a304d3f86a938367de1567f4b5bff",
-                "sha256:2e0d881ad471768bf6e6c2bf905d183543f10098e3b3640fc029509530091502",
-                "sha256:30c77c1dc9f253283e34c27935fded5015f7d1abe83bc7821680ac444eaf7793",
-                "sha256:3487286bc29a5aa4b93a072e9592f22254291ce96a9fbc5251f566b6b7343cdb",
-                "sha256:372da284cfd642d8e08ef606917846fa2ee350f64994bebfbd3afb0040436905",
-                "sha256:41179b8a845742d1eb60449bdb2992196e211341818565abded11cfa90efb821",
-                "sha256:44d654437b8ddd9eee7d1eaee28b7219bec228520ff809af170488fd2fed3e2b",
-                "sha256:4a7697d8cb0f27399b0e393c0b90f0f1e40c82023ea4d45d22bce7032a5d7b81",
-                "sha256:51cb9476a3987c8967ebab3f0fe144819781fca264f57f89760037a2ea191cb0",
-                "sha256:52596d3d0e8bdf3af43db3e9ba8dcdaac724ba7b5ca3f6358529d56f7a166f8b",
-                "sha256:53194af30d5bad77fcba80e23a1441c71abfb3e01192034f8246e0d8f99528f3",
-                "sha256:5fec2d43a2cc6965edc0bb9e83e1e4b557f76f843a77a2496cbe719583ce8184",
-                "sha256:6c90e11318f0d3c436a42409f2749ee1a115cd8b067d7f14c148f1ce5574d701",
-                "sha256:74d881fc777ebb11c63736622b60cb9e4aee5cace591ce274fb69e582a12a61a",
-                "sha256:7501140f755b725495941b43347ba8a2777407fc7f250d4f5a7d2a1050ba8e82",
-                "sha256:796c9c3c79747146ebd278dbe1e5c5c05dd6b10cc3bcb8389dfdf844f3ead638",
-                "sha256:869a64f53488f40fa5b5b9dcb9e9b2962a66a87dab37790f3fcfb5144b996ef5",
-                "sha256:8963a499849a1fc54b35b1c9f162f4108017b2e6db2c46c1bed93a72262ed083",
-                "sha256:8d0a0725ad7c1a0bcd8d1b437e191107d457e2ec1084b9f190630a4fb1af78e6",
-                "sha256:900fbf7759501bc7807fd6638c947d7a831fc9fdf742dc10f02956ff7220fa90",
-                "sha256:92b017ce34b68a7d67bd6d117e6d443a9bf63a2ecf8567bb3d8c6c7bc5014465",
-                "sha256:970284a88b99673ccb2e4e334cfb38a10aab7cd44f7457564d11898a74b62d0a",
-                "sha256:972c85d205b51e30e59525694670de6a8a89691186012535f9d7dbaa230e42c3",
-                "sha256:9a1ef3b66e38ef8618ce5fdc7bea3d9f45f3624e2a66295eea5e57966c85909e",
-                "sha256:af0e781009aaf59e25c5a678122391cb0f345ac0ec272c7961dc5455e1c40066",
-                "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf",
-                "sha256:b7895207b4c843c76a25ab8c1e866261bcfe27bfaa20c192de5190121770672b",
-                "sha256:c0891a6a97b09c1f3e073a890514d5012eb256845c451bd48f7968ef939bf4ae",
-                "sha256:c2723d347ab06e7ddad1a58b2a821218239249a9e4365eaff6649d31180c1669",
-                "sha256:d1f8bf7b90ba55699b3a5e44930e93ff0189aa27186e96071fac7dd0d06a1873",
-                "sha256:d1f9ce122f83b2305592c11d64f181b87153fc2c2bbd3bb4a3dde8303cfb1a6b",
-                "sha256:d314ed732c25d29775e84a960c3c60808b682c08d86602ec2c3008e1202e3bb6",
-                "sha256:d636598c8305e1f90b439dbf4f66437de4a5e3c31fdf47ad29542478c8508bbb",
-                "sha256:deee1077aae10d8fa88cb02c845cfba9b62c55e1183f52f6ae6a2df6a2187160",
-                "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c",
-                "sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079",
-                "sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d",
-                "sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6"
+            "extras": [
+                "toml"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==5.5"
+            "hashes": [
+                "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0",
+                "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd",
+                "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884",
+                "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48",
+                "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76",
+                "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0",
+                "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64",
+                "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685",
+                "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47",
+                "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d",
+                "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840",
+                "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f",
+                "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971",
+                "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c",
+                "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a",
+                "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de",
+                "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17",
+                "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4",
+                "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521",
+                "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57",
+                "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b",
+                "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282",
+                "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644",
+                "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475",
+                "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d",
+                "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da",
+                "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953",
+                "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2",
+                "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e",
+                "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c",
+                "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc",
+                "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64",
+                "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74",
+                "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617",
+                "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3",
+                "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d",
+                "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa",
+                "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739",
+                "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8",
+                "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8",
+                "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781",
+                "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58",
+                "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9",
+                "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c",
+                "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd",
+                "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e",
+                "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==6.2"
         },
         "iniconfig": {
             "hashes": [
@@ -102,69 +100,118 @@
             ],
             "version": "==1.1.1"
         },
+        "mypy": {
+            "hashes": [
+                "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce",
+                "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d",
+                "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069",
+                "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c",
+                "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d",
+                "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714",
+                "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a",
+                "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d",
+                "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05",
+                "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266",
+                "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697",
+                "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc",
+                "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799",
+                "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd",
+                "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00",
+                "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7",
+                "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a",
+                "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0",
+                "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0",
+                "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"
+            ],
+            "index": "pypi",
+            "version": "==0.931"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
-                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
-                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.0"
+            "version": "==21.3"
         },
         "pluggy": {
             "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
         },
         "py": {
             "hashes": [
-                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
-                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.10.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
+                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
-                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+                "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
+                "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"
             ],
             "index": "pypi",
-            "version": "==6.2.4"
+            "version": "==6.2.5"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a",
-                "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"
+                "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6",
+                "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"
             ],
             "index": "pypi",
-            "version": "==2.12.1"
+            "version": "==3.0.0"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:b5bde28da1fed24b9bd1d4d2b8cba62300bfb4ec9a6187a957e8ddb9434c5224",
+                "sha256:c292c34f58502a1eb2bbb9f5bbc9a5ebc37bee10ffb8c2d6bbdfa8eb13cc14e1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
+                "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.1"
         },
         "yapf": {
             "hashes": [
-                "sha256:408fb9a2b254c302f49db83c59f9aa0b4b0fd0ec25be3a5c51181327922ff63d",
-                "sha256:e3a234ba8455fe201eaa649cdac872d590089a18b661e39bbac7020978dd9c2e"
+                "sha256:8fea849025584e486fd06d6ba2bed717f396080fd3cc236ba10cb97c4c51cf32",
+                "sha256:a3f5085d37ef7e3e004c4ba9f9b3e40c54ff1901cd111f05145ae313a7c67d1b"
             ],
             "index": "pypi",
-            "version": "==0.31.0"
+            "version": "==0.32.0"
         }
     }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "48c5c9bec5c28d5f71b9bbb03545ccffd9cbbe7107c8b4127175904d7016bb44"
+            "sha256": "890d7db455a854ec06e27b48300bbdd77762436337d27002ee4b12ea8c0412fd"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -93,12 +93,27 @@
             "markers": "python_version >= '3.6'",
             "version": "==6.2"
         },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
         "iniconfig": {
             "hashes": [
                 "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
                 "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
             ],
             "version": "==1.1.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "mypy": {
             "hashes": [
@@ -156,6 +171,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
         },
         "pyparsing": {
             "hashes": [

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -48,6 +48,7 @@ class Subscription:
         print('Received', msg)
 
     """
+
     def __init__(
         self,
         conn,
@@ -280,6 +281,7 @@ class Subscription:
 
 
 class _SubscriptionMessageIterator:
+
     def __init__(self, queue) -> None:
         self._queue = queue
         self._unsubscribed_future = asyncio.Future()

--- a/nats/errors.py
+++ b/nats/errors.py
@@ -24,51 +24,61 @@ class Error(Exception):
 
 
 class TimeoutError(asyncio.TimeoutError):
+
     def __str__(self) -> str:
         return "nats: timeout"
 
 
 class NoRespondersError(Error):
+
     def __str__(self) -> str:
         return "nats: no responders available for request"
 
 
 class StaleConnectionError(Error):
+
     def __str__(self) -> str:
         return "nats: stale connection"
 
 
 class ConnectionClosedError(Error):
+
     def __str__(self) -> str:
         return "nats: connection closed"
 
 
 class SecureConnRequiredError(Error):
+
     def __str__(self) -> str:
         return "nats: secure connection required"
 
 
 class SecureConnWantedError(Error):
+
     def __str__(self) -> str:
         return "nats: secure connection not available"
 
 
 class SecureConnFailedError(Error):
+
     def __str__(self) -> str:
         return "nats: secure connection failed"
 
 
 class BadSubscriptionError(Error):
+
     def __str__(self) -> str:
         return "nats: invalid subscription"
 
 
 class BadSubjectError(Error):
+
     def __str__(self) -> str:
         return "nats: invalid subject"
 
 
 class SlowConsumerError(Error):
+
     def __init__(
         self, subject: str, reply: str, sid: int, sub: Subscription
     ) -> None:
@@ -83,56 +93,67 @@ class SlowConsumerError(Error):
 
 
 class BadTimeoutError(Error):
+
     def __str__(self) -> str:
         return "nats: timeout invalid"
 
 
 class AuthorizationError(Error):
+
     def __str__(self) -> str:
         return "nats: authorization failed"
 
 
 class NoServersError(Error):
+
     def __str__(self) -> str:
         return "nats: no servers available for connection"
 
 
 class JsonParseError(Error):
+
     def __str__(self) -> str:
         return "nats: connect message, json parse err"
 
 
 class MaxPayloadError(Error):
+
     def __str__(self) -> str:
         return "nats: maximum payload exceeded"
 
 
 class DrainTimeoutError(TimeoutError):
+
     def __str__(self) -> str:
         return "nats: draining connection timed out"
 
 
 class ConnectionDrainingError(Error):
+
     def __str__(self) -> str:
         return "nats: connection draining"
 
 
 class ConnectionReconnectingError(Error):
+
     def __str__(self) -> str:
         return "nats: connection reconnecting"
 
 
 class InvalidUserCredentialsError(Error):
+
     def __str__(self) -> str:
         return "nats: invalid user credentials"
 
 
 class InvalidCallbackTypeError(Error):
+
     def __str__(self) -> str:
         return "nats: callbacks must be coroutine functions"
 
 
 class ProtocolError(Error):
+
     def __str__(self) -> str:
         return "nats: protocol error"
 
@@ -142,11 +163,13 @@ class NotJSMessageError(Error):
     When it is attempted to use an API meant for JetStream on a message
     that does not belong to a stream.
     """
+
     def __str__(self) -> str:
         return "nats: not a JetStream message"
 
 
 class MsgAlreadyAckdError(Error):
+
     def __init__(self, msg=None) -> None:
         self._msg = msg
 

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -44,6 +44,7 @@ class Base:
     """
     Helper dataclass to filter unknown fields from the API.
     """
+
     @classmethod
     def properties(klass, **opts) -> List[str]:
         return [f.name for f in fields(klass)]

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -274,7 +274,7 @@ class DeliverPolicy(str, Enum):
 
     References:
         * `Consumers, DeliverPolicy/OptStartSeq/OptStartTime <https://docs.nats.io/jetstream/concepts/consumers#deliverpolicy-optstartseq-optstarttime>`_
-    """
+    """  # noqa: E501
 
     all = "all"
     last = "last"

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -64,6 +64,7 @@ class JetStreamContext(JetStreamManager):
             asyncio.run(main())
 
     """
+
     def __init__(
         self,
         conn: "NATS",
@@ -311,6 +312,7 @@ class JetStreamContext(JetStreamManager):
 
     @staticmethod
     def _auto_ack_callback(callback) -> Callable[[Msg], Awaitable[None]]:
+
         async def new_callback(msg: Msg) -> None:
             await callback(msg)
             try:
@@ -410,6 +412,7 @@ class JetStreamContext(JetStreamManager):
         return timeout - (time.monotonic() - start_time)
 
     class _JSI():
+
         def __init__(
             self,
             js: "JetStreamContext",
@@ -531,6 +534,7 @@ class JetStreamContext(JetStreamManager):
         """
         PushSubscription is a subscription that is delivered messages.
         """
+
         def __init__(
             self,
             js: "JetStreamContext",
@@ -574,6 +578,7 @@ class JetStreamContext(JetStreamManager):
         """
         PullSubscription is a subscription that can fetch messages.
         """
+
         def __init__(
             self,
             js: "JetStreamContext",

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -25,6 +25,7 @@ class Error(nats.errors.Error):
     """
     An Error raised by the NATS client when using JetStream.
     """
+
     def __init__(self, description: Optional[str] = None) -> None:
         self.description = description
 
@@ -124,6 +125,7 @@ class NoStreamResponseError(Error):
     """
     Raised if the client gets a 503 when publishing a message.
     """
+
     def __str__(self) -> str:
         return "nats: no response from stream"
 
@@ -133,6 +135,7 @@ class ConsumerSequenceMismatchError(Error):
     Async error raised by the client with idle_heartbeat mode enabled
     when one of the message sequences is not the expected one.
     """
+
     def __init__(
         self,
         stream_resume_sequence=None,
@@ -166,6 +169,7 @@ class KeyDeletedError(Error):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
+
     def __init__(self, entry=None, op=None) -> None:
         self.entry = entry
         self.op = op

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -25,6 +25,7 @@ class Error(nats.errors.Error):
     """
     An Error raised by the NATS client when using JetStream.
     """
+
     def __init__(self, description: Optional[str] = None) -> None:
         self.description = description
 
@@ -86,7 +87,10 @@ class APIError(Error):
             raise APIError(**err)
 
     def __str__(self) -> str:
-        return f"nats: {self.__class__.__name__}: code={self.code} err_code={self.err_code} description='{self.description}'"
+        return (
+            f"nats: {type(self).__name__}: code={self.code} err_code={self.err_code} "
+            f"description='{self.description}'"
+        )
 
 
 class ServiceUnavailableError(APIError):
@@ -121,6 +125,7 @@ class NoStreamResponseError(Error):
     """
     Raised if the client gets a 503 when publishing a message.
     """
+
     def __str__(self) -> str:
         return "nats: no response from stream"
 
@@ -130,6 +135,7 @@ class ConsumerSequenceMismatchError(Error):
     Async error raised by the client with idle_heartbeat mode enabled
     when one of the message sequences is not the expected one.
     """
+
     def __init__(
         self,
         stream_resume_sequence=None,
@@ -142,7 +148,10 @@ class ConsumerSequenceMismatchError(Error):
 
     def __str__(self) -> str:
         gap = self.last_consumer_sequence - self.consumer_sequence
-        return f"nats: sequence mismatch for consumer at sequence {self.consumer_sequence} ({gap} sequences behind), should restart consumer from stream sequence {self.stream_resume_sequence}"
+        return (
+            f"nats: sequence mismatch for consumer at sequence {self.consumer_sequence} "
+            f"({gap} sequences behind), should restart consumer from stream sequence {self.stream_resume_sequence}"
+        )
 
 
 class BucketNotFoundError(NotFoundError):
@@ -160,6 +169,7 @@ class KeyDeletedError(Error):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
+
     def __init__(self, entry=None, op=None) -> None:
         self.entry = entry
         self.op = op

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -25,7 +25,6 @@ class Error(nats.errors.Error):
     """
     An Error raised by the NATS client when using JetStream.
     """
-
     def __init__(self, description: Optional[str] = None) -> None:
         self.description = description
 
@@ -125,7 +124,6 @@ class NoStreamResponseError(Error):
     """
     Raised if the client gets a 503 when publishing a message.
     """
-
     def __str__(self) -> str:
         return "nats: no response from stream"
 
@@ -135,7 +133,6 @@ class ConsumerSequenceMismatchError(Error):
     Async error raised by the client with idle_heartbeat mode enabled
     when one of the message sequences is not the expected one.
     """
-
     def __init__(
         self,
         stream_resume_sequence=None,
@@ -169,7 +166,6 @@ class KeyDeletedError(Error):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
-
     def __init__(self, entry=None, op=None) -> None:
         self.entry = entry
         self.op = op

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -60,6 +60,7 @@ class KeyValue:
             asyncio.run(main())
 
     """
+
     @dataclass
     class Entry:
         """

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -28,6 +28,7 @@ class JetStreamManager:
     """
     JetStreamManager exposes management APIs for JetStream.
     """
+
     def __init__(
         self,
         conn: "NATS",

--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -31,6 +31,7 @@ class NUID:
     NUID is an implementation of the approach for fast generation of
     unique identifiers used for inboxes in NATS.
     """
+
     def __init__(self) -> None:
         self._srand = SystemRandom()
         self._prand = Random(self._srand.randint(0, MaxInt))

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -70,6 +70,7 @@ PERMISSIONS_ERR = "permissions violation"
 
 
 class Parser:
+
     def __init__(self, nc=None) -> None:
         self.nc = nc
         self.reset()
@@ -208,5 +209,6 @@ class ErrProtocol(ProtocolError):
     """
     .. deprecated:: v2.0.0
     """
+
     def __str__(self) -> str:
         return "nats: Protocol Error"

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,3 +16,6 @@ coalesce_brackets=true
 allow_split_before_dict_value=false
 indent_dictionary_value=true
 split_before_expression_after_opening_paren=true
+
+[flake8]
+max-line-length = 120

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,6 +18,7 @@ from tests.utils import async_test, SingleServerTestCase, MultiServerAuthTestCas
 
 
 class ClientUtilsTest(unittest.TestCase):
+
     def test_default_connect_command(self):
         nc = NATS()
         nc.options["verbose"] = False
@@ -42,6 +43,7 @@ class ClientUtilsTest(unittest.TestCase):
 
 
 class ClientTest(SingleServerTestCase):
+
     @async_test
     async def test_default_connect(self):
         nc = NATS()
@@ -856,6 +858,7 @@ class ClientTest(SingleServerTestCase):
 
 
 class ClientReconnectTest(MultiServerAuthTestCase):
+
     @async_test
     async def test_connect_with_auth(self):
         nc = NATS()
@@ -1368,6 +1371,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
 
 
 class ClientAuthTokenTest(MultiServerAuthTokenTestCase):
+
     @async_test
     async def test_connect_with_auth_token(self):
         nc = NATS()
@@ -1475,6 +1479,7 @@ class ClientAuthTokenTest(MultiServerAuthTokenTestCase):
 
 
 class ClientTLSTest(TLSServerTestCase):
+
     @async_test
     async def test_connect(self):
         nc = NATS()
@@ -1549,6 +1554,7 @@ class ClientTLSTest(TLSServerTestCase):
 
 
 class ClientTLSReconnectTest(MultiTLSServerAuthTestCase):
+
     @async_test
     async def test_tls_reconnect(self):
 
@@ -1622,6 +1628,7 @@ class ClientTLSReconnectTest(MultiTLSServerAuthTestCase):
 
 
 class ClusterDiscoveryTest(ClusteringTestCase):
+
     @async_test
     async def test_discover_servers_on_first_connect(self):
         nc = NATS()
@@ -1682,6 +1689,7 @@ class ClusterDiscoveryTest(ClusteringTestCase):
 
 
 class ClusterDiscoveryReconnectTest(ClusteringDiscoveryAuthTestCase):
+
     @async_test
     async def test_reconnect_to_new_server_with_auth(self):
         nc = NATS()
@@ -1731,8 +1739,10 @@ class ClusterDiscoveryReconnectTest(ClusteringDiscoveryAuthTestCase):
 
 
 class ConnectFailuresTest(SingleServerTestCase):
+
     @async_test
     async def test_empty_info_op_uses_defaults(self):
+
         async def bad_server(reader, writer):
             writer.write(b'INFO {}\r\n')
             await writer.drain()
@@ -1762,6 +1772,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
     @async_test
     async def test_empty_response_from_server(self):
+
         async def bad_server(reader, writer):
             writer.write(b'')
             await asyncio.sleep(0.2)
@@ -1789,6 +1800,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
     @async_test
     async def test_malformed_info_response_from_server(self):
+
         async def bad_server(reader, writer):
             writer.write(b'INF')
             await asyncio.sleep(0.2)
@@ -1816,6 +1828,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
     @async_test
     async def test_malformed_info_json_response_from_server(self):
+
         async def bad_server(reader, writer):
             writer.write(b'INFO {\r\n')
             await asyncio.sleep(0.2)
@@ -1844,6 +1857,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
     @async_test
     async def test_connect_timeout(self):
+
         async def slow_server(reader, writer):
             await asyncio.sleep(1)
             writer.close()
@@ -1880,6 +1894,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
     @async_test
     async def test_connect_timeout_then_connect_to_healthy_server(self):
+
         async def slow_server(reader, writer):
             await asyncio.sleep(1)
             writer.close()
@@ -1933,6 +1948,7 @@ class ConnectFailuresTest(SingleServerTestCase):
 
 
 class ClientDrainTest(SingleServerTestCase):
+
     @async_test
     async def test_drain_subscription(self):
         nc = NATS()

--- a/tests/test_client_async_await.py
+++ b/tests/test_client_async_await.py
@@ -9,6 +9,7 @@ from tests.utils import (async_test, SingleServerTestCase)
 
 
 class ClientAsyncAwaitTest(SingleServerTestCase):
+
     @async_test
     async def test_async_await_subscribe_async(self):
         nc = NATS()

--- a/tests/test_client_nkeys.py
+++ b/tests/test_client_nkeys.py
@@ -19,6 +19,7 @@ from tests.utils import (
 
 
 class ClientNkeysAuthTest(NkeysServerTestCase):
+
     @async_test
     async def test_nkeys_connect(self):
         if not nkeys_installed:
@@ -60,6 +61,7 @@ class ClientNkeysAuthTest(NkeysServerTestCase):
 
 
 class ClientJWTAuthTest(TrustedServerTestCase):
+
     @async_test
     async def test_nkeys_jwt_creds_user_connect(self):
         if not nkeys_installed:

--- a/tests/test_client_v2.py
+++ b/tests/test_client_v2.py
@@ -16,6 +16,7 @@ from tests.utils import *
 
 
 class HeadersTest(SingleServerTestCase):
+
     @async_test
     async def test_simple_headers(self):
         nc = await nats.connect()

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -21,6 +21,7 @@ from tests.utils import *
 
 
 class PublishTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_publish(self):
         nc = NATS()
@@ -73,6 +74,7 @@ class PublishTest(SingleJetStreamServerTestCase):
 
 
 class PullSubscribeTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_auto_create_consumer(self):
         nc = NATS()
@@ -582,6 +584,7 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
 
 
 class JSMTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_stream_management(self):
         nc = NATS()
@@ -698,6 +701,7 @@ class JSMTest(SingleJetStreamServerTestCase):
 
 
 class SubscribeTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_queue_subscribe_deliver_group(self):
         nc = await nats.connect()
@@ -866,6 +870,7 @@ class SubscribeTest(SingleJetStreamServerTestCase):
 
 
 class AckPolicyTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_double_acking_pull_subscribe(self):
         nc = await nats.connect()
@@ -954,6 +959,7 @@ class AckPolicyTest(SingleJetStreamServerTestCase):
 
 
 class OrderedConsumerTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_flow_control(self):
         errors = []
@@ -1199,6 +1205,7 @@ class OrderedConsumerTest(SingleJetStreamServerTestCase):
 
 
 class KVTest(SingleJetStreamServerTestCase):
+
     @async_test
     async def test_kv_simple(self):
         errors = []

--- a/tests/test_nuid.py
+++ b/tests/test_nuid.py
@@ -20,6 +20,7 @@ from nats.nuid import BASE, NUID, MAX_SEQ, PREFIX_LENGTH, TOTAL_LENGTH
 
 
 class NUIDTest(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,6 +9,7 @@ from tests.utils import async_test
 
 
 class MockNatsClient:
+
     def __init__(self):
         self._subs = {}
         self._pongs = []
@@ -38,6 +39,7 @@ class MockNatsClient:
 
 
 class ProtocolParserTest(unittest.TestCase):
+
     def setUp(self):
         self.loop = asyncio.new_event_loop()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,6 +22,7 @@ SERVER_BIN_DIR_NAME = "nats-server"
 
 
 class NATSD:
+
     def __init__(
         self,
         port=4222,
@@ -166,6 +167,7 @@ class NATSD:
 
 
 class SingleServerTestCase(unittest.TestCase):
+
     def setUp(self):
         self.server_pool = []
         self.loop = asyncio.new_event_loop()
@@ -182,6 +184,7 @@ class SingleServerTestCase(unittest.TestCase):
 
 
 class MultiServerAuthTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -203,6 +206,7 @@ class MultiServerAuthTestCase(unittest.TestCase):
 
 
 class MultiServerAuthTokenTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -224,6 +228,7 @@ class MultiServerAuthTokenTestCase(unittest.TestCase):
 
 
 class TLSServerTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.loop = asyncio.new_event_loop()
@@ -247,6 +252,7 @@ class TLSServerTestCase(unittest.TestCase):
 
 
 class MultiTLSServerAuthTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -280,6 +286,7 @@ class MultiTLSServerAuthTestCase(unittest.TestCase):
 
 
 class ClusteringTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -328,6 +335,7 @@ class ClusteringTestCase(unittest.TestCase):
 
 
 class ClusteringDiscoveryAuthTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -377,6 +385,7 @@ class ClusteringDiscoveryAuthTestCase(unittest.TestCase):
 
 
 class NkeysServerTestCase(unittest.TestCase):
+
     def setUp(self):
         self.server_pool = []
         self.loop = asyncio.new_event_loop()
@@ -395,6 +404,7 @@ class NkeysServerTestCase(unittest.TestCase):
 
 
 class TrustedServerTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.server_pool = []
@@ -415,6 +425,7 @@ class TrustedServerTestCase(unittest.TestCase):
 
 
 class SingleJetStreamServerTestCase(unittest.TestCase):
+
     def setUp(self):
         self.server_pool = []
         self.loop = asyncio.new_event_loop()
@@ -456,6 +467,7 @@ def get_config_file(file_path):
 
 
 def async_test(test_case_fun, timeout=5):
+
     @wraps(test_case_fun)
     def wrapper(test_case, *args, **kw):
         asyncio.set_event_loop(test_case.loop)
@@ -467,6 +479,7 @@ def async_test(test_case_fun, timeout=5):
 
 
 def async_long_test(test_case_fun, timeout=10):
+
     @wraps(test_case_fun)
     def wrapper(test_case, *args, **kw):
         asyncio.set_event_loop(test_case.loop)


### PR DESCRIPTION
The PR adds [mypy](http://mypy-lang.org/) and [flake8](https://flake8.pycqa.org/en/latest/) on CI.

+ **mypy** is a type checker. It finds some type misuse bugs (I've fixed a lot of issues in my previous PRs there, so it's actually helpful) and makes sure you don't lie in your type annotations (and type annotations are important because there are user-facing and part of the library API).
+ **flake8** finds some trivial bugs and makes sure you follow [PEP-8](https://www.python.org/dev/peps/pep-0008/). For example, I previously fixed there bare `try-except` blocks (by replacing `except:` with `except Exception:`) so it won't suppress `sys.exit`, kill signals, and KeyboardInterrupt (and you never want to suppress any of it in a library).

Currently, they check only `nats/js` because this is the only part of the project I fixed so far. And the only part that allows going a bit wild since it's not in a major release yet.