### PR TITLE
Add sid attribute to nats.aio.msg.Msg class

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1653,7 +1653,7 @@ class Client:
             self._subs.pop(sid, None)
 
         hdr = await self._process_headers(headers)
-        msg = self._build_message(subject, reply, data, hdr)
+        msg = self._build_message(sid, subject, reply, data, hdr)
         if not msg:
             return
 
@@ -1758,12 +1758,14 @@ class Client:
 
     def _build_message(
         self,
+        sid: int,
         subject: bytes,
         reply: bytes,
         data: bytes,
         headers: dict[str, str] | None,
     ):
         return self.msg_class(
+            sid=sid,
             subject=subject.decode(),
             reply=reply.decode(),
             data=data,

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -41,6 +41,7 @@ class Msg:
     Msg represents a message delivered by NATS.
     """
     _client: NATS
+    sid: int
     subject: str = ''
     reply: str = ''
     data: bytes = b''

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,6 +279,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual('foo', msg.subject)
         self.assertEqual('', msg.reply)
         self.assertEqual(payload, msg.data)
+        self.assertEqual(sub._id, msg.sid)
         self.assertEqual(1, sub._received)
         await nc.close()
         await asyncio.sleep(0.5)
@@ -330,6 +331,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual('foo', msg.subject)
         self.assertEqual('', msg.reply)
         self.assertEqual(payload, msg.data)
+        self.assertEqual(sid._id, msg.sid)
 
     @async_test
     async def test_subscribe_no_echo(self):


### PR DESCRIPTION
This PR addresses the issue [#427 (Add subscription ID in Msg](https://github.com/nats-io/nats.py/issues/427))

## Description

- [x] Add a new attribute `sid` to `nats.aio.msg.Msg`

## Breaking changes

In order to create an instance of `nats.aio.msg.Msg`, a new argument `sid` must be provided.

> There should not be any users creating messages in their applications, but there may be users creating messages in tests. Those users will be required to fix their code.

## Alternatives

PR can be updated in order to avoid introducing breaking changes:

- Add `sid` parameter with `None` as default value:  This is not a breaking change but type annotation for `sid` attribute is `int|None`.

- Add `_sid`  parameter with `None` as default value, and define a property named `sid` which would raise an error is `self._sid` is `None` or return `self._sid`: This is not a breaking change and type annotation for `sid` property is `int` as expected. Implemented in #430 

Although breaking change can be avoided by defining a default value for subscription ID, IMO allowing `None` as a value when creating a message (either through `_sid` or `sid` argument) does not make sense because messages are always received for a subscription. As such, I'm in favor of a breaking change right now, rather than adding unneeded complexity.
