### PR TITLE
Updated signatures for 'servers' and 'discovered_servers' properties

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1089,18 +1089,18 @@ class Client:
         return None
 
     @property
-    def servers(self) -> List[str]:
+    def servers(self) -> List[ParseResult]:
         servers = []
         for srv in self._server_pool:
-            servers.append(str(srv.uri))
+            servers.append(srv.uri)
         return servers
 
     @property
-    def discovered_servers(self) -> List[str]:
+    def discovered_servers(self) -> List[ParseResult]:
         servers = []
         for srv in self._server_pool:
             if srv.discovered:
-                servers.append(str(srv.uri))
+                servers.append(srv.uri)
         return servers
 
     @property


### PR DESCRIPTION
This PR updates the `servers` and `discovered_servers` properties in `nats.aio.Client` to return `ParseResult` objects rather than simple strings, matching the existing pattern established by the `connected_url` property. 

**Motivation:**
The existing codebase returns 'stringified' ParseResults, like these:
```
"ParseResult(scheme='nats', netloc='localhost:4222', path='', params='', query='', fragment='')"
```
This can make usage a bit difficult for end users, since they'd be expected to either transform the string back into a ParseResult to use it or parse the string to pull out the information they need.
