### PR TITLE
Move configs from setup.cfg into pyproject.toml

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
-## Community Code of Conduct
+# Community Code of Conduct
 
 NATS follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,28 @@ version = {attr = "nats.aio.client.__version__"}
 include = ["nats*"]  # package names should match these glob patterns (["*"] by default)
 exclude = ["scripts", "tests"]  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+[tool.mypy]
+files = ["nats"]
+python_version = "3.7"
+ignore_missing_imports = true
+follow_imports = "silent"
+show_error_codes = true
+check_untyped_defs = false
+
+[tool.pytest.ini_options]
+addopts = ["--cov=nats", "--cov-report=html"]
+
+[tool.yapf]
+split_before_first_argument = true
+dedent_closing_brackets = true
+coalesce_brackets = true
+allow_split_before_dict_value = false
+indent_dictionary_value = true
+split_before_expression_after_opening_paren = true
+
+[tool.isort]
+combine_as_imports = true
+multi_line_output = 3
+include_trailing_comma = true
+src_paths = ["nats", "tests"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,28 +1,2 @@
-[mypy]
-files=nats
-python_version=3.7
-ignore_missing_imports=true
-follow_imports=silent
-show_error_codes=true
-check_untyped_defs=false
-
-[tool:pytest]
-addopts=--cov=nats --cov-report html
-testpaths=tests
-
-[yapf]
-split_before_first_argument=true
-dedent_closing_brackets=true
-coalesce_brackets=true
-allow_split_before_dict_value=false
-indent_dictionary_value=true
-split_before_expression_after_opening_paren=true
-
 [flake8]
 max-line-length = 120
-
-[isort]
-combine_as_imports=true
-multi_line_output=3
-include_trailing_comma=true
-src_paths=nats,tests


### PR DESCRIPTION
Cool kids use pyproject.toml for tool configs. TOML is nice and typed, with syntax highlighting, linters, formatters, all that stuff. Only flake8 stays in setup.cfg because they're boring.