### PR TITLE
Updates to KV implementation

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -57,7 +57,7 @@ from .subscription import (
     Subscription,
 )
 
-__version__ = '2.1.7'
+__version__ = '2.2.0'
 __lang__ = 'python3'
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -117,7 +117,9 @@ class Srv:
     tls_name: Optional[str] = None
     server_version: Optional[str] = None
 
+
 class ServerVersion:
+
     def __init__(self, server_version: str):
         self._server_version = server_version
         self._major_version = None
@@ -168,6 +170,7 @@ class ServerVersion:
 
     def __repr__(self) -> str:
         return f"<nats server v{self._server_version}>"
+
 
 async def _default_error_callback(ex: Exception) -> None:
     """
@@ -1161,7 +1164,7 @@ class Client:
         if self._current_server and self._current_server.server_version:
             return ServerVersion(self._current_server.server_version)
         return ServerVersion("0.0.0-unknown")
-            
+
     async def _send_command(self, cmd: bytes, priority: bool = False) -> None:
         if priority:
             self._pending.insert(0, cmd)

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -115,7 +115,59 @@ class Srv:
     did_connect: bool = False
     discovered: bool = False
     tls_name: Optional[str] = None
+    server_version: Optional[str] = None
 
+class ServerVersion:
+    def __init__(self, server_version: str):
+        self._server_version = server_version
+        self._major_version = None
+        self._minor_version = None
+        self._patch_version = None
+        self._dev_version = None
+
+    def parse_version(self):
+        v = (self._server_version).split('-')
+        if len(v) > 1:
+            self._dev_version = v[1]
+        tokens = v[0].split('.')
+        n = len(tokens)
+        if n > 1:
+            self._major_version = int(tokens[0])
+        if n > 2:
+            self._minor_version = int(tokens[1])
+        if n > 3:
+            self._patch_version = int(tokens[2])
+
+    @property
+    def major(self) -> int:
+        version = self._major_version
+        if not version:
+            self.parse_version()
+        return self._major_version
+
+    @property
+    def minor(self) -> int:
+        version = self._minor_version
+        if not version:
+            self.parse_version()
+        return self._minor_version
+
+    @property
+    def patch(self) -> int:
+        version = self._patch_version
+        if not version:
+            self.parse_version()
+        return self._patch_version
+
+    @property
+    def dev(self) -> int:
+        version = self._dev_version
+        if not version:
+            self.parse_version()
+        return self._dev_version
+
+    def __repr__(self) -> str:
+        return f"<nats server v{self._server_version}>"
 
 async def _default_error_callback(ex: Exception) -> None:
     """
@@ -1100,6 +1152,16 @@ class Client:
     def is_draining_pubs(self) -> bool:
         return self._status == Client.DRAINING_PUBS
 
+    @property
+    def connected_server_version(self) -> ServerVersion:
+        """
+        Returns the ServerVersion of the server to which the client
+        is currently connected.
+        """
+        if self._current_server and self._current_server.server_version:
+            return ServerVersion(self._current_server.server_version)
+        return ServerVersion("0.0.0-unknown")
+            
     async def _send_command(self, cmd: bytes, priority: bool = False) -> None:
         if priority:
             self._pending.insert(0, cmd)
@@ -1776,6 +1838,9 @@ class Client:
 
         self._server_info = srv_info
         self._process_info(srv_info, initial_connection=True)
+
+        if 'version' in self._server_info:
+            self._current_server.server_version = self._server_info['version']
 
         if 'max_payload' in self._server_info:
             self._max_payload = self._server_info["max_payload"]

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -80,7 +80,8 @@ class Base:
         """Convert the value from seconds to nanoseconds.
         """
         if val is None:
-            return None
+            # We use 0 to avoid sending null to Go servers.
+            return 0
         return int(val * _NANOSECOND)
 
     @classmethod
@@ -235,6 +236,7 @@ class StreamConfig(Base):
     deny_delete: bool = False
     deny_purge: bool = False
     allow_rollup_hdrs: bool = False
+    allow_direct: Optional[bool] = None
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):
@@ -495,6 +497,8 @@ class KeyValueConfig(Base):
     max_bytes: Optional[int] = None
     storage: Optional[StorageType] = None
     replicas: int = 1
+    placement: Optional[Placement] = None
+    republish: Optional[bool] = None
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -504,6 +504,7 @@ class KeyValueConfig(Base):
     replicas: int = 1
     placement: Optional[Placement] = None
     republish: Optional[bool] = None
+    direct: Optional[bool] = None
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -249,7 +249,9 @@ class StreamConfig(Base):
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()
-        result['duplicate_window'] = self._to_nanoseconds(self.duplicate_window)
+        result['duplicate_window'] = self._to_nanoseconds(
+            self.duplicate_window
+        )
         result['max_age'] = self._to_nanoseconds(self.max_age)
         return result
 
@@ -472,6 +474,7 @@ class RawStreamMsg(Base):
     data: Optional[bytes] = None
     hdrs: Optional[bytes] = None
     headers: Optional[dict] = None
+    stream: Optional[str] = None
     # TODO: Add 'time'
 
     @property

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -241,6 +241,7 @@ class StreamConfig(Base):
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):
         cls._convert_nanoseconds(resp, 'max_age')
+        cls._convert_nanoseconds(resp, 'duplicate_window')
         cls._convert(resp, 'placement', Placement)
         cls._convert(resp, 'mirror', StreamSource)
         cls._convert(resp, 'sources', StreamSource)
@@ -248,6 +249,7 @@ class StreamConfig(Base):
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()
+        result['duplicate_window'] = self._to_nanoseconds(self.duplicate_window)
         result['max_age'] = self._to_nanoseconds(self.max_age)
         return result
 

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -988,6 +988,10 @@ class JetStreamContext(JetStreamManager):
             config = api.KeyValueConfig(bucket=params["bucket"])
         config = config.evolve(**params)
 
+        duplicate_window = 2 * 60 # 2 minutes
+        if config.ttl and config.ttl < duplicate_window:
+            duplicate_window = config.ttl
+
         stream = api.StreamConfig(
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),
             description=config.description,
@@ -996,6 +1000,7 @@ class JetStreamContext(JetStreamManager):
             allow_rollup_hdrs=True,
             deny_delete=True,
             discard=api.DiscardPolicy.NEW,
+            duplicate_window=duplicate_window,
             max_age=config.ttl,
             max_bytes=config.max_bytes,
             max_consumers=-1,

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -954,40 +954,6 @@ class JetStreamContext(JetStreamManager):
 
             return msgs
 
-    #############################
-    #                           #
-    # JetStream Manager Context #
-    #                           #
-    #############################
-
-    async def get_last_msg(
-        self,
-        stream_name: str,
-        subject: str,
-    ) -> api.RawStreamMsg:
-        """
-        get_last_msg retrieves a message from a stream.
-        """
-        req_subject = f"{self._prefix}.STREAM.MSG.GET.{stream_name}"
-        req = {'last_by_subj': subject}
-        data = json.dumps(req)
-        resp = await self._api_request(
-            req_subject, data.encode(), timeout=self._timeout
-        )
-        raw_msg = api.RawStreamMsg.from_response(resp['message'])
-        if raw_msg.hdrs:
-            hdrs = base64.b64decode(raw_msg.hdrs)
-            raw_headers = hdrs[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
-            parsed_headers = self._jsm._hdr_parser.parsebytes(raw_headers)
-            headers = None
-            if len(parsed_headers.items()) > 0:
-                headers = {}
-                for k, v in parsed_headers.items():
-                    headers[k] = v
-            raw_msg.headers = headers
-
-        return raw_msg
-
     ######################
     #                    #
     # KeyValue Context   #

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -996,7 +996,7 @@ class JetStreamContext(JetStreamManager):
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),
             description=config.description,
             subjects=[f"$KV.{config.bucket}.>"],
-            allow_direct=True,
+            allow_direct=config.direct,
             allow_rollup_hdrs=True,
             deny_delete=True,
             discard=api.DiscardPolicy.NEW,

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The NATS Authors
+# Copyright 2021-2022 The NATS Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -974,6 +974,7 @@ class JetStreamContext(JetStreamManager):
             stream=stream,
             pre=KV_PRE_TEMPLATE.format(bucket=bucket),
             js=self,
+            direct=si.config.allow_direct
         )
 
     async def create_key_value(
@@ -988,7 +989,7 @@ class JetStreamContext(JetStreamManager):
             config = api.KeyValueConfig(bucket=params["bucket"])
         config = config.evolve(**params)
 
-        duplicate_window = 2 * 60 # 2 minutes
+        duplicate_window = 2 * 60  # 2 minutes
         if config.ttl and config.ttl < duplicate_window:
             duplicate_window = config.ttl
 
@@ -1010,14 +1011,15 @@ class JetStreamContext(JetStreamManager):
             num_replicas=config.replicas,
             storage=config.storage,
         )
-        await self.add_stream(stream)
-
+        si = await self.add_stream(stream)
         assert stream.name is not None
+
         return KeyValue(
             name=config.bucket,
             stream=stream.name,
             pre=KV_PRE_TEMPLATE.format(bucket=config.bucket),
             js=self,
+            direct=si.config.allow_direct
         )
 
     async def delete_key_value(self, bucket: str) -> bool:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -1024,16 +1024,20 @@ class JetStreamContext(JetStreamManager):
 
         stream = api.StreamConfig(
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),
-            description=None,
+            description=config.description,
             subjects=[f"$KV.{config.bucket}.>"],
-            max_msgs_per_subject=config.history,
-            max_bytes=config.max_bytes,
-            max_age=config.ttl,
-            max_msg_size=config.max_value_size,
-            storage=config.storage,
-            num_replicas=config.replicas,
+            allow_direct=True,
             allow_rollup_hdrs=True,
             deny_delete=True,
+            discard=api.DiscardPolicy.NEW,
+            max_age=config.ttl,
+            max_bytes=config.max_bytes,
+            max_consumers=-1,
+            max_msg_size=config.max_value_size,
+            max_msgs=-1,
+            max_msgs_per_subject=config.history,
+            num_replicas=config.replicas,
+            storage=config.storage,
         )
         await self.add_stream(stream)
 

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -13,7 +13,6 @@
 #
 
 import asyncio
-import base64
 import json
 import time
 from typing import TYPE_CHECKING, Awaitable, Callable, List, Optional

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -201,3 +201,15 @@ class KeyNotFoundError(KeyValueError, NotFoundError):
         if self.message:
             s += f": {self.message}"
         return s
+
+
+class KeyWrongLastSequenceError(KeyValueError, BadRequestError):
+    """
+    Raised when trying to update a key with the wrong last sequence.
+    """
+
+    def __init__(self, description=None) -> None:
+        self.description = description
+
+    def __str__(self) -> str:
+        return f"nats: {self.description}"

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The NATS Authors
+# Copyright 2016-2022 The NATS Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -37,7 +37,7 @@ class Error(nats.errors.Error):
         return f"nats: JetStream.{self.__class__.__name__} {desc}"
 
 
-@dataclass
+@dataclass(repr=False,init=False)
 class APIError(Error):
     """
     An Error that is the result of interacting with NATS JetStream.
@@ -117,7 +117,7 @@ class NotFoundError(APIError):
 
 class BadRequestError(APIError):
     """
-    A 400 error
+    A 400 error.
     """
     pass
 
@@ -162,11 +162,17 @@ class BucketNotFoundError(NotFoundError):
     pass
 
 
-class BadBucketError(Error):
+class BadBucketError(APIError):
     pass
 
 
-class KeyDeletedError(Error):
+class KeyValueError(APIError):
+    """
+    Raised when there is an issue interacting with the KeyValue store.
+    """
+    pass
+
+class KeyDeletedError(KeyValueError, NotFoundError):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
     """
@@ -177,3 +183,17 @@ class KeyDeletedError(Error):
 
     def __str__(self) -> str:
         return "nats: key was deleted"
+
+
+class KeyNotFoundError(KeyValueError, NotFoundError):
+    """
+    Raised when trying to get a key that does not exists from a JetStream KeyValue store.
+    """
+
+    def __init__(self, entry=None, op=None) -> None:
+        self.entry = entry
+        self.op = op
+
+    def __str__(self) -> str:
+        return "nats: key not found"
+

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -37,7 +37,7 @@ class Error(nats.errors.Error):
         return f"nats: JetStream.{self.__class__.__name__} {desc}"
 
 
-@dataclass(repr=False,init=False)
+@dataclass(repr=False, init=False)
 class APIError(Error):
     """
     An Error that is the result of interacting with NATS JetStream.
@@ -172,6 +172,7 @@ class KeyValueError(APIError):
     """
     pass
 
+
 class KeyDeletedError(KeyValueError, NotFoundError):
     """
     Raised when trying to get a key that was deleted from a JetStream KeyValue store.
@@ -190,10 +191,13 @@ class KeyNotFoundError(KeyValueError, NotFoundError):
     Raised when trying to get a key that does not exists from a JetStream KeyValue store.
     """
 
-    def __init__(self, entry=None, op=None) -> None:
+    def __init__(self, entry=None, op=None, message=None) -> None:
         self.entry = entry
         self.op = op
+        self.message = message
 
     def __str__(self) -> str:
-        return "nats: key not found"
-
+        s = "nats: key not found"
+        if self.message:
+            s += f": {self.message}"
+        return s

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 #
 
-import base64
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -118,7 +117,6 @@ class KeyValue:
     async def get(self, key: str, revision: Optional[int] = None) -> Entry:
         """
         get returns the latest value for the key.
-        
         """
         entry = None
         try:
@@ -129,7 +127,6 @@ class KeyValue:
 
     async def _get(self, key: str, revision: Optional[int] = None) -> Entry:
         msg = None
-        data = None
         subject = f"{self._pre}{key}"
         try:
             if revision:
@@ -145,7 +142,7 @@ class KeyValue:
                     seq=revision,
                     direct=self._direct,
                 )
-        except nats.js.errors.NotFoundError as err:
+        except nats.js.errors.NotFoundError:
             raise nats.js.errors.KeyNotFoundError
 
         # Check whether the revision from the stream does not match the key.

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1911,16 +1911,16 @@ class KVTest(SingleJetStreamServerTestCase):
 
         # Check with low level msg APIs.
 
-        msg = await js.get_msg("KV_TEST", seq=1)
+        msg = await js.get_msg("KV_TEST", seq=1, direct=True)
         assert msg.data == b'1'
 
         # last by subject
-        msg = await js.get_msg("KV_TEST", subject="$KV.TEST.C")
+        msg = await js.get_msg("KV_TEST", subject="$KV.TEST.C", direct=True)
         assert msg.data == b'333'
 
         # next by subject
         msg = await js.get_msg(
-            "KV_TEST", seq=4, next=True, subject="$KV.TEST.C"
+            "KV_TEST", seq=4, next=True, subject="$KV.TEST.C", direct=True
         )
         assert msg.data == b'33'
 

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1738,7 +1738,11 @@ class KVTest(SingleJetStreamServerTestCase):
 
         bucket = "TEST"
         kv = await js.create_key_value(
-            bucket=bucket, history=5, ttl=3600, description="Basic KV"
+            bucket=bucket,
+            history=5,
+            ttl=3600,
+            description="Basic KV",
+            direct=False
         )
         status = await kv.status()
 
@@ -1749,6 +1753,223 @@ class KVTest(SingleJetStreamServerTestCase):
 
         # Check server version for some of these.
         assert config.allow_rollup_hdrs == True
+        assert config.deny_delete == True
+        assert config.deny_purge == False
+        assert config.discard == 'new'
+        assert config.duplicate_window == 120.0
+        assert config.max_age == 3600.0
+        assert config.max_bytes == -1
+        assert config.max_consumers == -1
+        assert config.max_msg_size == -1
+        assert config.max_msgs == -1
+        assert config.max_msgs_per_subject == 5
+        assert config.mirror == None
+        assert config.no_ack == False
+        assert config.num_replicas == 1
+        assert config.placement == None
+        assert config.retention == 'limits'
+        assert config.sealed == False
+        assert config.sources == None
+        assert config.storage == 'file'
+        assert config.template_owner == None
+
+        version = nc.connected_server_version
+        if version.major == 2 and version.minor < 9:
+            assert config.allow_direct == None
+        else:
+            assert config.allow_direct == False
+
+        # Nothing from start
+        with pytest.raises(KeyNotFoundError):
+            await kv.get(f"name")
+
+        # Simple Put
+        revision = await kv.put(f"name", b'alice')
+        assert revision == 1
+
+        # Simple Get
+        result = await kv.get(f"name")
+        assert result.revision == 1
+        assert result.value == b'alice'
+
+        # Delete
+        ok = await kv.delete(f"name")
+        assert ok
+
+        # Deleting then getting again should be a not found error still,
+        # although internall this is a KeyDeletedError.
+        with pytest.raises(KeyNotFoundError):
+            await kv.get(f"name")
+
+        # Recreate with different name.
+        revision = await kv.create("name", b'bob')
+        assert revision == 3
+
+        # Expect last revision to be 4
+        with pytest.raises(BadRequestError):
+            await kv.delete("name", last=4)
+
+        # Correct revision should work.
+        ok = await kv.delete("name", last=3)
+        assert ok
+
+        # Conditional Updates.
+        revision = await kv.update("name", b"hoge", last=4)
+        assert revision == 5
+
+        # Should fail since revision number not the latest.
+        with pytest.raises(BadRequestError):
+            await kv.update("name", b"hoge", last=3)
+
+        # Update with correct latest.
+        revision = await kv.update("name", b"fuga", last=revision)
+        assert revision == 6
+
+        # Create a different key.
+        revision = await kv.create("age", b'2038')
+        assert revision == 7
+
+        # Get current.
+        entry = await kv.get("age")
+        assert entry.value == b'2038'
+        assert entry.revision == 7
+
+        # Update the new key.
+        revision = await kv.update("age", b'2039', last=revision)
+        assert revision == 8
+
+        # Get latest.
+        entry = await kv.get("age")
+        assert entry.value == b'2039'
+        assert entry.revision == 8
+
+        # Internally uses get msg API instead of get last msg.
+        entry = await kv.get("age", revision=7)
+        assert entry.value == b'2038'
+        assert entry.revision == 7
+
+        # Getting past keys with the wrong expected subject is an error.
+        with pytest.raises(KeyNotFoundError) as err:
+            entry = await kv.get("age", revision=6)
+            assert entry.value == b'fuga'
+            assert entry.revision == 6
+        assert str(
+            err.value
+        ) == "nats: key not found: expected '$KV.TEST.age', but got '$KV.TEST.name'"
+
+        with pytest.raises(KeyNotFoundError) as err:
+            await kv.get("age", revision=5)
+
+        with pytest.raises(KeyNotFoundError) as err:
+            await kv.get("age", revision=4)
+
+        entry = await kv.get("name", revision=3)
+        assert entry.value == b'bob'
+
+        with pytest.raises(KeyWrongLastSequenceError,
+                           match="nats: wrong last sequence: 8"):
+            await kv.create("age", b'1')
+
+        # Now let's delete and recreate.
+        await kv.delete("age", last=8)
+        await kv.create("age", b'final')
+
+        with pytest.raises(KeyWrongLastSequenceError,
+                           match="nats: wrong last sequence: 10"):
+            await kv.create("age", b'1')
+
+        entry = await kv.get("age")
+        assert entry.revision == 10
+
+    @async_test
+    async def test_kv_direct_get_msg(self):
+        errors = []
+
+        async def error_handler(e):
+            print("Error:", e, type(e))
+            errors.append(e)
+
+        nc = await nats.connect(error_cb=error_handler)
+
+        version = nc.connected_server_version
+        if version.major == 2 and version.minor < 9:
+            pytest.skip("KV Direct feature requires nats-server v2.9.0")
+
+        js = nc.jetstream()
+
+        bucket = "TEST"
+        kv = await js.create_key_value(
+            bucket=bucket,
+            history=5,
+            ttl=3600,
+            description="Direct KV",
+            direct=True
+        )
+
+        si = await js.stream_info("KV_TEST")
+        config = si.config
+        assert config.description == "Direct KV"
+        assert config.subjects == ['$KV.TEST.>']
+        await kv.create("A", b'1')
+        await kv.create("B", b'2')
+        await kv.create("C", b'3')
+        await kv.create("D", b'4')
+        await kv.create("E", b'5')
+        await kv.create("F", b'6')
+
+        await kv.put("C", b'33')
+        await kv.put("D", b'44')
+        await kv.put("C", b'333')
+
+        # Check with low level msg APIs.
+
+        msg = await js.get_msg("KV_TEST", seq=1, direct=True)
+        assert msg.data == b'1'
+
+        # last by subject
+        msg = await js.get_msg("KV_TEST", subject="$KV.TEST.C", direct=True)
+        assert msg.data == b'333'
+
+        # next by subject
+        msg = await js.get_msg(
+            "KV_TEST", seq=4, next=True, subject="$KV.TEST.C", direct=True
+        )
+        assert msg.data == b'33'
+
+    @async_test
+    async def test_kv_direct(self):
+        errors = []
+
+        async def error_handler(e):
+            print("Error:", e, type(e))
+            errors.append(e)
+
+        nc = await nats.connect(error_cb=error_handler)
+        js = nc.jetstream()
+
+        version = nc.connected_server_version
+        if version.major == 2 and version.minor < 9:
+            pytest.skip("KV Direct feature requires nats-server v2.9.0")
+
+        bucket = "TEST"
+        await js.create_key_value(
+            bucket=bucket,
+            history=5,
+            ttl=3600,
+            description="Explicit Direct KV",
+            direct=True
+        )
+        kv = await js.key_value(bucket=bucket)
+        status = await kv.status()
+
+        si = await js.stream_info("KV_TEST")
+        config = si.config
+        assert config.description == "Explicit Direct KV"
+        assert config.subjects == ['$KV.TEST.>']
+
+        # Check server version for some of these.
+        assert config.allow_rollup_hdrs == True
+        assert config.allow_direct == True
         assert config.deny_delete == True
         assert config.deny_purge == False
         assert config.discard == 'new'
@@ -1870,59 +2091,6 @@ class KVTest(SingleJetStreamServerTestCase):
 
         entry = await kv.get("age")
         assert entry.revision == 10
-
-    @async_test
-    async def test_kv_direct(self):
-        errors = []
-
-        async def error_handler(e):
-            print("Error:", e, type(e))
-            errors.append(e)
-
-        nc = await nats.connect(error_cb=error_handler)
-
-        version = nc.connected_server_version
-        if version.major == 2 and version.minor < 9:
-            pytest.skip("KV Direct feature requires nats-server v2.9.0")
-
-        js = nc.jetstream()
-
-        bucket = "TEST"
-        kv = await js.create_key_value(
-            bucket=bucket, history=5, ttl=3600, description="Direct KV"
-        )
-
-        si = await js.stream_info("KV_TEST")
-        config = si.config
-        assert config.description == "Direct KV"
-        assert config.subjects == ['$KV.TEST.>']
-        assert config.allow_direct == True
-
-        await kv.create("A", b'1')
-        await kv.create("B", b'2')
-        await kv.create("C", b'3')
-        await kv.create("D", b'4')
-        await kv.create("E", b'5')
-        await kv.create("F", b'6')
-
-        await kv.put("C", b'33')
-        await kv.put("D", b'44')
-        await kv.put("C", b'333')
-
-        # Check with low level msg APIs.
-
-        msg = await js.get_msg("KV_TEST", seq=1, direct=True)
-        assert msg.data == b'1'
-
-        # last by subject
-        msg = await js.get_msg("KV_TEST", subject="$KV.TEST.C", direct=True)
-        assert msg.data == b'333'
-
-        # next by subject
-        msg = await js.get_msg(
-            "KV_TEST", seq=4, next=True, subject="$KV.TEST.C", direct=True
-        )
-        assert msg.data == b'33'
 
 
 class ConsumerReplicasTest(SingleJetStreamServerTestCase):


### PR DESCRIPTION

- Added `connected_server_version` to check server version
- Added `allow_direct`, `placement`, `republish` fields to `StreamConfig`
- Added `get_msg(direct=True)` option for faster lookups without encapsulated data as  JSON
- Changed KV `duplicate_window` to be 2 minutes like Go client.
- Changed KV `discard_policy` to `DiscardPolicy.NEW`
- Added `KeyNotFoundError` and `KeyWrongLastSequenceError` errors for when `kv.get` fails
- Added `kv.get("key", revision=3` option to fetch past history of a key
- Added `js.get_msg("key", seq="3", next=True)` to get the closest next value for a subject from given revision
