### PR TITLE
Make 'cluster' optional in 'Placement' class.

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -128,7 +128,7 @@ class PubAck(Base):
 class Placement(Base):
     """Placement directives to consider when placing replicas of this stream"""
 
-    cluster: str
+    cluster: Optional[str] = None
     tags: Optional[List[str]] = None
 
 


### PR DESCRIPTION
Fix for issue #308, where you would get a `TypeError: __init__() missing 1 required positional argument: 'cluster'` when connecting to a KV bucket ☺️