### PR TITLE
Support sending requests with reconnected client

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -638,8 +638,9 @@ class Client:
             if self._closed_cb is not None:
                 await self._closed_cb()
 
-        # Set the client_id back to None
+        # Set the client_id and subscription prefix back to None
         self._client_id = None
+        self._resp_sub_prefix = None
 
     async def drain(self) -> None:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -918,6 +918,19 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(0, err_count)
 
     @async_test
+    async def test_connect_after_close(self):
+        nc = await nats.connect()
+        with self.assertRaises(nats.errors.NoRespondersError):
+            await nc.request("missing", timeout=0.01)
+        await nc.close()
+        await nc.connect()
+        # If connect does not work, a TimeoutError will be thrown instead of a NoRespondersError
+        with self.assertRaises(nats.errors.NoRespondersError):
+            await nc.request("missing", timeout=0.01)
+        await nc.close()
+
+
+    @async_test
     async def test_pending_data_size_flush_on_close(self):
         nc = NATS()
 


### PR DESCRIPTION
This pull request fixes a bug (or at least a non documented behaviour). It brings very little change to the codebase.

## Problem description

- [x] It is not possible to send requests using a client which has been connected twice.

## Reproducible example:

```python
from nats import NATS

nc = NATS()

await nc.connect()
await nc.close()
await nc.connect()
# We expect a NoRespondersError but we get a TimeoutError without this PR
await nc.request("some.unknown.subject", timeout=0.1)
```

## Objectives of the PR

- [x] Let users send requests with clients which were already closed before

## Proposal implementation

- [x] Reset `Client._resp_sub_prefix` at the end of the `Client._close` method.
  
I saw that `Client._client_id` is already resetted at that time, so I though that it was the right place to reset `Client._resp_sub_prefix` too.

## How was this PR tested ?

I added a single test which is very similar to the example above. If we can talk to NATS server, then a request on a subject without subjecription must raise a `NoRespondersError`, if not, a `TimeoutError` is raised and test fails.