### PR TITLE
Add max_message_size as a configurable connection parameter

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -96,6 +96,7 @@ DEFAULT_MAX_FLUSHER_QUEUE_SIZE = 1024
 DEFAULT_FLUSH_TIMEOUT = 10  # in seconds
 DEFAULT_CONNECT_TIMEOUT = 2  # in seconds
 DEFAULT_DRAIN_TIMEOUT = 30  # in seconds
+DEFAULT_MAX_MESSAGE_SIZE = 4 * 1024 * 1024
 MAX_CONTROL_LINE_SIZE = 1024
 
 NATS_HDR_LINE = bytearray(b'NATS/1.0')
@@ -315,6 +316,7 @@ class Client:
         inbox_prefix: Union[str, bytes] = DEFAULT_INBOX_PREFIX,
         pending_size: int = DEFAULT_PENDING_SIZE,
         flush_timeout: Optional[float] = None,
+        max_message_size: int = DEFAULT_MAX_MESSAGE_SIZE
     ) -> None:
         """
         Establishes a connection to NATS.
@@ -445,6 +447,7 @@ class Client:
         self.options["token"] = token
         self.options["connect_timeout"] = connect_timeout
         self.options["drain_timeout"] = drain_timeout
+        self.options["max_message_size"] = max_message_size
 
         if tls:
             self.options['tls'] = tls
@@ -1309,13 +1312,15 @@ class Client:
                         s.uri,
                         ssl_context=self.ssl_context,
                         buffer_size=DEFAULT_BUFFER_SIZE,
-                        connect_timeout=self.options['connect_timeout']
+                        connect_timeout=self.options['connect_timeout'],
+                        max_msg_size=self.options['max_message_size']
                     )
                 else:
                     await self._transport.connect(
                         s.uri,
                         buffer_size=DEFAULT_BUFFER_SIZE,
-                        connect_timeout=self.options['connect_timeout']
+                        connect_timeout=self.options['connect_timeout'],
+                        max_msg_size=self.options['max_message_size']
                     )
                 self._current_server = s
                 break


### PR DESCRIPTION
The WebSocket library used has a default max message size of 4MB (per https://docs.aiohttp.org/en/v3.8.4/client_reference.html#aiohttp.ClientSession.ws_connect).

If the NATS server supports and has messages larger than this 4MB limit, we encounter the following error during reading of the message:
```
nats: encountered error
Traceback (most recent call last):
  File "/home/seb/.local/lib/python3.8/site-packages/nats/aio/client.py", line 2073, in _read_loop
    await self._ps.parse(b)
  File "/home/seb/.local/lib/python3.8/site-packages/nats/protocol/parser.py", line 95, in parse
    self.buf.extend(data)
TypeError: can't extend bytearray with NoneType
```
This error basically translates to, `self.buf` is smaller than the size of the payload `b` (within the AIO `WebSocketReader` class).

As such, I've added a new `max_message_size` property to the connection, which is passed to the WebSocket transport to resolve this issue. I maintained the default 4MB limit.
