### PR TITLE
Fixes to internal flush mechanism plus new connect options 

### DIFF
--- a/nats/errors.py
+++ b/nats/errors.py
@@ -42,6 +42,24 @@ class StaleConnectionError(Error):
         return "nats: stale connection"
 
 
+class OutboundBufferLimitError(Error):
+
+    def __str__(self) -> str:
+        return "nats: outbound buffer limit exceeded"
+
+
+class UnexpectedEOF(StaleConnectionError):
+
+    def __str__(self) -> str:
+        return "nats: unexpected EOF"
+
+
+class FlushTimeoutError(TimeoutError):
+
+    def __str__(self) -> str:
+        return "nats: flush timeout"
+
+
 class ConnectionClosedError(Error):
 
     def __str__(self) -> str:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -111,6 +111,8 @@ class NATSD:
         if len(self.routes) > 0:
             cmd.append('--routes')
             cmd.append(','.join(self.routes))
+            cmd.append('--cluster_name')
+            cmd.append('CLUSTER')
 
         if self.config_file is not None:
             cmd.append("--config")


### PR DESCRIPTION
A default pending size of 64 MB like the server is used by default.
This can be changed by using the `pending_size` option on connect, for example to set it to 8MB only:

```python
nats.connect(pending_size=8*1024*1024)
```

And similar to the nats.go client, it can be disabled if set to be negative:

```python
nats.connect(pending_size=-1)
```

When this is done, then any published message during a disconnection will result in a synchronous `OutboundBufferLimitError` thrown when publishing.

To control the flushing there is a `flush_timeout` option that can be passed on connect as well:

```python
nats.connect(flush_timeout=10)
```

By default, there is no flush timeout so the client can wait indefinely during a flush similar to nats.go (eventually the ping interval ought to unblock the flushing)

Changes:

- Changed `nc.flush()` to now throw `FlushTimeoutError` instead which is a subtype of `TimeoutError` that it used be using for backwards compatibility.

- Changed EOF disconnections being reported as `StaleConnectionError` and they are instead a `UnexpectedEOF` error.

Signed-off-by: Waldemar Quevedo <wally@nats.io>