### PR TITLE
Add sid property to nats.aio.msg.Msg class

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1653,7 +1653,7 @@ class Client:
             self._subs.pop(sid, None)
 
         hdr = await self._process_headers(headers)
-        msg = self._build_message(subject, reply, data, hdr)
+        msg = self._build_message(sid, subject, reply, data, hdr)
         if not msg:
             return
 
@@ -1758,6 +1758,7 @@ class Client:
 
     def _build_message(
         self,
+        sid: int,
         subject: bytes,
         reply: bytes,
         data: bytes,
@@ -1769,6 +1770,7 @@ class Client:
             data=data,
             headers=headers,
             _client=self,
+            _sid=sid,
         )
 
     def _process_disconnect(self) -> None:

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -48,6 +48,7 @@ class Msg:
 
     _metadata: Metadata | None = None
     _ackd: bool = False
+    _sid: int | None = None
 
     class Ack:
         Ack = b"+ACK"
@@ -74,6 +75,15 @@ class Msg:
         header returns the headers from a message.
         """
         return self.headers
+
+    @property
+    def sid(self) -> int:
+        """
+        sid returns the subscription ID from a message.
+        """
+        if self._sid is None:
+            raise Error('sid not set')
+        return self._sid
 
     async def respond(self, data: bytes) -> None:
         """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,6 +279,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual('foo', msg.subject)
         self.assertEqual('', msg.reply)
         self.assertEqual(payload, msg.data)
+        self.assertEqual(sub._id, msg.sid)
         self.assertEqual(1, sub._received)
         await nc.close()
         await asyncio.sleep(0.5)
@@ -330,6 +331,7 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual('foo', msg.subject)
         self.assertEqual('', msg.reply)
         self.assertEqual(payload, msg.data)
+        self.assertEqual(sid._id, msg.sid)
 
     @async_test
     async def test_subscribe_no_echo(self):

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1708,7 +1708,7 @@ class OrderedConsumerTest(SingleJetStreamServerTestCase):
         # Consumer will lose some messages.
         orig_build_message = nc._build_message
 
-        def _build_message(subject, reply, data, headers):
+        def _build_message(sid, subject, reply, data, headers):
             r = random.randint(0, 100)
             if r <= 10 and headers and headers.get("data"):
                 nc._build_message = orig_build_message
@@ -1720,6 +1720,7 @@ class OrderedConsumerTest(SingleJetStreamServerTestCase):
                 data=data,
                 headers=headers,
                 _client=nc,
+                _sid=sid,
             )
 
         # Override to introduce arbitrary loss.


### PR DESCRIPTION
This PR addresses the issue [#427 (Add subscription ID in Msg](https://github.com/nats-io/nats.py/issues/427))

## Alternatives

This PR is an alternative implementation of #428. In case #428 is accepted, this PR can be closed.

## Description

- [x] Add the `sid` property to `nats.aio.msg.Msg`
- [x] Avoid breaking change