### PR TITLE
Improve JS API

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -479,11 +479,11 @@ class KeyValueConfig(Base):
     bucket: str
     description: Optional[str] = None
     max_value_size: Optional[int] = None
-    history: Optional[int] = None
+    history: int = 1
     ttl: Optional[float] = None  # in seconds
     max_bytes: Optional[int] = None
     storage: Optional[StorageType] = None
-    replicas: Optional[int] = None
+    replicas: int = 1
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -17,8 +17,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypeVar
 import json
 
-
-_NANOSECOND = 10 ** 9
+_NANOSECOND = 10**9
 
 
 class Header(str, Enum):

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -15,7 +15,6 @@
 from dataclasses import dataclass, fields, replace
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypeVar
-import json
 
 _NANOSECOND = 10**9
 
@@ -85,7 +84,10 @@ class Base:
 
     @classmethod
     def from_response(cls: Type[_B], resp: Dict[str, Any]) -> _B:
-        # Reject unknown properties before loading.
+        """Read the class instance from a server response.
+
+        Unknown fields are ignored ("open-world assumption").
+        """
         params = {}
         for field in fields(cls):
             if field.name in resp:
@@ -93,9 +95,13 @@ class Base:
         return cls(**params)
 
     def evolve(self: _B, **params) -> _B:
+        """Return a copy of the instance with the passed values replaced.
+        """
         return replace(self, **params)
 
     def as_dict(self) -> Dict[str, object]:
+        """Return the object converted into an API-friendly dict.
+        """
         result = {}
         for field in fields(self):
             val = getattr(self, field.name)
@@ -105,9 +111,6 @@ class Base:
                 val = val.as_dict()
             result[field.name] = val
         return result
-
-    def as_json(self) -> str:
-        return json.dumps(self.as_dict())
 
 
 @dataclass

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -623,7 +623,7 @@ class JetStreamContext(JetStreamManager):
             )
             return info
 
-        async def fetch(self, batch: int = 1, timeout: int = 5) -> List[Msg]:
+        async def fetch(self, batch: int = 1, timeout: float = 5) -> List[Msg]:
             """
             fetch makes a request to JetStream to be delivered a set of messages.
 
@@ -660,15 +660,15 @@ class JetStreamContext(JetStreamManager):
             if not timeout or timeout <= 0:
                 raise ValueError("nats: invalid fetch timeout")
 
-            expires = (timeout * 1_000_000_000) - 100_000
+            expires = int(timeout * 1_000_000_000) - 100_000
             if batch == 1:
-                msg = await self._fetch_one(batch, expires, timeout)
+                msg = await self._fetch_one(expires, timeout)
                 return [msg]
             msgs = await self._fetch_n(batch, expires, timeout)
             return msgs
 
         async def _fetch_one(
-            self, batch: int, expires: int, timeout: int
+            self, expires: int, timeout: float,
         ) -> Msg:
             queue = self._sub._pending_queue
 
@@ -706,8 +706,9 @@ class JetStreamContext(JetStreamManager):
                 return msg
             raise nats.js.errors.APIError.from_msg(msg)
 
-        async def _fetch_n(self, batch: int, expires: int,
-                           timeout: int) -> List[Msg]:
+        async def _fetch_n(
+            self, batch: int, expires: int, timeout: float,
+        ) -> List[Msg]:
             msgs = []
             queue = self._sub._pending_queue
             start_time = time.monotonic()

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -888,8 +888,6 @@ class JetStreamContext(JetStreamManager):
             config.history = 1
         if not config.replicas:
             config.replicas = 1
-        if config.ttl:
-            config.ttl = config.ttl * 1_000_000_000
 
         stream = api.StreamConfig(
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -864,15 +864,15 @@ class JetStreamContext(JetStreamManager):
             js=self,
         )
 
-    async def create_key_value(self, **params) -> KeyValue:
+    async def create_key_value(
+        self, config: Optional[api.KeyValueConfig] = None, **params,
+    ) -> KeyValue:
         """
         create_key_value takes an api.KeyValueConfig and creates a KV in JetStream.
         """
-        config = api.KeyValueConfig(**params)
-        if not config.history:
-            config.history = 1
-        if not config.replicas:
-            config.replicas = 1
+        if config is None:
+            config = api.KeyValueConfig(bucket=params["bucket"])
+        config = config.evolve(**params)
 
         stream = api.StreamConfig(
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -652,7 +652,9 @@ class JetStreamContext(JetStreamManager):
             return msgs
 
         async def _fetch_one(
-            self, expires: int, timeout: float,
+            self,
+            expires: int,
+            timeout: float,
         ) -> Msg:
             queue = self._sub._pending_queue
 
@@ -691,7 +693,10 @@ class JetStreamContext(JetStreamManager):
             raise nats.js.errors.APIError.from_msg(msg)
 
         async def _fetch_n(
-            self, batch: int, expires: int, timeout: float,
+            self,
+            batch: int,
+            expires: int,
+            timeout: float,
         ) -> List[Msg]:
             msgs = []
             queue = self._sub._pending_queue
@@ -865,7 +870,9 @@ class JetStreamContext(JetStreamManager):
         )
 
     async def create_key_value(
-        self, config: Optional[api.KeyValueConfig] = None, **params,
+        self,
+        config: Optional[api.KeyValueConfig] = None,
+        **params,
     ) -> KeyValue:
         """
         create_key_value takes an api.KeyValueConfig and creates a KV in JetStream.

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -98,7 +98,7 @@ class KeyValue:
             """
             if self.stream_info.config.max_age is None:
                 return None
-            return self.stream_info.config.max_age / 1_000_000_000
+            return self.stream_info.config.max_age
 
     def __init__(
         self,

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -78,7 +78,7 @@ class JetStreamManager:
         if config.name is None:
             raise ValueError("nats: stream name is required")
 
-        data = config.as_json()
+        data = json.dumps(config.as_dict())
         resp = await self._api_request(
             f"{self._prefix}.STREAM.CREATE.{config.name}",
             data.encode(),

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -40,10 +40,10 @@ class JetStreamManager:
         self._hdr_parser = BytesParser()
 
     async def account_info(self) -> api.AccountInfo:
-        info = await self._api_request(
+        resp = await self._api_request(
             f"{self._prefix}.INFO", b'', timeout=self._timeout
         )
-        return api.AccountInfo.loads(**info)
+        return api.AccountInfo.from_response(resp)
 
     async def find_stream_name_by_subject(self, subject: str) -> str:
         """
@@ -64,7 +64,7 @@ class JetStreamManager:
         resp = await self._api_request(
             f"{self._prefix}.STREAM.INFO.{name}", timeout=self._timeout
         )
-        return api.StreamInfo.loads(**resp)
+        return api.StreamInfo.from_response(resp)
 
     async def add_stream(
         self, config: api.StreamConfig = None, **params
@@ -84,7 +84,7 @@ class JetStreamManager:
             data.encode(),
             timeout=self._timeout,
         )
-        return api.StreamInfo.loads(**resp)
+        return api.StreamInfo.from_response(resp)
 
     async def delete_stream(self, name: str) -> bool:
         """
@@ -106,7 +106,7 @@ class JetStreamManager:
             b'',
             timeout=timeout
         )
-        return api.ConsumerInfo.loads(**resp)
+        return api.ConsumerInfo.from_response(resp)
 
     async def add_consumer(
         self,
@@ -115,7 +115,6 @@ class JetStreamManager:
         timeout: Optional[float] = None,
         **params,
     ) -> api.ConsumerInfo:
-        # TODO: Convert from seconds into nanoseconds.
         if not timeout:
             timeout = self._timeout
         if config is None:
@@ -138,7 +137,7 @@ class JetStreamManager:
                 req_data,
                 timeout=timeout
             )
-        return api.ConsumerInfo.loads(**resp)
+        return api.ConsumerInfo.from_response(resp)
 
     async def delete_consumer(self, stream: str, consumer: str) -> bool:
         resp = await self._api_request(

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1223,7 +1223,7 @@ class KVTest(SingleJetStreamServerTestCase):
         self.assertEqual(status.bucket, "TEST")
         self.assertEqual(status.values, 0)
         self.assertEqual(status.history, 5)
-        self.assertEqual(int(status.ttl), 3600)
+        self.assertEqual(status.ttl, 3600)
 
         seq = await kv.put("hello", b'world')
         self.assertEqual(seq, 1)

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -396,7 +396,8 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         await js.add_stream(name="TEST3", subjects=["max"])
 
         sub = await js.pull_subscribe(
-            "max", "example", config={'max_waiting': 3}
+            "max", "example",
+            config=nats.js.api.ConsumerConfig(max_waiting=3),
         )
         results = None
         try:
@@ -476,7 +477,8 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         await js.add_stream(name="TEST31", subjects=["max"])
 
         sub = await js.pull_subscribe(
-            "max", "example", config={'max_waiting': 3}
+            "max", "example",
+            config=nats.js.api.ConsumerConfig(max_waiting=3),
         )
         results = None
         try:

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -396,7 +396,8 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         await js.add_stream(name="TEST3", subjects=["max"])
 
         sub = await js.pull_subscribe(
-            "max", "example",
+            "max",
+            "example",
             config=nats.js.api.ConsumerConfig(max_waiting=3),
         )
         results = None
@@ -477,7 +478,8 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         await js.add_stream(name="TEST31", subjects=["max"])
 
         sub = await js.pull_subscribe(
-            "max", "example",
+            "max",
+            "example",
             config=nats.js.api.ConsumerConfig(max_waiting=3),
         )
         results = None


### PR DESCRIPTION
1. The Nats API uses nanoseconds for time, Python uses seconds. So, some classes in `nats/js` had time in nanoseconds, some in seconds. I've made them all store time in seconds and convert it into nanoseconds in `as_dict` result.
2. `Base.loads` silently drops unknown fields. While it is great for API responses (an open-world assumption), it can be harmful for the cases where the user passes a value explicitly. So, I renamed the method into `from_response` and use it only for parsing API responses. The `evolve` method now uses `dataclasses.replace` instead. Everything that was in `__post_init__` also migrated into `from_response` since it is also applicable only for API responses, not for user-provided data. It also helped to avoid double-conversion of time from nanoseconds.
