### PR TITLE
Raise asyncio.CancelledError back

### DIFF
--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -229,11 +229,8 @@ class Subscription:
             # Subscription is done and won't be receiving further
             # messages so can throw it away now.
             self._conn._remove_sub(self._id)
-        # QUESTION: Can this except block swallow external cancellations ?
         except asyncio.CancelledError:
-            # In case draining of a connection times out then
-            # the sub per task will be canceled as well.
-            pass
+            raise
         finally:
             self._closed = True
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2628,6 +2628,26 @@ class ClientDrainTest(SingleServerTestCase):
                 servers=["tls://127.0.0.1:4222", "wss://127.0.0.1:8080"]
             )
 
+    @async_test
+    async def test_drain_cancelled_errors_raised(self):
+        nc = NATS()
+        await nc.connect()
+
+        async def cb(msg):
+            await asyncio.sleep(20)
+
+        sub = await nc.subscribe(f"test.sub", cb=cb)
+        await nc.publish("test.sub")
+        await nc.publish("test.sub")
+        await asyncio.sleep(0.1)
+        with self.assertRaises(asyncio.CancelledError):
+            # with self.assertRaises(asyncio.CancelledError):
+            with unittest.mock.patch(
+                    "asyncio.wait_for",
+                    unittest.mock.AsyncMock(side_effect=asyncio.CancelledError
+                                            )):
+                await sub.drain()
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
## Motivation

> This PR addresses the issue #373

When a SIGINT is received by an python application running a pull subscribe consumer, `next_msg()` coroutine may suppress the exception.

This PR raises back the exception once it's catched.

## State of the PR

- [x] This PR fixes the issue mentionned by #373 

- [ ] This PR includes comments which should not be kept. I did a little `Ctrl+F` with `except asyncio.CancelledError` and saw several except blocks. I wonder if they could also cause suppression of the exception.

- [ ] The message commit of this PR should be modified (current message is "wip: add comments regarding cancel exceptions")

I hope it can be useful to discuss what changes are needed to avoid suppressions exceptions :)


