### PR TITLE
Change default log to warn and add async reference

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -178,7 +178,7 @@ async def _default_error_callback(ex: Exception) -> None:
     Provides a default way to handle async errors if the user
     does not provide one.
     """
-    _logger.error('nats: encountered error', exc_info=ex)
+    _logger.warn('nats: encountered async error', exc_info=ex)
 
 
 class Client:


### PR DESCRIPTION
# Motivation

When trying to connect to the nats-server, there is a loop to select the servers to connect to from a pool. For example: If there is an asyncio timeout, it will throw an Exception and be handled by increasing the number of reconnects. The loop will continue and try to connect to a new server in the pool, if possible.

However, the `error_cb` will be called, and it will print as error on the default logger. As it is an "expected error", I don't think it warrants an error log by default, as it may raise some eyebrows when, in fact, the only action point that a library user may have is to provide an `error_cb` that does not print an error.

```
while True:
   try:
      ...
    except Exception as e:
                    s.last_attempt = time.monotonic()
                    s.reconnects += 1
    
                    self._err = e
                    await self._error_cb(e)
                    continue
```

# Suggestion

My proposed change is to use the warn level instead of error