### PR TITLE
Make all type annotations lazy

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
+
 from typing import List, Union
 
 from .aio.client import Client as NATS

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import ipaddress

--- a/nats/aio/errors.py
+++ b/nats/aio/errors.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import nats.errors
 
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
+
 import datetime
 import json
 from dataclasses import dataclass

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import asyncio
 from typing import (
     TYPE_CHECKING,

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import asyncio
 import ssl

--- a/nats/js/__init__.py
+++ b/nats/js/__init__.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from . import api
 from .client import JetStreamContext
 from .manager import JetStreamManager

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from dataclasses import dataclass, fields, replace
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypeVar

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import asyncio
 import json
 import time

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional
 

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import asyncio
 import datetime
 from dataclasses import dataclass

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 import base64
 import json
 from email.parser import BytesParser

--- a/nats/nuid.py
+++ b/nats/nuid.py
@@ -12,6 +12,8 @@
 # limitations under the License.
 #
 
+from __future__ import annotations
+
 from random import Random
 from secrets import randbelow, token_bytes
 from sys import maxsize as MaxInt

--- a/nats/protocol/command.py
+++ b/nats/protocol/command.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Callable
 
 PUB_OP = 'PUB'

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -15,6 +15,8 @@
 NATS network protocol parser.
 """
 
+from __future__ import annotations
+
 import json
 import re
 from typing import Any, Dict


### PR DESCRIPTION
[PEP 563](https://peps.python.org/pep-0563/) introduced postponed evaluation of type annotations. It makes importing modules faster and allows to use the latest Python features in older Python releases and to use forward references and type-checking-only objects without quoting annotations. In other words, a lot of cool stuff. The feature can be activated since Python 3.7 by adding in the file `from __future__ import annotations`. The feature was supposed to be the default behavior since Python 3.10 or so, but was postponed indefinitely because of some corner cases when it doesn't work well (runtime type annotation evaluation for closures).