### PR TITLE
Use the new type annotations syntax

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -13,14 +13,11 @@
 #
 from __future__ import annotations
 
-from typing import List, Union
-
 from .aio.client import Client as NATS
 
 
 async def connect(
-    servers: Union[str, List[str]] = ["nats://localhost:4222"],
-    **options
+    servers: str | list[str] = ["nats://localhost:4222"], **options
 ) -> NATS:
     """
     :param servers: List of servers to connect.

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import datetime
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING
 
 from nats.errors import Error, MsgAlreadyAckdError, NotJSMessageError
 
@@ -29,13 +29,13 @@ class Msg:
     """
     Msg represents a message delivered by NATS.
     """
-    _client: "NATS"
+    _client: NATS
     subject: str = ''
     reply: str = ''
     data: bytes = b''
-    headers: Optional[Dict[str, str]] = None
+    headers: dict[str, str] | None = None
 
-    _metadata: Optional["Metadata"] = None
+    _metadata: Metadata | None = None
     _ackd: bool = False
 
     class Ack:
@@ -69,7 +69,7 @@ class Msg:
         V2TokenCount = 12
 
     @property
-    def header(self) -> Optional[dict]:
+    def header(self) -> dict | None:
         """
         header returns the headers from a message.
         """
@@ -103,7 +103,7 @@ class Msg:
         self._ackd = True
         return resp
 
-    async def nak(self, delay: Optional[Union[int, float]] = None) -> None:
+    async def nak(self, delay: int | float | None = None) -> None:
         """
         nak negatively acknowledges a message delivered by JetStream triggering a redelivery.
         if `delay` is provided, redelivery is delayed for `delay` seconds
@@ -139,7 +139,7 @@ class Msg:
     # TODO(@orsinium): use a cached_property. Available in functools since 3.8,
     # as a package (backports.cached-property), or can be just copy-pasted in the project.
     @property
-    def metadata(self) -> "Metadata":
+    def metadata(self) -> Metadata:
         """
         metadata returns the Metadata of a JetStream message.
         """
@@ -193,7 +193,7 @@ class Msg:
         msg._metadata = metadata
         return metadata
 
-    def _get_metadata_fields(self, reply: Optional[str]) -> List[str]:
+    def _get_metadata_fields(self, reply: str | None) -> list[str]:
         return Msg.Metadata._get_metadata_fields(reply)
 
     def _check_reply(self) -> None:
@@ -216,13 +216,13 @@ class Msg:
         - consumer is the name of the consumer.
 
         """
-        sequence: Optional["SequencePair"] = None
-        num_pending: Optional[int] = None
-        num_delivered: Optional[int] = None
-        timestamp: Optional[datetime.datetime] = None
-        stream: Optional[str] = None
-        consumer: Optional[str] = None
-        domain: Optional[str] = None
+        sequence: SequencePair | None = None
+        num_pending: int | None = None
+        num_delivered: int | None = None
+        timestamp: datetime.datetime | None = None
+        stream: str | None = None
+        consumer: str | None = None
+        domain: str | None = None
 
         @dataclass
         class SequencePair:
@@ -233,7 +233,7 @@ class Msg:
             stream: int
 
         @classmethod
-        def _get_metadata_fields(cls, reply: Optional[str]) -> List[str]:
+        def _get_metadata_fields(cls, reply: str | None) -> list[str]:
             if not reply:
                 raise NotJSMessageError
             tokens = reply.split('.')

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 import abc
 import asyncio
 import ssl
-from typing import Optional, Union, List
 from urllib.parse import ParseResult
-
-from nats import errors
 
 try:
     import aiohttp
@@ -29,7 +26,7 @@ class Transport(abc.ABC):
     @abc.abstractmethod
     async def connect_tls(
         self,
-        uri: Union[str, ParseResult],
+        uri: str | ParseResult,
         ssl_context: ssl.SSLContext,
         buffer_size: int,
         connect_timeout: int,
@@ -49,7 +46,7 @@ class Transport(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def writelines(self, payload: List[bytes]):
+    def writelines(self, payload: list[bytes]):
         """
         Writes a list of bytes, one by one, to the underlying transport. Needs a call to drain() to be successfully
         written.
@@ -110,10 +107,10 @@ class Transport(abc.ABC):
 class TcpTransport(Transport):
 
     def __init__(self):
-        self._bare_io_reader: Optional[asyncio.StreamReader] = None
-        self._io_reader: Optional[asyncio.StreamReader] = None
-        self._bare_io_writer: Optional[asyncio.StreamWriter] = None
-        self._io_writer: Optional[asyncio.StreamWriter] = None
+        self._bare_io_reader: asyncio.StreamReader | None = None
+        self._io_reader: asyncio.StreamReader | None = None
+        self._bare_io_writer: asyncio.StreamWriter | None = None
+        self._io_writer: asyncio.StreamWriter | None = None
 
     async def connect(
         self, uri: ParseResult, buffer_size: int, connect_timeout: int
@@ -137,7 +134,7 @@ class TcpTransport(Transport):
 
     async def connect_tls(
         self,
-        uri: Union[str, ParseResult],
+        uri: str | ParseResult,
         ssl_context: ssl.SSLContext,
         buffer_size: int,
         connect_timeout: int,
@@ -196,7 +193,7 @@ class WebSocketTransport(Transport):
             raise ImportError(
                 "Could not import aiohttp transport, please install it with `pip install aiohttp`"
             )
-        self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
+        self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._client: aiohttp.ClientSession = aiohttp.ClientSession()
         self._pending = asyncio.Queue()
         self._close_task = asyncio.Future()
@@ -211,7 +208,7 @@ class WebSocketTransport(Transport):
 
     async def connect_tls(
         self,
-        uri: Union[str, ParseResult],
+        uri: str | ParseResult,
         ssl_context: ssl.SSLContext,
         buffer_size: int,
         connect_timeout: int,

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields, replace
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, TypeVar
 
 _NANOSECOND = 10**9
 
@@ -57,7 +57,7 @@ class Base:
     """
 
     @staticmethod
-    def _convert(resp: Dict[str, Any], field: str, type: Type["Base"]) -> None:
+    def _convert(resp: dict[str, Any], field: str, type: type[Base]) -> None:
         """Convert the field into the given type in place.
         """
         data = resp.get(field, None)
@@ -69,7 +69,7 @@ class Base:
             resp[field] = type.from_response(data)
 
     @staticmethod
-    def _convert_nanoseconds(resp: Dict[str, Any], field: str) -> None:
+    def _convert_nanoseconds(resp: dict[str, Any], field: str) -> None:
         """Convert the given field from nanoseconds to seconds in place.
         """
         val = resp.get(field, None)
@@ -78,7 +78,7 @@ class Base:
         resp[field] = val
 
     @staticmethod
-    def _to_nanoseconds(val: Optional[float]) -> Optional[int]:
+    def _to_nanoseconds(val: float | None) -> int | None:
         """Convert the value from seconds to nanoseconds.
         """
         if val is None:
@@ -87,7 +87,7 @@ class Base:
         return int(val * _NANOSECOND)
 
     @classmethod
-    def from_response(cls: Type[_B], resp: Dict[str, Any]) -> _B:
+    def from_response(cls: type[_B], resp: dict[str, Any]) -> _B:
         """Read the class instance from a server response.
 
         Unknown fields are ignored ("open-world assumption").
@@ -103,7 +103,7 @@ class Base:
         """
         return replace(self, **params)
 
-    def as_dict(self) -> Dict[str, object]:
+    def as_dict(self) -> dict[str, object]:
         """Return the object converted into an API-friendly dict.
         """
         result = {}
@@ -124,35 +124,35 @@ class PubAck(Base):
     """
     stream: str
     seq: int
-    domain: Optional[str] = None
-    duplicate: Optional[bool] = None
+    domain: str | None = None
+    duplicate: bool | None = None
 
 
 @dataclass
 class Placement(Base):
     """Placement directives to consider when placing replicas of this stream"""
 
-    cluster: Optional[str] = None
-    tags: Optional[List[str]] = None
+    cluster: str | None = None
+    tags: list[str] | None = None
 
 
 @dataclass
 class ExternalStream(Base):
     api: str
-    deliver: Optional[str] = None
+    deliver: str | None = None
 
 
 @dataclass
 class StreamSource(Base):
     name: str
-    opt_start_seq: Optional[int] = None
+    opt_start_seq: int | None = None
     # FIXME: Handle time type, omit for now.
     # opt_start_time: Optional[str] = None
-    filter_subject: Optional[str] = None
-    external: Optional[ExternalStream] = None
+    filter_subject: str | None = None
+    external: ExternalStream | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'external', ExternalStream)
         return super().from_response(resp)
 
@@ -160,15 +160,15 @@ class StreamSource(Base):
 @dataclass
 class StreamSourceInfo(Base):
     name: str
-    lag: Optional[int] = None
-    active: Optional[int] = None
-    error: Optional[Dict[str, Any]] = None
+    lag: int | None = None
+    active: int | None = None
+    error: dict[str, Any] | None = None
 
 
 @dataclass
 class LostStreamData(Base):
-    msgs: Optional[List[int]] = None
-    bytes: Optional[int] = None
+    msgs: list[int] | None = None
+    bytes: int | None = None
 
 
 @dataclass
@@ -178,12 +178,12 @@ class StreamState(Base):
     first_seq: int
     last_seq: int
     consumer_count: int
-    deleted: Optional[List[int]] = None
-    num_deleted: Optional[int] = None
-    lost: Optional[LostStreamData] = None
+    deleted: list[int] | None = None
+    num_deleted: int | None = None
+    lost: LostStreamData | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'lost', LostStreamData)
         return super().from_response(resp)
 
@@ -216,9 +216,9 @@ class RePublish(Base):
     RePublish is for republishing messages once committed to a stream. The original
     subject cis remapped from the subject pattern to the destination pattern.
     """
-    src: Optional[str] = None
-    dest: Optional[str] = None
-    headers_only: Optional[bool] = None
+    src: str | None = None
+    dest: str | None = None
+    headers_only: bool | None = None
 
 
 @dataclass
@@ -226,41 +226,41 @@ class StreamConfig(Base):
     """
     StreamConfig represents the configuration of a stream.
     """
-    name: Optional[str] = None
-    description: Optional[str] = None
-    subjects: Optional[List[str]] = None
-    retention: Optional[RetentionPolicy] = None
-    max_consumers: Optional[int] = None
-    max_msgs: Optional[int] = None
-    max_bytes: Optional[int] = None
-    discard: Optional[DiscardPolicy] = DiscardPolicy.OLD
-    max_age: Optional[float] = None  # in seconds
+    name: str | None = None
+    description: str | None = None
+    subjects: list[str] | None = None
+    retention: RetentionPolicy | None = None
+    max_consumers: int | None = None
+    max_msgs: int | None = None
+    max_bytes: int | None = None
+    discard: DiscardPolicy | None = DiscardPolicy.OLD
+    max_age: float | None = None  # in seconds
     max_msgs_per_subject: int = -1
-    max_msg_size: Optional[int] = -1
-    storage: Optional[StorageType] = None
-    num_replicas: Optional[int] = None
+    max_msg_size: int | None = -1
+    storage: StorageType | None = None
+    num_replicas: int | None = None
     no_ack: bool = False
-    template_owner: Optional[str] = None
+    template_owner: str | None = None
     duplicate_window: float = 0
-    placement: Optional[Placement] = None
-    mirror: Optional[StreamSource] = None
-    sources: Optional[List[StreamSource]] = None
+    placement: Placement | None = None
+    mirror: StreamSource | None = None
+    sources: list[StreamSource] | None = None
     sealed: bool = False
     deny_delete: bool = False
     deny_purge: bool = False
     allow_rollup_hdrs: bool = False
 
     # Allow republish of the message after being sequenced and stored.
-    republish: Optional[RePublish] = None
+    republish: RePublish | None = None
 
     # Allow higher performance, direct access to get individual messages. E.g. KeyValue
-    allow_direct: Optional[bool] = None
+    allow_direct: bool | None = None
 
     # Allow higher performance and unified direct access for mirrors as well.
-    mirror_direct: Optional[bool] = None
+    mirror_direct: bool | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert_nanoseconds(resp, 'max_age')
         cls._convert_nanoseconds(resp, 'duplicate_window')
         cls._convert(resp, 'placement', Placement)
@@ -268,7 +268,7 @@ class StreamConfig(Base):
         cls._convert(resp, 'sources', StreamSource)
         return super().from_response(resp)
 
-    def as_dict(self) -> Dict[str, object]:
+    def as_dict(self) -> dict[str, object]:
         result = super().as_dict()
         result['duplicate_window'] = self._to_nanoseconds(
             self.duplicate_window
@@ -279,21 +279,21 @@ class StreamConfig(Base):
 
 @dataclass
 class PeerInfo(Base):
-    name: Optional[str] = None
-    current: Optional[bool] = None
-    offline: Optional[bool] = None
-    active: Optional[int] = None
-    lag: Optional[int] = None
+    name: str | None = None
+    current: bool | None = None
+    offline: bool | None = None
+    active: int | None = None
+    lag: int | None = None
 
 
 @dataclass
 class ClusterInfo(Base):
-    leader: Optional[str] = None
-    name: Optional[str] = None
-    replicas: Optional[List[PeerInfo]] = None
+    leader: str | None = None
+    name: str | None = None
+    replicas: list[PeerInfo] | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'replicas', PeerInfo)
         return super().from_response(resp)
 
@@ -305,13 +305,13 @@ class StreamInfo(Base):
     """
     config: StreamConfig
     state: StreamState
-    mirror: Optional[StreamSourceInfo] = None
-    sources: Optional[List[StreamSourceInfo]] = None
-    cluster: Optional[ClusterInfo] = None
-    did_create: Optional[bool] = None
+    mirror: StreamSourceInfo | None = None
+    sources: list[StreamSourceInfo] | None = None
+    cluster: ClusterInfo | None = None
+    did_create: bool | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'config', StreamConfig)
         cls._convert(resp, 'state', StreamState)
         cls._convert(resp, 'mirror', StreamSourceInfo)
@@ -373,47 +373,47 @@ class ConsumerConfig(Base):
     References:
         * `Consumers <https://docs.nats.io/jetstream/concepts/consumers>`_
     """
-    name: Optional[str] = None
-    durable_name: Optional[str] = None
-    description: Optional[str] = None
-    deliver_policy: Optional[DeliverPolicy] = DeliverPolicy.ALL
-    opt_start_seq: Optional[int] = None
-    opt_start_time: Optional[int] = None
-    ack_policy: Optional[AckPolicy] = AckPolicy.EXPLICIT
-    ack_wait: Optional[float] = None  # in seconds
-    max_deliver: Optional[int] = None
-    filter_subject: Optional[str] = None
-    replay_policy: Optional[ReplayPolicy] = ReplayPolicy.INSTANT
-    rate_limit_bps: Optional[int] = None
-    sample_freq: Optional[str] = None
-    max_waiting: Optional[int] = None
-    max_ack_pending: Optional[int] = None
-    flow_control: Optional[bool] = None
-    idle_heartbeat: Optional[float] = None
-    headers_only: Optional[bool] = None
+    name: str | None = None
+    durable_name: str | None = None
+    description: str | None = None
+    deliver_policy: DeliverPolicy | None = DeliverPolicy.ALL
+    opt_start_seq: int | None = None
+    opt_start_time: int | None = None
+    ack_policy: AckPolicy | None = AckPolicy.EXPLICIT
+    ack_wait: float | None = None  # in seconds
+    max_deliver: int | None = None
+    filter_subject: str | None = None
+    replay_policy: ReplayPolicy | None = ReplayPolicy.INSTANT
+    rate_limit_bps: int | None = None
+    sample_freq: str | None = None
+    max_waiting: int | None = None
+    max_ack_pending: int | None = None
+    flow_control: bool | None = None
+    idle_heartbeat: float | None = None
+    headers_only: bool | None = None
 
     # Push based consumers.
-    deliver_subject: Optional[str] = None
-    deliver_group: Optional[str] = None
+    deliver_subject: str | None = None
+    deliver_group: str | None = None
 
     # Ephemeral inactivity threshold
-    inactive_threshold: Optional[float] = None  # in seconds
+    inactive_threshold: float | None = None  # in seconds
 
     # Generally inherited by parent stream and other markers, now can
     # be configured directly.
-    num_replicas: Optional[int] = None
+    num_replicas: int | None = None
 
     # Force memory storage.
-    mem_storage: Optional[bool] = None
+    mem_storage: bool | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert_nanoseconds(resp, 'ack_wait')
         cls._convert_nanoseconds(resp, 'idle_heartbeat')
         cls._convert_nanoseconds(resp, 'inactive_threshold')
         return super().from_response(resp)
 
-    def as_dict(self) -> Dict[str, object]:
+    def as_dict(self) -> dict[str, object]:
         result = super().as_dict()
         result['ack_wait'] = self._to_nanoseconds(self.ack_wait)
         result['idle_heartbeat'] = self._to_nanoseconds(self.idle_heartbeat)
@@ -441,17 +441,17 @@ class ConsumerInfo(Base):
     config: ConsumerConfig
     # FIXME: Do not handle dates for now.
     # created: datetime
-    delivered: Optional[SequenceInfo] = None
-    ack_floor: Optional[SequenceInfo] = None
-    num_ack_pending: Optional[int] = None
-    num_redelivered: Optional[int] = None
-    num_waiting: Optional[int] = None
-    num_pending: Optional[int] = None
-    cluster: Optional[ClusterInfo] = None
-    push_bound: Optional[bool] = None
+    delivered: SequenceInfo | None = None
+    ack_floor: SequenceInfo | None = None
+    num_ack_pending: int | None = None
+    num_redelivered: int | None = None
+    num_waiting: int | None = None
+    num_pending: int | None = None
+    cluster: ClusterInfo | None = None
+    push_bound: bool | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'delivered', SequenceInfo)
         cls._convert(resp, 'ack_floor', SequenceInfo)
         cls._convert(resp, 'config', ConsumerConfig)
@@ -486,7 +486,7 @@ class Tier(Base):
     limits: AccountLimits
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'limits', AccountLimits)
         return super().from_response(resp)
 
@@ -514,11 +514,11 @@ class AccountInfo(Base):
     limits: AccountLimits
 
     api: APIStats
-    domain: Optional[str] = None
-    tiers: Optional[Dict[str, Tier]] = None
+    domain: str | None = None
+    tiers: dict[str, Tier] | None = None
 
     @classmethod
-    def from_response(cls, resp: Dict[str, Any]):
+    def from_response(cls, resp: dict[str, Any]):
         cls._convert(resp, 'limits', AccountLimits)
         cls._convert(resp, 'api', APIStats)
         info = super().from_response(resp)
@@ -533,20 +533,20 @@ class AccountInfo(Base):
 
 @dataclass
 class RawStreamMsg(Base):
-    subject: Optional[str] = None
-    seq: Optional[int] = None
-    data: Optional[bytes] = None
-    hdrs: Optional[bytes] = None
-    headers: Optional[dict] = None
-    stream: Optional[str] = None
+    subject: str | None = None
+    seq: int | None = None
+    data: bytes | None = None
+    hdrs: bytes | None = None
+    headers: dict | None = None
+    stream: str | None = None
     # TODO: Add 'time'
 
     @property
-    def sequence(self) -> Optional[int]:
+    def sequence(self) -> int | None:
         return self.seq
 
     @property
-    def header(self) -> Optional[dict]:
+    def header(self) -> dict | None:
         """
         header returns the headers from a message.
         """
@@ -559,18 +559,18 @@ class KeyValueConfig(Base):
     KeyValueConfig is the configuration of a KeyValue store.
     """
     bucket: str
-    description: Optional[str] = None
-    max_value_size: Optional[int] = None
+    description: str | None = None
+    max_value_size: int | None = None
     history: int = 1
-    ttl: Optional[float] = None  # in seconds
-    max_bytes: Optional[int] = None
-    storage: Optional[StorageType] = None
+    ttl: float | None = None  # in seconds
+    max_bytes: int | None = None
+    storage: StorageType | None = None
     replicas: int = 1
-    placement: Optional[Placement] = None
-    republish: Optional[RePublish] = None
-    direct: Optional[bool] = None
+    placement: Placement | None = None
+    republish: RePublish | None = None
+    direct: bool | None = None
 
-    def as_dict(self) -> Dict[str, object]:
+    def as_dict(self) -> dict[str, object]:
         result = super().as_dict()
         result['ttl'] = self._to_nanoseconds(self.ttl)
         return result

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional
+from typing import TYPE_CHECKING, Any, NoReturn
 
 import nats.errors
 from nats.js import api
@@ -29,7 +29,7 @@ class Error(nats.errors.Error):
     An Error raised by the NATS client when using JetStream.
     """
 
-    def __init__(self, description: Optional[str] = None) -> None:
+    def __init__(self, description: str | None = None) -> None:
         self.description = description
 
     def __str__(self) -> str:
@@ -44,19 +44,19 @@ class APIError(Error):
     """
     An Error that is the result of interacting with NATS JetStream.
     """
-    code: Optional[int]
-    err_code: Optional[int]
-    description: Optional[str]
-    stream: Optional[str]
-    seq: Optional[int]
+    code: int | None
+    err_code: int | None
+    description: str | None
+    stream: str | None
+    seq: int | None
 
     def __init__(
         self,
-        code: Optional[int] = None,
-        description: Optional[str] = None,
-        err_code: Optional[int] = None,
-        stream: Optional[str] = None,
-        seq: Optional[int] = None,
+        code: int | None = None,
+        description: str | None = None,
+        err_code: int | None = None,
+        stream: str | None = None,
+        seq: int | None = None,
     ) -> None:
         self.code = code
         self.err_code = err_code
@@ -65,7 +65,7 @@ class APIError(Error):
         self.seq = seq
 
     @classmethod
-    def from_msg(cls, msg: "Msg") -> NoReturn:
+    def from_msg(cls, msg: Msg) -> NoReturn:
         if msg.header is None:
             raise APIError
         code = msg.header[api.Header.STATUS]
@@ -76,7 +76,7 @@ class APIError(Error):
             raise APIError(code=int(code), description=desc)
 
     @classmethod
-    def from_error(cls, err: Dict[str, Any]):
+    def from_error(cls, err: dict[str, Any]):
         code = err['code']
         if code == 503:
             raise ServiceUnavailableError(**err)

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 import nats.js.errors
 from nats.js import api
@@ -70,11 +70,11 @@ class KeyValue:
         """
         bucket: str
         key: str
-        value: Optional[bytes]
-        revision: Optional[int]
-        delta: Optional[int]
-        created: Optional[int]
-        operation: Optional[str]
+        value: bytes | None
+        revision: int | None
+        delta: int | None
+        created: int | None
+        operation: str | None
 
     @dataclass(frozen=True)
     class BucketStatus:
@@ -99,7 +99,7 @@ class KeyValue:
             return self.stream_info.config.max_msgs_per_subject
 
         @property
-        def ttl(self) -> Optional[float]:
+        def ttl(self) -> float | None:
             """
             ttl returns the max age in seconds.
             """
@@ -112,7 +112,7 @@ class KeyValue:
         name: str,
         stream: str,
         pre: str,
-        js: "JetStreamContext",
+        js: JetStreamContext,
         direct: bool,
     ) -> None:
         self._name = name
@@ -121,7 +121,7 @@ class KeyValue:
         self._js = js
         self._direct = direct
 
-    async def get(self, key: str, revision: Optional[int] = None) -> Entry:
+    async def get(self, key: str, revision: int | None = None) -> Entry:
         """
         get returns the latest value for the key.
         """
@@ -132,7 +132,7 @@ class KeyValue:
             raise nats.js.errors.KeyNotFoundError(err.entry, err.op)
         return entry
 
-    async def _get(self, key: str, revision: Optional[int] = None) -> Entry:
+    async def _get(self, key: str, revision: int | None = None) -> Entry:
         msg = None
         subject = f"{self._pre}{key}"
         try:
@@ -215,7 +215,7 @@ class KeyValue:
         return pa
 
     async def update(
-        self, key: str, value: bytes, last: Optional[int] = None
+        self, key: str, value: bytes, last: int | None = None
     ) -> int:
         """
         update will update the value iff the latest revision matches.
@@ -240,7 +240,7 @@ class KeyValue:
                 raise err
         return pa.seq
 
-    async def delete(self, key: str, last: Optional[int] = None) -> bool:
+    async def delete(self, key: str, last: int | None = None) -> bool:
         """
         delete will place a delete marker and remove all previous revisions.
         """
@@ -299,7 +299,7 @@ class KeyValue:
             self._js = js
             self._updates = asyncio.Queue(maxsize=256)
             self._sub = None
-            self._pending: Optional[int] = None
+            self._pending: int | None = None
 
             # init done means that the nil marker has been sent,
             # once this is sent it won't be sent anymore.
@@ -336,7 +336,7 @@ class KeyValue:
         """
         return await self.watch(">", **kwargs)
 
-    async def keys(self, **kwargs) -> List[str]:
+    async def keys(self, **kwargs) -> list[str]:
         """
         keys will return a list of the keys from a KeyValue store.
         """
@@ -358,7 +358,7 @@ class KeyValue:
 
         return keys
 
-    async def history(self, key: str) -> List[Entry]:
+    async def history(self, key: str) -> list[Entry]:
         """
         history retrieves a list of the entries so far.
         """

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 import json
 from email.parser import BytesParser
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any
 
 from nats.errors import NoRespondersError
 from nats.js import api
@@ -39,7 +39,7 @@ class JetStreamManager:
 
     def __init__(
         self,
-        conn: "NATS",
+        conn: NATS,
         prefix: str = api.DEFAULT_PREFIX,
         timeout: float = 5,
     ) -> None:
@@ -77,7 +77,7 @@ class JetStreamManager:
 
     async def add_stream(
         self,
-        config: Optional[api.StreamConfig] = None,
+        config: api.StreamConfig | None = None,
         **params
     ) -> api.StreamInfo:
         """
@@ -99,7 +99,7 @@ class JetStreamManager:
 
     async def update_stream(
         self,
-        config: Optional[api.StreamConfig] = None,
+        config: api.StreamConfig | None = None,
         **params
     ) -> api.StreamInfo:
         """
@@ -131,14 +131,14 @@ class JetStreamManager:
     async def purge_stream(
         self,
         name: str,
-        seq: Optional[int] = None,
-        subject: Optional[str] = None,
-        keep: Optional[int] = None
+        seq: int | None = None,
+        subject: str | None = None,
+        keep: int | None = None
     ) -> bool:
         """
         Purge a stream by name.
         """
-        stream_req: Dict[str, Any] = {}
+        stream_req: dict[str, Any] = {}
         if seq:
             stream_req['seq'] = seq
         if subject:
@@ -155,7 +155,7 @@ class JetStreamManager:
         return resp['success']
 
     async def consumer_info(
-        self, stream: str, consumer: str, timeout: Optional[float] = None
+        self, stream: str, consumer: str, timeout: float | None = None
     ):
         # TODO: Validate the stream and consumer names.
         if timeout is None:
@@ -167,7 +167,7 @@ class JetStreamManager:
         )
         return api.ConsumerInfo.from_response(resp)
 
-    async def streams_info(self) -> List[api.StreamInfo]:
+    async def streams_info(self) -> list[api.StreamInfo]:
         """
         streams_info retrieves a list of streams.
         """
@@ -185,8 +185,8 @@ class JetStreamManager:
     async def add_consumer(
         self,
         stream: str,
-        config: Optional[api.ConsumerConfig] = None,
-        timeout: Optional[float] = None,
+        config: api.ConsumerConfig | None = None,
+        timeout: float | None = None,
         **params,
     ) -> api.ConsumerInfo:
         if not timeout:
@@ -226,7 +226,7 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def consumers_info(self, stream: str) -> List[api.ConsumerInfo]:
+    async def consumers_info(self, stream: str) -> list[api.ConsumerInfo]:
         """
         consumers_info retrieves a list of consumers.
         """
@@ -244,16 +244,16 @@ class JetStreamManager:
     async def get_msg(
         self,
         stream_name: str,
-        seq: Optional[int] = None,
-        subject: Optional[str] = None,
-        direct: Optional[bool] = False,
-        next: Optional[bool] = False,
+        seq: int | None = None,
+        subject: str | None = None,
+        direct: bool | None = False,
+        next: bool | None = False,
     ) -> api.RawStreamMsg:
         """
         get_msg retrieves a message from a stream.
         """
         req_subject = None
-        req: Dict[str, Any] = {}
+        req: dict[str, Any] = {}
         if seq:
             req['seq'] = seq
         if subject:
@@ -300,7 +300,7 @@ class JetStreamManager:
                     headers[k] = v
             raw_msg.headers = headers
 
-        msg_data: Optional[bytes] = None
+        msg_data: bytes | None = None
         if raw_msg.data:
             msg_data = base64.b64decode(raw_msg.data)
         raw_msg.data = msg_data
@@ -344,7 +344,7 @@ class JetStreamManager:
         self,
         stream_name: str,
         subject: str,
-        direct: Optional[bool] = False,
+        direct: bool | None = False,
     ) -> api.RawStreamMsg:
         """
         get_last_msg retrieves the last message from a stream.
@@ -356,7 +356,7 @@ class JetStreamManager:
         req_subject: str,
         req: bytes = b'',
         timeout: float = 5,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         try:
             msg = await self._nc.request(req_subject, req, timeout=timeout)
             resp = json.loads(msg.data)

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Dict
+from typing import Any
 
 from nats.errors import ProtocolError
 
@@ -85,7 +85,7 @@ class Parser:
         self.state = AWAITING_CONTROL_LINE
         self.needed = 0
         self.header_needed = 0
-        self.msg_arg: Dict[str, Any] = {}
+        self.msg_arg: dict[str, Any] = {}
 
     async def parse(self, data: bytes = b''):
         """

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -247,7 +247,7 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         await asyncio.sleep(1)
         assert received is False
         await asyncio.sleep(1)
-        await js.publish("foo.111", 'Hello from NATS!'.encode())
+        await js.publish("foo.111", b'Hello from NATS!')
         await task
         assert received
 


### PR DESCRIPTION
PR #386 made all [type annotations lazy](https://peps.python.org/pep-0563/), meaning that they are not evaluated in runtime. That means, now we can use the [new syntax for type annotations](https://peps.python.org/pep-0604/) without breaking compatibility with older Python versions.

Before:

```python
from typing import List, Optional

a: Optional[List[str]]
```

After:

```python
a: list[str] | None
```
