### PR TITLE
Add couple of extra unique token characters to requests

### DIFF
--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -12,8 +12,9 @@
 # limitations under the License.
 #
 
-from random import Random, SystemRandom
+from random import Random
 from sys import maxsize as MaxInt
+from secrets import token_bytes, randbelow
 
 DIGITS = b'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 BASE = 62
@@ -33,8 +34,7 @@ class NUID:
     """
 
     def __init__(self) -> None:
-        self._srand = SystemRandom()
-        self._prand = Random(self._srand.randint(0, MaxInt))
+        self._prand = Random(randbelow(MaxInt))
         self._seq = self._prand.randint(0, MAX_SEQ)
         self._inc = MIN_INC + self._prand.randint(BASE + 1, INC)
         self._prefix = bytearray()
@@ -60,9 +60,7 @@ class NUID:
         return prefix
 
     def randomize_prefix(self) -> None:
-        random_bytes = (
-            self._srand.getrandbits(8) for i in range(PREFIX_LENGTH)
-        )
+        random_bytes = token_bytes(PREFIX_LENGTH)
         self._prefix = bytearray(DIGITS[c % BASE] for c in random_bytes)
 
     def reset_sequential(self) -> None:

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -700,6 +700,22 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         assert len(msgs) <= 100
         assert sub.pending_msgs == 0
         assert sub.pending_bytes == 0
+
+        # Consumer has a single message pending but none in buffer.
+        await js.publish("a3", b'last message')
+        info = await sub.consumer_info()
+        assert info.num_pending == 1
+        assert sub.pending_msgs == 0
+
+        # Remove interest
+        await sub.unsubscribe()
+        with pytest.raises(TimeoutError):
+            await sub.fetch(1, timeout=1)
+
+        # The pending message is still there, but not possible to consume.
+        info = await sub.consumer_info()
+        assert info.num_pending == 1
+
         await nc.close()
 
 

--- a/todo.md
+++ b/todo.md
@@ -20,7 +20,7 @@
 - [X] io_loop becomes loop parameter
 - [X] Drain Mode
 - [X] Connect timeout
+- [X] Adopt async/await in client
+- [X] Subscription object on subscribe
+- [X] Error handler yields the subscription
 - [ ] Use asyncio.Protocol
-- [ ] Adopt async/await in client
-- [ ] Subscription object on subscribe
-- [ ] Error handler yields the subscription


### PR DESCRIPTION
This is to ensure that the NUID does not become shared state for some reason and end up accidentally using the same response token for a request.

Signed-off-by: Waldemar Quevedo <wally@nats.io>