### PR TITLE
nats: add typing to main connect function

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -11,11 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import List, Union
 
 from .aio.client import Client as NATS
 
 
-async def connect(servers=["nats://localhost:4222"], **options) -> NATS:
+async def connect(
+    servers: Union[str, List[str]] = ["nats://localhost:4222"],
+    **options
+) -> NATS:
     """
     :param servers: List of servers to connect.
     :param options: NATS connect options.

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -219,7 +219,7 @@ class Client:
 
     async def connect(
         self,
-        servers: Union[str, List[str]] = ["nats://127.0.0.1:4222"],
+        servers: Union[str, List[str]] = ["nats://localhost:4222"],
         error_cb: Optional[ErrorCallback] = None,
         disconnected_cb: Optional[Callback] = None,
         closed_cb: Optional[Callback] = None,
@@ -1074,11 +1074,11 @@ class Client:
             try:
                 if "nats://" in connect_url or "tls://" in connect_url:
                     # Closer to how the Go client handles this.
-                    # e.g. nats://127.0.0.1:4222
+                    # e.g. nats://localhost:4222
                     uri = urlparse(connect_url)
                 elif ":" in connect_url:
                     # Expand the scheme for the user
-                    # e.g. 127.0.0.1:4222
+                    # e.g. localhost:4222
                     uri = urlparse(f"nats://{connect_url}")
                 else:
                     # Just use the endpoint with the default NATS port.

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -219,7 +219,7 @@ class Client:
 
     async def connect(
         self,
-        servers: List[str] = ["nats://127.0.0.1:4222"],
+        servers: Union[str, List[str]] = ["nats://127.0.0.1:4222"],
         error_cb: Optional[ErrorCallback] = None,
         disconnected_cb: Optional[Callback] = None,
         closed_cb: Optional[Callback] = None,


### PR DESCRIPTION
Currently, the `connect` functions of the main NATS modules are not
fully typed or typed slightly incorrectly. The examples all show that a
single string can be given for the `servers` parameter, but the `Client`
class does not declare that it accepts this type, which causes static
analysis issues when the module is used directly.

This commit extends the signatures for `connect` so that `servers` can
also be a `str`, effectively giving it the same type as what is expected
by `_setup_server_pool`.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>