### PR TITLE
Fixes incorrect formatting in `.travis.yml`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ jobs:
     install:
       - pip install uvloop
   allow_failures:
-    - python:
-      - "3.8"
-      - "3.9"
-      - "Python: 3.9/uvloop"
+    - python: "3.8"
+    - python: "3.9"
+    - name: "Python: 3.9/uvloop"


### PR DESCRIPTION
The intention seems to be for Travis to allow the following build jobs to fail, without causing the whole build operation to break:
- where `python="3.8"`
- where `python="3.9"`
- where `name="Python: 3.9/uvloop"`

However the YAML file is incorrectly formatted to communicate this, meaning that builds are failing. This commit addresses this.