### PR TITLE
Add flush in Hello World example

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -40,6 +40,9 @@ NATS Hello World in Python 🐍
 	msg = await sub.next_msg()
 	print("Received:", msg)
 
+	# Make sure all published messages have reached the subject
+	await nc.flush()
+
 	# Close NATS connection
 	await nc.close()
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -40,7 +40,7 @@ NATS Hello World in Python 🐍
 	msg = await sub.next_msg()
 	print("Received:", msg)
 
-	# Make sure all published messages have reached the subject
+	# Make sure all published messages have reached the server
 	await nc.flush()
 
 	# Close NATS connection


### PR DESCRIPTION
Adding flush in the HelloWorld example would give it way more visibility than adding it to the API reference, and it will enforce the practice of executing a `flush` before closing NATS connection