### PR TITLE
Untreated error callbacks when using websockets

### DIFF
--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -250,6 +250,9 @@ class WebSocketTransport(Transport):
 
     async def readline(self):
         data = await self._ws.receive()
+        if data.type == aiohttp.WSMsgType.CLOSE:
+            # if the connection terminated abruptly, return empty binary data to raise unexpected EOF
+            return b''
         return data.data
 
     async def drain(self):
@@ -267,7 +270,7 @@ class WebSocketTransport(Transport):
         self._close_task = asyncio.create_task(self._ws.close())
 
     def at_eof(self):
-        return self._ws._reader.at_eof()
+        return self._ws.closed
 
     def __bool__(self):
-        return bool(self._ws)
+        return bool(self._client)


### PR DESCRIPTION
There are two things:

- The parsing issue was caused by readline returning the actual error code (in this case 1001). I made it return `b''` instead and EOF will be triggered in the next call
- `__bool__` was returning false every time it was disconnected. I'm returning now if `self._client` exists instead.

If you want to test, simply use the script

```python
import asyncio
import nats


async def main():
    async def cb(msg):
        print(msg)
    ws = await nats.connect("ws://localhost", error_cb=cb)
    await ws.subscribe("hello", cb=cb)
    for i in range(100):
        await ws.publish("hello", f"hello world {i}".encode())
        await asyncio.sleep(5)


if __name__ == '__main__':
    asyncio.run(main())
```

And turn off the connection to NATS. This will cause now EOF in both implementations.

Closes https://github.com/nats-io/nats.py/issues/361