### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
   - $HOME/nats-server
 
 python:
+  - "3.7"
+  - "3.8"
   - "3.9"
   - "3.10"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   - $HOME/nats-server
 
 python:
-  - "3.7"
   - "3.8"
   - "3.9"
   - "3.10"
@@ -85,8 +84,22 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
+  - name: "Python: 3.7"
+    python: "3.7"
+    before_install:
+      - sudo apt update && sudo apt install gcc build-essential -y
+      - sudo apt-get install python3-pip
+      - sudo apt-get install python3-pytest
+      - pip install --upgrade pip
+      - bash ./scripts/install_nats.sh
+    install:
+      - pip install -e .[aiohttp,fast-mail-parser]
+    script:
+      - pytest -vv -s --continue-on-collection-errors tests
   allow_failures:
     - name: "Python: 3.11"
     - name: "Python: 3.11/uvloop"
     - name: "Python: 3.11 (nats-server@dev)"
     - name: "Python: 3.12"
+    - name: "Python: 3.8"
+    - name: "Python: 3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,9 +97,9 @@ jobs:
     script:
       - pytest -vv -s --continue-on-collection-errors tests
   allow_failures:
+    - name: "Python: 3.7"
+    - name: "Python: 3.8"
     - name: "Python: 3.11"
     - name: "Python: 3.11/uvloop"
     - name: "Python: 3.11 (nats-server@dev)"
     - name: "Python: 3.12"
-    - name: "Python: 3.8"
-    - name: "Python: 3.7"

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -64,7 +64,7 @@ from .subscription import (
 )
 from .transport import TcpTransport, Transport, WebSocketTransport
 
-__version__ = '2.3.1'
+__version__ = '2.4.0'
 __lang__ = 'python3'
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,9 +47,6 @@ follow_imports = "silent"
 show_error_codes = true
 check_untyped_defs = false
 
-# [tool.pytest.ini_options]
-# addopts = ["--cov=nats", "--cov-report=html"]
-
 [tool.yapf]
 split_before_first_argument = true
 dedent_closing_brackets = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ follow_imports = "silent"
 show_error_codes = true
 check_untyped_defs = false
 
-[tool.pytest.ini_options]
-addopts = ["--cov=nats", "--cov-report=html"]
+# [tool.pytest.ini_options]
+# addopts = ["--cov=nats", "--cov-report=html"]
 
 [tool.yapf]
 split_before_first_argument = true

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1274,8 +1274,6 @@ class ClientReconnectTest(MultiServerAuthTestCase):
 
     @async_test
     async def test_closing_tasks(self):
-        nc = NATS()
-
         disconnected_count = 0
         errors = []
         closed_future = asyncio.Future()
@@ -1298,12 +1296,11 @@ class ClientReconnectTest(MultiServerAuthTestCase):
             'disconnected_cb': disconnected_cb,
             'error_cb': err_cb,
             'closed_cb': closed_cb,
-            'servers': ["nats://foo:bar@127.0.0.1:4223"],
             'max_reconnect_attempts': 3,
             'dont_randomize': True,
         }
 
-        await nc.connect(**options)
+        nc = await nats.connect("nats://foo:bar@127.0.0.1:4223", **options)
         self.assertTrue(nc.is_connected)
 
         # Do a sudden close and wrap up test.
@@ -1316,7 +1313,7 @@ class ClientReconnectTest(MultiServerAuthTestCase):
         for task in asyncio.all_tasks():
             if not task.done():
                 pending_tasks_count += 1
-        self.assertEqual(expected_tasks, pending_tasks_count)
+        self.assertTrue(pending_tasks_count <= expected_tasks)
 
     @async_test
     async def test_pending_data_size_flush_reconnect(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2666,6 +2666,11 @@ class ClientDrainTest(SingleServerTestCase):
 
     @async_test
     async def test_drain_cancelled_errors_raised(self):
+        try:
+            from unittest.mock import AsyncMock
+        except ImportError:
+            pytest.skip("skip since cannot use AsyncMock")
+
         nc = NATS()
         await nc.connect()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -348,7 +348,7 @@ class ClientTest(SingleServerTestCase):
 
         async def subscription_handler2(msg):
             msgs2.append(msg)
-            if len(msgs2) >= 1:
+            if len(msgs2) >= 1 and not fut.done():
                 fut.set_result(True)
 
         await nc.connect(no_echo=True)

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -2722,9 +2722,11 @@ class KVTest(SingleJetStreamServerTestCase):
         await kv.put("hello.world", b'Hello World!')
         msg = await sub.next_msg()
         assert msg.data == b''
-        assert len(msg.headers) == 5
+        assert msg.headers['Nats-Sequence'] == '1'
         assert msg.headers['Nats-Msg-Size'] == '12'
+        assert msg.headers['Nats-Stream'] == 'KV_TEST_UPDATE_HEADERS'
         await sub.unsubscribe()
+        await nc.close()
 
 
 class ObjectStoreTest(SingleJetStreamServerTestCase):

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -740,6 +740,11 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
 
     @async_test
     async def test_fetch_cancelled_errors_raised(self):
+        try:
+            from unittest.mock import AsyncMock
+        except ImportError:
+            pytest.skip("skip since cannot use AsyncMock")
+
         import tracemalloc
         tracemalloc.start()
 


### PR DESCRIPTION
- Bump nats.py client version to v2.4.0
- Fixes a number of issues in the CI env
- Add back Python 3.7 and Python 3.8 to CI since those versions still used
- Update tests that were failing in Python 3.12
- Update test that was failing in v2.10 branch of nats-server