### PR TITLE
fix: KeyWatcher.updates() returns type of Entry | None

### DIFF
--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -298,7 +298,7 @@ class KeyValue:
 
         def __init__(self, js):
             self._js = js
-            self._updates = asyncio.Queue(maxsize=256)
+            self._updates: asyncio.Queue[KeyValue.Entry | None] = asyncio.Queue(maxsize=256)
             self._sub = None
             self._pending: Optional[int] = None
 


### PR DESCRIPTION
vscode/pyright infers the type of KeyWatcher.updates() as `Unknown`:

<img width="477" alt="CleanShot 2023-09-20 at 21 10 01@2x" src="https://github.com/nats-io/nats.py/assets/125105/168bac5d-6aaf-405b-8475-2a835b6df1f3">

with this fix the type is now inferred as `Entry | None`:

<img width="320" alt="CleanShot 2023-09-20 at 21 11 08@2x" src="https://github.com/nats-io/nats.py/assets/125105/ac54373b-3f5c-46ef-9abd-0aaaa0916f11">

in this example `e` could be `None`, so the type checker is now correctly telling us we haven't checked the `None` case (hence the red squiggly lines)

