### PR TITLE
Consumers info offset

### DIFF
--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -226,7 +226,7 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def consumers_info(self, stream: str, offset: Optional[int]) -> List[api.ConsumerInfo]:
+    async def consumers_info(self, stream: str, offset: Optional[int] = None) -> List[api.ConsumerInfo]:
         """
         consumers_info retrieves a list of consumers. Consumers list limit is 256 for more
         consider to use offset

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -226,13 +226,16 @@ class JetStreamManager:
         )
         return resp['success']
 
-    async def consumers_info(self, stream: str) -> List[api.ConsumerInfo]:
+    async def consumers_info(self, stream: str, offset: Optional[int]) -> List[api.ConsumerInfo]:
         """
-        consumers_info retrieves a list of consumers.
+        consumers_info retrieves a list of consumers. Consumers list limit is 256 for more
+        consider to use offset
+        :param stream: stream to get consumers
+        :param offset: consumers list offset
         """
         resp = await self._api_request(
             f"{self._prefix}.CONSUMER.LIST.{stream}",
-            b'',
+            b'' if offset is None else json.dumps({"offset": offset}).encode(),
             timeout=self._timeout,
         )
         consumers = []


### PR DESCRIPTION
# ISSUE
Current js.consumers_info() method is able to return only 256 consumers. 
# SOLUTION
Nats server has method [jsConsumerListRequest](https://github.com/nats-io/nats-server/blob/367d8576128d2170a457a0c826fc8a04a936da85/server/jetstream_api.go#L4011), according code the final consumer list restricted by `JSApiListLimit` [code](https://github.com/nats-io/nats-server/blob/367d8576128d2170a457a0c826fc8a04a936da85/server/jetstream_api.go#L4094),  [JSApiListLimit](https://github.com/nats-io/nats-server/blob/367d8576128d2170a457a0c826fc8a04a936da85/server/jetstream_api.go#L420).
 However, it is possible to use `offset` param in body of `CONSUMER.LIST`, so that obtain all info manually by js.consumers_info(stream, offset)