### PR TITLE
Fix header line to be compatible again with other clients

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1473,7 +1473,7 @@ class Client:
             return None
 
         hdr = None
-        raw_headers = headers[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
+        raw_headers = headers[NATS_HDR_LINE_SIZE:]
 
         # If the first character is an empty space, then this is
         # an inline status message sent by the server.
@@ -1485,7 +1485,7 @@ class Client:
         # Note: it is possible to receive a message with both inline status
         # and a set of headers.
         #
-        # NATS/1.0 100 Idle Heartbeat\r\nNats-Last-Consumer: 1016\r\nNats-Last-Stream: 1024\r\n\r\n
+        # NATS/1.0 100\r\nIdle Heartbeat\r\nNats-Last-Consumer: 1016\r\nNats-Last-Stream: 1024\r\n\r\n
         #
         if raw_headers[0] == _SPC_BYTE_:
             # Special handling for status messages.
@@ -1524,9 +1524,9 @@ class Client:
         #
         # Example header without status:
         #
-        # NATS/1.0foo: bar
-        # hello: world
+        # NATS/1.0\r\nfoo: bar\r\nhello: world
         #
+        raw_headers = headers[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
         try:
             parsed_hdr = self._hdr_parser.parsebytes(raw_headers)
             if len(parsed_hdr.items()) == 0:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -780,6 +780,7 @@ class Client:
         else:
             hdr = bytearray()
             hdr.extend(NATS_HDR_LINE)
+            hdr.extend(_CRLF_)
             for k, v in headers.items():
                 key = k.strip()
                 if not key:
@@ -1472,7 +1473,7 @@ class Client:
             return None
 
         hdr = None
-        raw_headers = headers[len(NATS_HDR_LINE):]
+        raw_headers = headers[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
 
         # If the first character is an empty space, then this is
         # an inline status message sent by the server.

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
 
 NATS_HDR_LINE = bytearray(b'NATS/1.0')
 NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
+_CRLF_ = b'\r\n'
+_CRLF_LEN_ = len(_CRLF_)
 KV_STREAM_TEMPLATE = "KV_{bucket}"
 KV_PRE_TEMPLATE = "$KV.{bucket}."
 Callback = Callable[['Msg'], Awaitable[None]]
@@ -926,7 +928,7 @@ class JetStreamContext(JetStreamManager):
         raw_msg = api.RawStreamMsg.from_response(resp['message'])
         if raw_msg.hdrs:
             hdrs = base64.b64decode(raw_msg.hdrs)
-            raw_headers = hdrs[len(NATS_HDR_LINE):]
+            raw_headers = hdrs[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
             parsed_headers = self._jsm._hdr_parser.parsebytes(raw_headers)
             headers = None
             if len(parsed_headers.items()) > 0:

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -25,6 +25,9 @@ if TYPE_CHECKING:
     from nats import NATS
 
 NATS_HDR_LINE = bytearray(b'NATS/1.0')
+NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
+_CRLF_ = b'\r\n'
+_CRLF_LEN_ = len(_CRLF_)
 
 
 class JetStreamManager:
@@ -221,7 +224,7 @@ class JetStreamManager:
         raw_msg = api.RawStreamMsg.from_response(resp['message'])
         if raw_msg.hdrs:
             hdrs = base64.b64decode(raw_msg.hdrs)
-            raw_headers = hdrs[len(NATS_HDR_LINE):]
+            raw_headers = hdrs[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
             parsed_headers = self._hdr_parser.parsebytes(raw_headers)
             headers = None
             if len(parsed_headers.items()) > 0:

--- a/tests/test_client_v2.py
+++ b/tests/test_client_v2.py
@@ -88,6 +88,17 @@ class HeadersTest(SingleServerTestCase):
         msg = await sub.next_msg()
         self.assertTrue(msg.headers == None)
 
+        hdrs = {
+            'timestamp': '2022-06-15T19:08:14.639020',
+            'type': 'rpc',
+            'command': 'publish_state',
+            'trace_id': '',
+            'span_id': ''
+        }
+        await nc.publish("foo", b'Hello from Python!', headers=hdrs)
+        msg = await sub.next_msg()
+        self.assertEqual(msg.headers, hdrs)
+
         await nc.close()
 
 

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -807,7 +807,7 @@ class JSMTest(SingleJetStreamServerTestCase):
         assert msg.subject == 'foo.a.1'
         assert msg.data == b'Hello'
         assert msg.headers["foo"] == "bar"
-        assert msg.hdrs == 'TkFUUy8xLjBmb286IGJhcg0KDQo='
+        assert msg.hdrs == 'TkFUUy8xLjANCmZvbzogYmFyDQoNCg=='
 
         with pytest.raises(BadRequestError):
             await jsm.get_msg("foo", 0)
@@ -1503,6 +1503,7 @@ class KVTest(SingleJetStreamServerTestCase):
 
         with pytest.raises(KeyDeletedError) as err:
             await kv.get("hello.1")
+
         assert err.value.entry.key == 'hello.1'
         assert err.value.entry.revision == 102
         assert err.value.entry.value == None


### PR DESCRIPTION
CRLF required in other clients parsers so this helps with compatibility with the spec.

Signed-off-by: Waldemar Quevedo <wally@nats.io>