### PR TITLE
Send credentials even if no_auth_required is set on INFO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ci: deps
 	pipenv run yapf --recursive --diff tests
 	# pipenv run mypy
 	pipenv run flake8 ./nats/js/
-	pipenv run pytest --verbose
+	pipenv run pytest -x -vv -s --continue-on-collection-errors
 
 watch:
 	while true; do pipenv run pytest -v -s -x; sleep 10; done

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1854,6 +1854,7 @@ class Client:
             connection_completed, self.options["connect_timeout"]
         )
         if INFO_OP not in info_line:
+            # FIXME: Handle PING/PONG arriving first as well.
             raise errors.Error(
                 "nats: empty response from server when expecting INFO message"
             )

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -243,7 +243,7 @@ class Client:
         self._resp_sub_prefix: bytearray | None = None
         self._nuid = NUID()
         self._inbox_prefix = bytearray(DEFAULT_INBOX_PREFIX)
-        self._auth_configured = None
+        self._auth_configured: bool = False
 
         # NKEYS support
         #
@@ -1867,8 +1867,7 @@ class Client:
             raise errors.Error("nats: info message, json parse error")
 
         # In case 'auth_required' is part of INFO, then need to send credentials.
-        auth_required = srv_info.get("auth_required")
-        if auth_required:
+        if srv_info.get("auth_required", False):
             self._auth_configured = True
 
         self._process_info(srv_info, initial_connection=True)

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -243,6 +243,7 @@ class Client:
         self._resp_sub_prefix: bytearray | None = None
         self._nuid = NUID()
         self._inbox_prefix = bytearray(DEFAULT_INBOX_PREFIX)
+        self._auth_configured = None
 
         # NKEYS support
         #
@@ -441,7 +442,11 @@ class Client:
         if tls_hostname:
             self.options['tls_hostname'] = tls_hostname
 
+        if user or password or token:
+            self._auth_configured = True
+
         if self._user_credentials is not None or self._nkeys_seed is not None:
+            self._auth_configured = True
             self._setup_nkeys_connect()
 
         # Queue used to trigger flushes to the socket.
@@ -1496,32 +1501,30 @@ class Client:
             options["headers"] = self._server_info["headers"]
             options["no_responders"] = self._server_info["headers"]
 
-        if "auth_required" in self._server_info:
-            if self._server_info["auth_required"]:
-                if "nonce" in self._server_info and self._signature_cb is not None:
-                    sig = self._signature_cb(self._server_info["nonce"])
-                    options["sig"] = sig.decode()
+        if self._auth_configured:
+            if "nonce" in self._server_info and self._signature_cb is not None:
+                sig = self._signature_cb(self._server_info["nonce"])
+                options["sig"] = sig.decode()
 
-                    if self._user_jwt_cb is not None:
-                        jwt = self._user_jwt_cb()
-                        options["jwt"] = jwt.decode()
-                    elif self._public_nkey is not None:
-                        options["nkey"] = self._public_nkey
-                # In case there is no password, then consider handle
-                # sending a token instead.
-                elif self.options["user"] is not None and self.options[
-                        "password"] is not None:
-                    options["user"] = self.options["user"]
-                    options["pass"] = self.options["password"]
-                elif self.options["token"] is not None:
-                    options["auth_token"] = self.options["token"]
-                elif self._current_server and self._current_server.uri.username is not None:
-                    if self._current_server.uri.password is None:
-                        options["auth_token"
-                                ] = self._current_server.uri.username
-                    else:
-                        options["user"] = self._current_server.uri.username
-                        options["pass"] = self._current_server.uri.password
+                if self._user_jwt_cb is not None:
+                    jwt = self._user_jwt_cb()
+                    options["jwt"] = jwt.decode()
+                elif self._public_nkey is not None:
+                    options["nkey"] = self._public_nkey
+            # In case there is no password, then consider handle
+            # sending a token instead.
+            elif self.options["user"] is not None and self.options[
+                    "password"] is not None:
+                options["user"] = self.options["user"]
+                options["pass"] = self.options["password"]
+            elif self.options["token"] is not None:
+                options["auth_token"] = self.options["token"]
+            elif self._current_server and self._current_server.uri.username is not None:
+                if self._current_server.uri.password is None:
+                    options["auth_token"] = self._current_server.uri.username
+                else:
+                    options["user"] = self._current_server.uri.username
+                    options["pass"] = self._current_server.uri.password
 
         if self.options["name"] is not None:
             options["name"] = self.options["name"]
@@ -1859,10 +1862,15 @@ class Client:
 
         try:
             srv_info = json.loads(info.decode())
+            self._server_info = srv_info
         except Exception:
             raise errors.Error("nats: info message, json parse error")
 
-        self._server_info = srv_info
+        # In case 'auth_required' is part of INFO, then need to send credentials.
+        auth_required = srv_info.get("auth_required")
+        if auth_required:
+            self._auth_configured = True
+
         self._process_info(srv_info, initial_connection=True)
 
         if 'version' in self._server_info:

--- a/tests/conf/no_auth_user.conf
+++ b/tests/conf/no_auth_user.conf
@@ -1,0 +1,35 @@
+port: 4555
+
+accounts {
+  a {
+    users = [ { user: 'foo', pass: 'foo',
+      permissions: {
+        subscribe: {
+          allow: ["foo", "_INBOX.>"],
+	  deny: ["bar"]
+	},
+        publish: {
+          allow: ["foo", "_INBOX.>"],
+	  deny: ["bar"]
+	}
+      }
+    }]
+  }
+  b {
+    users = [ { user: 'bar', pass: 'bar',
+      permissions: {
+        subscribe: {
+          allow: ["bar"],
+	  deny: [">"]
+	},
+        publish: {
+          allow: ["bar"],
+	  deny: [">"]
+	}
+      }
+    }]  
+  }
+}
+
+no_auth_user = "foo"
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2698,8 +2698,6 @@ class NoAuthUserClientTest(NoAuthUserServerTestCase):
             user="bar",
             password="bar",
             error_cb=err_cb,
-            allow_reconnect=False,
-            max_reconnect_attempts=0,
         )
         sub = await nc.subscribe("foo")
         await nc.flush()
@@ -2711,11 +2709,7 @@ class NoAuthUserClientTest(NoAuthUserServerTestCase):
             err
         ) == 'nats: permissions violation for subscription to "foo"'
 
-        nc2 = await nats.connect(
-            "nats://127.0.0.1:4555",
-            allow_reconnect=False,
-            max_reconnect_attempts=0,
-        )
+        nc2 = await nats.connect("nats://127.0.0.1:4555", )
 
         async def cb(msg):
             await msg.respond(b'pong')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2704,9 +2704,7 @@ class NoAuthUserClientTest(NoAuthUserServerTestCase):
         await nc.flush()
         await asyncio.wait_for(fut, 1)
         err = fut.result()
-        self.assertEqual(
-            str(err), 'nats: permissions violation for subscription to "foo"'
-        )
+        assert str(err) == 'nats: permissions violation for subscription to "foo"'
         await nc.close()
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -520,7 +520,7 @@ class NoAuthUserServerTestCase(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
 
         server = NATSD(
-            port=4222, config_file=get_config_file("conf/no_auth_user.conf")
+            port=4555, config_file=get_config_file("conf/no_auth_user.conf")
         )
         self.server_pool.append(server)
         for natsd in self.server_pool:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -513,6 +513,25 @@ class SingleJetStreamServerLimitsTestCase(unittest.TestCase):
         self.loop.close()
 
 
+class NoAuthUserServerTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.server_pool = []
+        self.loop = asyncio.new_event_loop()
+
+        server = NATSD(
+            port=4222, config_file=get_config_file("conf/no_auth_user.conf")
+        )
+        self.server_pool.append(server)
+        for natsd in self.server_pool:
+            start_natsd(natsd)
+
+    def tearDown(self):
+        for natsd in self.server_pool:
+            natsd.stop()
+        self.loop.close()
+
+
 def start_natsd(natsd: NATSD):
     natsd.start()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -522,6 +522,7 @@ class NoAuthUserServerTestCase(unittest.TestCase):
         server = NATSD(
             port=4555, config_file=get_config_file("conf/no_auth_user.conf")
         )
+        server.debug = True
         self.server_pool.append(server)
         for natsd in self.server_pool:
             start_natsd(natsd)


### PR DESCRIPTION
At nats-server v2.9.8 there was an issue with `auth_required` not being sent by the server in some configurations.  Go client was not affected because it was not checking this property on the INFO line, so this changes the logic to be more similar to the Go client and always send the credentials whenever they are configured.