### PR TITLE
Fix CLOSED WS connection detection.

### DIFF
--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -242,7 +242,7 @@ class WebSocketTransport(Transport):
 
     async def readline(self):
         data = await self._ws.receive()
-        if data.type == aiohttp.WSMsgType.CLOSE:
+        if data.type == aiohttp.WSMsgType.CLOSED:
             # if the connection terminated abruptly, return empty binary data to raise unexpected EOF
             return b''
         return data.data


### PR DESCRIPTION
The constant used is incorrect, and results in a `TypeError` due to passing `None` into `extend` when the connection closes, which does not trigger a reconnect.