### PR TITLE
Fix connected_url to return ParseResult

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -985,9 +985,9 @@ class Client:
             raise errors.TimeoutError
 
     @property
-    def connected_url(self) -> Optional[str]:
+    def connected_url(self) -> Optional[ParseResult]:
         if self._current_server and self.is_connected:
-            return str(self._current_server.uri)
+            return self._current_server.uri
         return None
 
     @property


### PR DESCRIPTION
Fixes connected_url property to return the ParseResult object instead of a string representation like `'ParseResult(scheme=\'nats\', netloc=\'localhost:4222\', path=\'\', params=\'\', query=\'\', fragment=\'\')'`

This was broken in a recent update, and makes the examples that print `nc.connected_url.netloc` throw an Exception: `AttributeError: 'str' object has no attribute 'netloc'`