### PR TITLE
[Fix #325] Removes the server address from reconnection logs in examples.

### DIFF
--- a/examples/clustered.py
+++ b/examples/clustered.py
@@ -30,8 +30,7 @@ async def run():
         print("Got disconnected!")
 
     async def reconnected_cb():
-        # See who we are connected to on reconnect.
-        print(f"Got reconnected to {nc.connected_url.netloc}")
+        print("Got reconnected to NATS...")
 
     # Setup callbacks to be notified on disconnects and reconnects
     options["disconnected_cb"] = disconnected_cb

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -9,7 +9,7 @@ async def main():
         print('Got disconnected!')
 
     async def reconnected_cb():
-        print(f'Got reconnected to {nc.connected_url.netloc}')
+        print('Got reconnected to NATS...')
 
     async def error_cb(e):
         print(f'There was an error: {e}')

--- a/examples/nats-pub/__main__.py
+++ b/examples/nats-pub/__main__.py
@@ -56,7 +56,7 @@ async def run():
         print("Error:", e)
 
     async def reconnected_cb():
-        print(f"Connected to NATS at {nc.connected_url.netloc}...")
+        print("Got reconnected to NATS...")
 
     options = {
         "error_cb": error_cb,

--- a/examples/nats-req/__main__.py
+++ b/examples/nats-req/__main__.py
@@ -55,7 +55,7 @@ async def run():
         print("Error:", e)
 
     async def reconnected_cb():
-        print(f"Connected to NATS at {nc.connected_url.netloc}...")
+        print("Got reconnected to NATS...")
 
     options = {"error_cb": error_cb, "reconnected_cb": reconnected_cb}
 

--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -56,7 +56,7 @@ async def run():
         loop.stop()
 
     async def reconnected_cb():
-        print(f"Connected to NATS at {nc.connected_url.netloc}...")
+        print("Got reconnected to NATS...")
 
     async def subscribe_handler(msg):
         subject = msg.subject


### PR DESCRIPTION
A couple of examples tries to log the server address during reconnection, through an inner reconnection callback passed as parameter to the client object.

However, this kind of callback need to be defined before we instantiate the client, so the inner callback isn't able to see and  access the client/connection object.

The issue was originaly described into the issue #325, however a couple of other examples also implement the same logic that surely fails in the same way (not tested on my side). I only focused my tests on the example given in the original issue.