### PR TITLE
Convert `republish` value into dataclass

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -266,6 +266,7 @@ class StreamConfig(Base):
         cls._convert(resp, 'placement', Placement)
         cls._convert(resp, 'mirror', StreamSource)
         cls._convert(resp, 'sources', StreamSource)
+        cls._convert(resp, 'republish', RePublish)
         return super().from_response(resp)
 
     def as_dict(self) -> dict[str, object]:


### PR DESCRIPTION
I haven't checked but it seems like the `republish` field in the API response is not converted to `RePublish` type from dict. I'll later see if I can add [typeguard](https://github.com/agronholm/typeguard) into tests to avoid such issues in the future.