### PR TITLE
Fix incorrect timeout propagation

### DIFF
--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -922,7 +922,7 @@ class JetStreamContext(JetStreamManager):
         req_subject = f"{self._prefix}.STREAM.MSG.GET.{stream_name}"
         req = {'last_by_subj': subject}
         data = json.dumps(req)
-        resp = await self._api_request(req_subject, data.encode())
+        resp = await self._api_request(req_subject, data.encode(), timeout=self._timeout)
         raw_msg = api.RawStreamMsg.from_response(resp['message'])
         if raw_msg.hdrs:
             hdrs = base64.b64decode(raw_msg.hdrs)


### PR DESCRIPTION
This commit adds timeout propagation on key value get operation.

I created a JetStream and tried grabbing value from KeyValue store like this:

```python3
js = nc.jetstream(timeout=60*5)
kv = await js.key_value(output.bucket_name)
cached_result = await kv.get(output.cache_key)
```

But the request was failing with a timeout error after 5s, which seemed to be a default in one of the nested function calls.

This PR adds propagation of timeout from JetStreamContext to operations related to key value store.

