### PR TITLE
Add inbox prefix as a configuration variable

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -723,6 +723,19 @@ class ClientTest(SingleServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_custom_inbox_prefix(self):
+        nc = NATS()
+
+        async def worker_handler(msg):
+            self.assertTrue(msg.reply.startswith('bar.'))
+            await msg.respond(b"OK")
+
+        await nc.connect(inbox_prefix="bar")
+        await nc.subscribe("foo", cb=worker_handler)
+        await nc.request("foo", b'')
+        await nc.close()
+
+    @async_test
     async def test_msg_respond(self):
         nc = NATS()
         msgs = []


### PR DESCRIPTION
We can configure the inbox prefix on many other nats client implementation, including the go client (https://github.com/nats-io/nats.go/blob/161162cae0b290287b5e2246732c0075e3724497/nats.go#L1143-L1152) or the java client (https://github.com/nats-io/nats.java/blob/a551760a10e620049fb5f4848d104e96fba4ed0f/src/main/java/io/nats/client/Options.java#L572).

The point of this PR is to reproduce the same behaviour on the python client