### PR TITLE
Add custom inbox prefix support for JS pull subscribe

### DIFF
--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -376,6 +376,7 @@ class JetStreamContext(JetStreamManager):
         config: api.ConsumerConfig | None = None,
         pending_msgs_limit: int = DEFAULT_JS_SUB_PENDING_MSGS_LIMIT,
         pending_bytes_limit: int = DEFAULT_JS_SUB_PENDING_BYTES_LIMIT,
+        inbox_prefix: bytes = api.INBOX_PREFIX,
     ) -> JetStreamContext.PullSubscription:
         """Create consumer and pull subscription.
 
@@ -423,6 +424,7 @@ class JetStreamContext(JetStreamManager):
         return await self.pull_subscribe_bind(
             durable=durable,
             stream=stream,
+            inbox_prefix=inbox_prefix,
             pending_bytes_limit=pending_bytes_limit,
             pending_msgs_limit=pending_msgs_limit,
         )


### PR DESCRIPTION
With [#276](https://github.com/nats-io/nats.py/pull/276), custom inbox prefix support is added to core NATS features, but not JS. This PR addresses this issue.

This is an important problem since it affects authorization permissions. If the user cannot specify a custom inbox prefix, the user's messages can be received by the non-authorized users who subscribed to the default inbox subject.