### PR TITLE
Add consumer backoff parameter support

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -383,6 +383,7 @@ class ConsumerConfig(Base):
     ack_policy: Optional[AckPolicy] = AckPolicy.EXPLICIT
     ack_wait: Optional[float] = None  # in seconds
     max_deliver: Optional[int] = None
+    backoff: Optional[List[int]] = None
     filter_subject: Optional[str] = None
     replay_policy: Optional[ReplayPolicy] = ReplayPolicy.INSTANT
     rate_limit_bps: Optional[int] = None

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -276,7 +276,8 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
             deliver_policy=nats.js.api.DeliverPolicy.ALL,
             max_deliver=20,
             max_waiting=512,
-            # ack_wait=30,
+            backoff=[2, 4, 8, 16],
+            ack_wait=30,
             max_ack_pending=1024,
             filter_subject="events.a"
         )


### PR DESCRIPTION
Since NATS v2.7.1 a backoff consumer config is available. This PR makes the setting available on python client