### PR TITLE
typing: support PEP-561

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     author_email='wally@synadia.com',
     license='Apache 2 License',
     packages=['nats', 'nats.aio', 'nats.protocol', 'nats.js'],
+    package_data={"nats": ["py.typed"]},
     zip_safe=True,
     extras_require=EXTRAS
 )


### PR DESCRIPTION
Currently, when using nats-py, mypy will complain about:
```
Skipping analyzing "nats": module is installed, but missing library
stubs or py.typed marker
```

This commit aims to solve this by opting into typing follow the
requirements of PEP-561:
https://www.python.org/dev/peps/pep-0561/#packaging-type-information.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>