### PR TITLE
require deliver_subject in JS subscribe_bind

### DIFF
--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -303,7 +303,7 @@ class JetStreamContext(JetStreamManager):
         if cb and not manual_ack:
             cb = self._auto_ack_callback(cb)
         if config.deliver_subject is None:
-            config.deliver_subject = self._nc.new_inbox()
+            raise TypeError("config.deliver_subject is required")
         sub = await self._nc.subscribe(
             subject=config.deliver_subject,
             queue=config.deliver_group or "",


### PR DESCRIPTION
Since deliver_subject must be created before creating the consumer, require it to be already present when calling subscribe_bind instead of implicitly creating it.