### PR TITLE
Add "num_replicas" field for consumer

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -365,6 +365,7 @@ class ConsumerConfig(Base):
     flow_control: Optional[bool] = None
     idle_heartbeat: Optional[float] = None
     headers_only: Optional[bool] = None
+    num_replicas: Optional[int] = None
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1590,7 +1590,7 @@ class ConsumerReplicasTest(SingleJetStreamServerTestCase):
 
 
         # Create consumer
-        config = nats.js.api.ConsumerConfig(num_replicas=1)
+        config = nats.js.api.ConsumerConfig(num_replicas=1, durable_name="mycons")
         cons = await js.add_consumer(stream="TESTREPLICAS", config=config)
 
         assert cons.config.num_replicas == 1

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1577,3 +1577,22 @@ class KVTest(SingleJetStreamServerTestCase):
 
         with pytest.raises(BadBucketError):
             await js.key_value(bucket="TEST3")
+
+class ConsumerReplicasTest(SingleJetStreamServerTestCase):
+    @async_test
+    async def test_number_of_consumer_replicas(self):
+        nc = await nats.connect()
+
+        js = nc.jetstream()
+        await js.add_stream(name="TESTREPLICAS", subjects=["test.replicas"])
+        for i in range(0, 10):
+            await js.publish("test", f'{i}'.encode())
+
+
+        # Create consumer
+        config = nats.js.api.ConsumerConfig(num_replicas=1)
+        cons = await js.add_consumer(stream="TESTREPLICAS", config=config)
+
+        assert cons.config.num_replicas == 1
+
+        await nc.close()

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1586,7 +1586,7 @@ class ConsumerReplicasTest(SingleJetStreamServerTestCase):
         js = nc.jetstream()
         await js.add_stream(name="TESTREPLICAS", subjects=["test.replicas"])
         for i in range(0, 10):
-            await js.publish("test", f'{i}'.encode())
+            await js.publish("test.replicas", f'{i}'.encode())
 
 
         # Create consumer


### PR DESCRIPTION
This adds `num_replicas` field to allow configuring the number of replicas for a durable consumer.