### PR TITLE
support parsing headers with fast-mail-parser

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -34,6 +34,11 @@ from typing import (
 )
 from urllib.parse import ParseResult, urlparse
 
+try:
+    from fast_mail_parser import parse_email
+except ImportError:
+    parse_email = None
+
 import nats.js
 from nats import errors
 from nats.nuid import NUID
@@ -1610,19 +1615,22 @@ class Client:
         #
         raw_headers = headers[NATS_HDR_LINE_SIZE + _CRLF_LEN_:]
         try:
-            parsed_hdr = self._hdr_parser.parsebytes(raw_headers)
-            if len(parsed_hdr.items()) == 0:
-                return hdr
+            if parse_email:
+                parsed_hdr = parse_email(raw_headers).headers
             else:
-                if not hdr:
-                    hdr = {}
-                for k, v in parsed_hdr.items():
-                    hdr[k.strip()] = v.strip()
+                parsed_hdr = {
+                    k_.strip(): v.strip()
+                    for k, v in self._hdr_parser.parsebytes(raw_headers).items()
+                }
+            if hdr:
+                hdr.update(parsed_hdr)
+            else:
+                hdr = parsed_hdr
         except Exception as e:
             await self._error_cb(e)
             return hdr
 
-        return hdr
+        return hdr or None
 
     async def _process_msg(
         self,

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1619,7 +1619,7 @@ class Client:
                 parsed_hdr = parse_email(raw_headers).headers
             else:
                 parsed_hdr = {
-                    k_.strip(): v.strip()
+                    k.strip(): v.strip()
                     for k, v in self._hdr_parser.parsebytes(raw_headers).items()
                 }
             if hdr:

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 setup(
     name="nats-py",
     extras_require={
-        'nkeys': ['nkeys']
+        'nkeys': ['nkeys'],
+        'fast_parse': ['fast-mail-parser'],
     }
 )


### PR DESCRIPTION
Hi,

While experimenting with a NATS subscriber with headers, I noticed that by adding a few headers to my publications, I ended up getting almost double CPU load on the subscriber side.

Looking more closely at what is happening, it looks like we end up spending almost 40% of the active time inside `email.parser.BytesParser`

<img width="1744" alt="Screenshot 2023-03-02 at 12 51 38" src="https://user-images.githubusercontent.com/12514040/222456696-c1b097c6-ba39-437a-86d6-3b4e22f7fa45.png">

This PR is aimed at raising the awareness that this part is quite costly, and it exist a [rust-based equivalent](https://github.com/namecheap/fast_mail_parser/) doing the work way faster:

```
In [4]: data = b'tkid: fb9ac7f6942d0c7ccda526913af8f012\r\nconnclass: ads\r\nconnid: adsbRQB'

In [1]: from email.parser import BytesParser
In [2]: p = BytesParser()
In [5]: %timeit p.parsebytes(d)
31.5 µs ± 595 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [8]: from fast_mail_parser import parse_email
In [9]: %timeit parse_email(data)
2.63 µs ± 44.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Please excuse the test not passing, there are some differences in the way the rust lib deals with empty values and I thought it was too preliminary to optimize at this point, without knowing if you think this is interesting enough to be implemented.

Before:
<img width="1731" alt="Screenshot 2023-03-02 at 15 32 53" src="https://user-images.githubusercontent.com/12514040/222457859-8eecdcf1-7545-4b66-a2a4-749a43e927d6.png">

After:
<img width="1663" alt="Screenshot 2023-03-02 at 15 33 04" src="https://user-images.githubusercontent.com/12514040/222457907-4e35737a-f741-45be-b795-96736b85aa39.png">

Hoping this is useful!