### PR TITLE
Feature/implement websockets

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,3 +12,4 @@ yapf = "*"
 
 [packages]
 nkeys = "*"
+aiohttp = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ mypy = "*"
 pytest = "*"
 pytest-cov = "*"
 yapf = "*"
+toml = "*"  # see https://github.com/google/yapf/issues/936
 
 [packages]
 nkeys = "*"

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1206,6 +1206,8 @@ class Client:
                     # Closer to how the Go client handles this.
                     # e.g. nats://localhost:4222
                     uri = urlparse(connect_url)
+                elif "ws://" in connect_url or "wss://" in connect_url:
+                    uri = urlparse(connect_url)
                 elif ":" in connect_url:
                     # Expand the scheme for the user
                     # e.g. localhost:4222
@@ -1263,14 +1265,13 @@ class Client:
             try:
                 s.last_attempt = time.monotonic()
                 if not self._transport:
-                    if s.uri.hostname.startswith("ws"):
+                    if s.uri.scheme == "ws":
                         self._transport = WebsocketTransport()
                     else:
                         # use TcpTransport as a fallback
                         self._transport = TcpTransport()
                 await self._transport.connect(
-                    s.uri.hostname,
-                    s.uri.port,
+                    s.uri,
                     buffer_size=DEFAULT_BUFFER_SIZE,
                     connect_timeout=self.options['connect_timeout']
                 )
@@ -1869,8 +1870,8 @@ class Client:
 
             # connect to transport via tls
             await self._transport.connect_tls(
+                self._current_server.uri,
                 ssl_context,
-                hostname,
                 DEFAULT_BUFFER_SIZE,
                 self.options['connect_timeout']
             )

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1245,6 +1245,14 @@ class Client:
                     self._server_pool.append(Srv(uri))
             except ValueError:
                 raise errors.Error("nats: invalid connect url option")
+            # make sure protocols aren't mixed
+            if not (all(server.uri.scheme in ("nats", "tls")
+                        for server in self._server_pool)
+                    or all(server.uri.scheme in ("ws", "wss")
+                           for server in self._server_pool)):
+                raise errors.Error(
+                    "nats: mixing of websocket and non websocket URLs is not allowed"
+                )
         else:
             raise errors.Error("nats: invalid connect url option")
 

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -56,7 +56,7 @@ from .subscription import (
     DEFAULT_SUB_PENDING_MSGS_LIMIT,
     Subscription,
 )
-from .transport import Transport, TcpTransport, WebsocketTransport
+from .transport import Transport, TcpTransport, WebSocketTransport
 
 __version__ = '2.2.0'
 __lang__ = 'python3'
@@ -1277,7 +1277,7 @@ class Client:
                 s.last_attempt = time.monotonic()
                 if not self._transport:
                     if s.uri.scheme in ("ws", "wss"):
-                        self._transport = WebsocketTransport()
+                        self._transport = WebSocketTransport()
                     else:
                         # use TcpTransport as a fallback
                         self._transport = TcpTransport()
@@ -1882,8 +1882,10 @@ class Client:
 
             # connect to transport via tls
             await self._transport.connect_tls(
-                self._current_server.uri, self.ssl_context,
-                DEFAULT_BUFFER_SIZE, self.options['connect_timeout']
+                hostname,
+                self.ssl_context,
+                DEFAULT_BUFFER_SIZE,
+                self.options['connect_timeout'],
             )
 
         # Refresh state of parser upon reconnect.

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1955,6 +1955,7 @@ class Client:
             future = asyncio.Future()
         self._pongs.append(future)
         self._transport.write(PING_PROTO)
+        self._pending_data_size += len(PING_PROTO)
         await self._flush_pending()
 
     async def _flusher(self) -> None:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1882,10 +1882,8 @@ class Client:
 
             # connect to transport via tls
             await self._transport.connect_tls(
-                self._current_server.uri,
-                self.ssl_context,
-                DEFAULT_BUFFER_SIZE,
-                self.options['connect_timeout']
+                self._current_server.uri, self.ssl_context,
+                DEFAULT_BUFFER_SIZE, self.options['connect_timeout']
             )
 
         # Refresh state of parser upon reconnect.

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -14,12 +14,18 @@ except ImportError:
 class Transport(abc.ABC):
 
     @abc.abstractmethod
-    async def connect(self, uri: ParseResult, buffer_size: int, connect_timeout: int):
+    async def connect(
+        self, uri: ParseResult, buffer_size: int, connect_timeout: int
+    ):
         pass
 
     @abc.abstractmethod
     async def connect_tls(
-        self, uri: ParseResult, ssl_context: ssl.SSLContext, buffer_size: int, connect_timeout: int,
+        self,
+        uri: ParseResult,
+        ssl_context: ssl.SSLContext,
+        buffer_size: int,
+        connect_timeout: int,
     ):
         pass
 
@@ -61,18 +67,23 @@ class Transport(abc.ABC):
 
 
 class TcpTransport(Transport):
+
     def __init__(self):
         self._bare_io_reader: Optional[asyncio.StreamReader] = None
         self._io_reader: Optional[asyncio.StreamReader] = None
         self._bare_io_writer: Optional[asyncio.StreamWriter] = None
         self._io_writer: Optional[asyncio.StreamWriter] = None
 
-    async def connect(self, uri: ParseResult, buffer_size: int, connect_timeout: int):
-        r, w = await asyncio.wait_for(asyncio.open_connection(
-            host=uri.hostname,
-            port=uri.port,
-            limit=buffer_size,
-        ), connect_timeout)
+    async def connect(
+        self, uri: ParseResult, buffer_size: int, connect_timeout: int
+    ):
+        r, w = await asyncio.wait_for(
+            asyncio.open_connection(
+                host=uri.hostname,
+                port=uri.port,
+                limit=buffer_size,
+            ), connect_timeout
+        )
         # We keep a reference to the initial transport we used when
         # establishing the connection in case we later upgrade to TLS
         # after getting the first INFO message. This is in order to
@@ -84,7 +95,11 @@ class TcpTransport(Transport):
         self._bare_io_writer = self._io_writer = w
 
     async def connect_tls(
-        self, uri: ParseResult, ssl_context: ssl.SSLContext, buffer_size: int, connect_timeout: int,
+        self,
+        uri: ParseResult,
+        ssl_context: ssl.SSLContext,
+        buffer_size: int,
+        connect_timeout: int,
     ):
         # loop.start_tls was introduced in python 3.7
         # the previous method is removed in 3.9
@@ -151,6 +166,7 @@ class TcpTransport(Transport):
 
 
 class WebsocketTransport(Transport):
+
     def __init__(self):
         if not aiohttp:
             raise ImportError(
@@ -161,14 +177,24 @@ class WebsocketTransport(Transport):
         self._pending = asyncio.Queue()
         self._close_task = asyncio.Future()
 
-    async def connect(self, uri: ParseResult, buffer_size: int, connect_timeout: int):
+    async def connect(
+        self, uri: ParseResult, buffer_size: int, connect_timeout: int
+    ):
         # for websocket library, the uri must contain the scheme already
-        self._ws = await self._client.ws_connect(uri.geturl(), timeout=connect_timeout)
+        self._ws = await self._client.ws_connect(
+            uri.geturl(), timeout=connect_timeout
+        )
 
     async def connect_tls(
-        self, uri: ParseResult, ssl_context: ssl.SSLContext, buffer_size: int, connect_timeout: int,
+        self,
+        uri: ParseResult,
+        ssl_context: ssl.SSLContext,
+        buffer_size: int,
+        connect_timeout: int,
     ):
-        self._ws = await self._client.ws_connect(uri.geturl(), ssl_context=ssl_context, timeout=connect_timeout)
+        self._ws = await self._client.ws_connect(
+            uri.geturl(), ssl_context=ssl_context, timeout=connect_timeout
+        )
 
     def write(self, payload):
         self._pending.put_nowait(payload)

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -1,0 +1,197 @@
+import abc
+import asyncio
+import sys
+import ssl
+from typing import Optional
+from nats import errors
+try:
+    import websockets
+    import websockets.legacy.client
+except ImportError:
+    websockets = None
+
+
+class Transport(abc.ABC):
+
+    @abc.abstractmethod
+    async def connect(self, hostname: str, port: int, buffer_size: int, connect_timeout: int):
+        pass
+
+    @abc.abstractmethod
+    async def connect_tls(
+        self, ssl_context: ssl.SSLContext, hostname: str, buffer_size: int, connect_timeout: int,
+    ):
+        pass
+
+    @abc.abstractmethod
+    def write(self, payload):
+        pass
+
+    @abc.abstractmethod
+    def writelines(self, payload):
+        pass
+
+    @abc.abstractmethod
+    async def read(self, buffer_size: int):
+        pass
+
+    @abc.abstractmethod
+    async def readline(self):
+        pass
+
+    @abc.abstractmethod
+    async def drain(self):
+        pass
+
+    @abc.abstractmethod
+    async def wait_closed(self):
+        pass
+
+    @abc.abstractmethod
+    def close(self):
+        pass
+
+    @abc.abstractmethod
+    def at_eof(self):
+        pass
+
+    @abc.abstractmethod
+    def __bool__(self):
+        pass
+
+
+class TcpTransport(Transport):
+    def __init__(self):
+        self._bare_io_reader: Optional[asyncio.StreamReader] = None
+        self._io_reader: Optional[asyncio.StreamReader] = None
+        self._bare_io_writer: Optional[asyncio.StreamWriter] = None
+        self._io_writer: Optional[asyncio.StreamWriter] = None
+
+    async def connect(self, hostname: str, port: int, buffer_size: int, connect_timeout: int):
+        r, w = await asyncio.wait_for(asyncio.open_connection(
+            host=hostname,
+            port=port,
+            limit=buffer_size,
+        ), connect_timeout)
+        # We keep a reference to the initial transport we used when
+        # establishing the connection in case we later upgrade to TLS
+        # after getting the first INFO message. This is in order to
+        # prevent the GC closing the socket after we send CONNECT
+        # and replace the transport.
+        #
+        # See https://github.com/nats-io/asyncio-nats/issues/43
+        self._bare_io_reader = self._io_reader = r
+        self._bare_io_writer = self._io_writer = w
+
+    async def connect_tls(
+        self, ssl_context: ssl.SSLContext, hostname: str, buffer_size: int, connect_timeout: int,
+    ):
+        # loop.start_tls was introduced in python 3.7
+        # the previous method is removed in 3.9
+        if sys.version_info.minor >= 7:
+            # manually recreate the stream reader/writer with a tls upgraded transport
+            reader = asyncio.StreamReader()
+            protocol = asyncio.StreamReaderProtocol(reader)
+            transport_future = asyncio.get_running_loop().start_tls(
+                self._io_writer.transport,
+                protocol,
+                ssl_context,
+                server_hostname=hostname
+            )
+            transport = await asyncio.wait_for(
+                transport_future, connect_timeout
+            )
+            writer = asyncio.StreamWriter(
+                transport, protocol, reader, asyncio.get_running_loop()
+            )
+            self._io_reader, self._io_writer = reader, writer
+        else:
+            transport = self._io_writer.transport
+            sock = transport.get_extra_info('socket')
+            if not sock:
+                # This shouldn't happen
+                raise errors.Error('nats: unable to get socket')
+
+            connection_future = asyncio.open_connection(
+                limit=buffer_size,
+                sock=sock,
+                ssl=ssl_context,
+                server_hostname=hostname,
+            )
+            self._io_reader, self._io_writer = await asyncio.wait_for(
+                connection_future, connect_timeout
+            )
+
+    def write(self, payload):
+        return self._io_writer.write(payload)
+
+    def writelines(self, payload):
+        return self._io_writer.writelines(payload)
+
+    async def read(self, buffer_size: int):
+        return await self._io_reader.read(buffer_size)
+
+    async def readline(self):
+        return await self._io_reader.readline()
+
+    async def drain(self):
+        return await self._io_writer.drain()
+
+    async def wait_closed(self):
+        return await self._io_writer.wait_closed()
+
+    def close(self):
+        return self._io_writer.close()
+
+    def at_eof(self):
+        return self._io_reader.at_eof()
+
+    def __bool__(self):
+        return bool(self._io_writer) and bool(self._io_reader)
+
+
+class WebsocketTransport(Transport):
+    def __init__(self):
+        if not websockets:
+            raise ImportError(
+                "Could not import websockets transport, please install it with `pip install websockets===10.3`"
+            )
+        self._ws: Optional[websockets.legacy.client.WebSocketClientProtocol] = None
+
+    async def connect(self, hostname: str, port: int, buffer_size: int, connect_timeout: int):
+        self._ws = await websockets.connect(
+            uri=hostname, port=port, max_size=buffer_size, open_timeout=connect_timeout
+        )
+
+    async def connect_tls(
+        self, ssl_context: ssl.SSLContext, hostname: str, buffer_size: int, connect_timeout: int,
+    ):
+        raise NotImplementedError("TLS was not implemented for websocket transport")
+
+    def write(self, payload):
+        return self._ws.send(payload)
+
+    def writelines(self, payload):
+        for message in payload:
+            self._ws.send(message)
+
+    async def read(self, buffer_size: int):
+        return await self._ws.read_frame(buffer_size)
+
+    async def readline(self):
+        return await self._ws.read_message()
+
+    async def drain(self):
+        return await self._ws.drain()
+
+    async def wait_closed(self):
+        return await self._ws.wait_closed()
+
+    def close(self):
+        return self._ws.close()
+
+    def at_eof(self):
+        return self._ws.eof_received()
+
+    def __bool__(self):
+        return bool(self._ws)

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -175,7 +175,7 @@ class WebsocketTransport(Transport):
 
     def writelines(self, payload):
         for message in payload:
-            self._pending.put_nowait(message)
+            self.write(message)
 
     async def read(self, buffer_size: int):
         return await self.readline()

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -168,7 +168,7 @@ class WebsocketTransport(Transport):
     async def connect_tls(
         self, uri: ParseResult, ssl_context: ssl.SSLContext, buffer_size: int, connect_timeout: int,
     ):
-        self._ws = self._client.ws_connect(uri.geturl(), ssl_context=ssl_context, timeout=connect_timeout)
+        self._ws = await self._client.ws_connect(uri.geturl(), ssl_context=ssl_context, timeout=connect_timeout)
 
     def write(self, payload):
         self._pending.put_nowait(payload)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2620,7 +2620,6 @@ class ClientDrainTest(SingleServerTestCase):
                 servers=["tls://127.0.0.1:4222", "wss://127.0.0.1:8080"]
             )
 
-    @async_test
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2604,6 +2604,23 @@ class ClientDrainTest(SingleServerTestCase):
                     **{cb: f}
                 )
 
+    @async_test
+    async def test_protocol_mixing(self):
+        nc = NATS()
+        with self.assertRaises(nats.errors.Error):
+            await nc.connect(
+                servers=["nats://127.0.0.1:4222", "ws://127.0.0.1:8080"]
+            )
+        with self.assertRaises(nats.errors.Error):
+            await nc.connect(
+                servers=["nats://127.0.0.1:4222", "wss://127.0.0.1:8080"]
+            )
+        with self.assertRaises(nats.errors.Error):
+            await nc.connect(
+                servers=["tls://127.0.0.1:4222", "wss://127.0.0.1:8080"]
+            )
+
+    @async_test
 
 if __name__ == '__main__':
     import sys

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -1,0 +1,108 @@
+import asyncio
+import http.client
+import json
+import shutil
+import ssl
+import tempfile
+import time
+import unittest
+from unittest import mock
+
+import nats
+from nats.aio.client import Client as NATS, __version__
+from nats.aio.errors import *
+from tests.utils import *
+
+
+class HeadersTest(SingleWebsocketServerTestCase):
+
+    @async_test
+    async def test_simple_headers(self):
+        nc = await nats.connect("ws://localhost:8080")
+
+        sub = await nc.subscribe("foo")
+        await nc.flush()
+        await nc.publish(
+            "foo", b'hello world', headers={
+                'foo': 'bar',
+                'hello': 'world-1'
+            }
+        )
+
+        msg = await sub.next_msg()
+        self.assertTrue(msg.headers != None)
+        self.assertEqual(len(msg.headers), 2)
+
+        self.assertEqual(msg.headers['foo'], 'bar')
+        self.assertEqual(msg.headers['hello'], 'world-1')
+
+        await nc.close()
+
+    @async_test
+    async def test_request_with_headers(self):
+        nc = await nats.connect("ws://localhost:8080")
+
+        async def service(msg):
+            # Add another header
+            msg.headers['quux'] = 'quuz'
+            await msg.respond(b'OK!')
+
+        await nc.subscribe("foo", cb=service)
+        await nc.flush()
+        msg = await nc.request(
+            "foo", b'hello world', headers={
+                'foo': 'bar',
+                'hello': 'world'
+            }
+        )
+
+        self.assertTrue(msg.headers != None)
+        self.assertEqual(len(msg.headers), 3)
+        self.assertEqual(msg.headers['foo'], 'bar')
+        self.assertEqual(msg.headers['hello'], 'world')
+        self.assertEqual(msg.headers['quux'], 'quuz')
+        self.assertEqual(msg.data, b'OK!')
+
+        await nc.close()
+
+    @async_test
+    async def test_empty_headers(self):
+        nc = await nats.connect("ws://localhost:8080")
+
+        sub = await nc.subscribe("foo")
+        await nc.flush()
+        await nc.publish("foo", b'hello world', headers={'': ''})
+
+        msg = await sub.next_msg()
+        self.assertTrue(msg.headers == None)
+
+        # Empty long key
+        await nc.publish("foo", b'hello world', headers={'      ': ''})
+        msg = await sub.next_msg()
+        self.assertTrue(msg.headers == None)
+
+        # Empty long key
+        await nc.publish(
+            "foo", b'hello world', headers={'': '                  '}
+        )
+        msg = await sub.next_msg()
+        self.assertTrue(msg.headers == None)
+
+        hdrs = {
+            'timestamp': '2022-06-15T19:08:14.639020',
+            'type': 'rpc',
+            'command': 'publish_state',
+            'trace_id': '',
+            'span_id': ''
+        }
+        await nc.publish("foo", b'Hello from Python!', headers=hdrs)
+        msg = await sub.next_msg()
+        self.assertEqual(msg.headers, hdrs)
+
+        await nc.close()
+
+
+if __name__ == '__main__':
+    import sys
+    runner = unittest.TextTestRunner(stream=sys.stdout)
+    unittest.main(verbosity=2, exit=False, testRunner=runner)

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -14,7 +14,7 @@ from nats.aio.errors import *
 from tests.utils import *
 
 
-class HeadersTest(SingleWebsocketServerTestCase):
+class HeadersTest(SingleWebSocketServerTestCase):
 
     @async_test
     async def test_simple_headers(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -444,6 +444,24 @@ class SingleJetStreamServerTestCase(unittest.TestCase):
         self.loop.close()
 
 
+class SingleWebsocketServerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.server_pool = []
+        self.loop = asyncio.new_event_loop()
+
+        server = NATSD(port=4222, config_file=get_config_file("websocket/ws.conf"))
+        self.server_pool.append(server)
+        for natsd in self.server_pool:
+            start_natsd(natsd)
+
+    def tearDown(self):
+        for natsd in self.server_pool:
+            natsd.stop()
+            shutil.rmtree(natsd.store_dir)
+        self.loop.close()
+
+
 def start_natsd(natsd: NATSD):
     natsd.start()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -444,7 +444,7 @@ class SingleJetStreamServerTestCase(unittest.TestCase):
         self.loop.close()
 
 
-class SingleWebsocketServerTestCase(unittest.TestCase):
+class SingleWebSocketServerTestCase(unittest.TestCase):
 
     def setUp(self):
         self.server_pool = []

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -450,7 +450,9 @@ class SingleWebsocketServerTestCase(unittest.TestCase):
         self.server_pool = []
         self.loop = asyncio.new_event_loop()
 
-        server = NATSD(port=4222, config_file=get_config_file("websocket/ws.conf"))
+        server = NATSD(
+            port=4222, config_file=get_config_file("websocket/ws.conf")
+        )
         self.server_pool.append(server)
         for natsd in self.server_pool:
             start_natsd(natsd)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -460,7 +460,6 @@ class SingleWebsocketServerTestCase(unittest.TestCase):
     def tearDown(self):
         for natsd in self.server_pool:
             natsd.stop()
-            shutil.rmtree(natsd.store_dir)
         self.loop.close()
 
 

--- a/tests/websocket/ws.conf
+++ b/tests/websocket/ws.conf
@@ -1,0 +1,5 @@
+websocket
+{
+    port: 8080
+    no_tls: true
+}


### PR DESCRIPTION
Open points:

- [x] Implement and test websockets transport for nats.
   - [x] Test old behaviour
   - [x] Test ws
   - [x] Test wss
- [x] Need to review the changes made to the core of nats
   - [x] Created a ssl_context implementation as property of client https://github.com/nats-io/nats.py/blob/c72de758b7c053292b8cd005ba3fd5a5fb5f8e7c/nats/aio/client.py#L1169
   - [x] Added an increase in _pending_data_size. To me this seems like a bug, where the flush would be skipped if the transport used previously (stream) didn't write bytes immediately https://github.com/nats-io/nats.py/blob/c72de758b7c053292b8cd005ba3fd5a5fb5f8e7c/nats/aio/client.py#L1958
   - [x] Added transport instance inside client. https://github.com/nats-io/nats.py/blob/c72de758b7c053292b8cd005ba3fd5a5fb5f8e7c/nats/aio/client.py#L1278

- [x] Need to figure out what to do when transport needs replacement (i.e. when mixing both ws and nats connections on the server list)
- [x] Make tests run
- [x] Optional: include aiohttp as a optional dependency, similar to nkeys
- [ ] Optional: write more tests to test the transport

Here is the test client to test this functionality:

```python
import asyncio
import nats


async def main():
    nc = await nats.connect("wss://demo.nats.io:8443")

    async def message_handler(msg):
        subject = msg.subject
        reply = msg.reply
        data = msg.data.decode()
        print("Received a message on '{subject} {reply}': {data}".format(
            subject=subject, reply=reply, data=data))

    # Simple publisher and async subscriber via coroutine.
    sub = await nc.subscribe("foo", cb=message_handler)

    await nc.publish("foo", b'Hello')
    await nc.publish("foo", b'World')
    await nc.publish("foo", b'!!!!!')

    await asyncio.sleep(5)  # wait for messages to arrive

    await sub.unsubscribe()

    # Terminate connection to NATS.
    await nc.drain()
    await nc.close()


if __name__ == '__main__':
    asyncio.run(main())

```

Closes #353
Closes #270