### PR TITLE
Add tls_handshake_first option.

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -64,7 +64,7 @@ from .subscription import (
 )
 from .transport import TcpTransport, Transport, WebSocketTransport
 
-__version__ = '2.4.0'
+__version__ = '2.5.0'
 __lang__ = 'python3'
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # These are here for GitHub's dependency graph and help with setuptools support in some environments.
 setup(
     name="nats-py",
-    version='2.4.0',
+    version='2.5.0',
     license='Apache 2 License',
     extras_require={
         'nkeys': ['nkeys'],

--- a/tests/conf/tls_handshake_first.conf
+++ b/tests/conf/tls_handshake_first.conf
@@ -1,6 +1,8 @@
+port: 4224
 tls {
   cert_file: "./tests/certs/server-cert.pem"
   key_file: "./tests/certs/server-key.pem"
   ca_file: "./tests/certs/ca.pem"
   handshake_first: true
+  verify: true
 }

--- a/tests/conf/tls_handshake_first.conf
+++ b/tests/conf/tls_handshake_first.conf
@@ -1,0 +1,6 @@
+tls {
+  cert_file: "./tests/certs/server-cert.pem"
+  key_file: "./tests/certs/server-key.pem"
+  ca_file: "./tests/certs/ca.pem"
+  handshake_first: true
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1798,14 +1798,19 @@ class ClientTLSReconnectTest(MultiTLSServerAuthTestCase):
         self.assertEqual(1, reconnected_count)
         self.assertEqual(1, err_count)
 
+
 class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
 
     @async_test
     async def test_connect(self):
-        if os.environ['NATS_SERVER_VERSION'] != 'main':
+        if os.environ.get('NATS_SERVER_VERSION') != 'main':
             pytest.skip("test requires nats-server@main")
 
-        nc = await nats.connect('nats://127.0.0.1:4224', tls=self.ssl_ctx, tls_handshake_first=True)
+        nc = await nats.connect(
+            'nats://127.0.0.1:4224',
+            tls=self.ssl_ctx,
+            tls_handshake_first=True
+        )
         self.assertEqual(nc._server_info['max_payload'], nc.max_payload)
         self.assertTrue(nc._server_info['tls_required'])
         self.assertTrue(nc._server_info['tls_verify'])
@@ -1817,7 +1822,7 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
 
     @async_test
     async def test_default_connect_using_tls_scheme(self):
-        if os.environ['NATS_SERVER_VERSION'] != 'main':
+        if os.environ.get('NATS_SERVER_VERSION') != 'main':
             pytest.skip("test requires nats-server@main")
 
         nc = NATS()
@@ -1825,23 +1830,29 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
         # Will attempt to connect using TLS with default certs.
         with self.assertRaises(ssl.SSLError):
             await nc.connect(
-                servers=['tls://127.0.0.1:4224'], allow_reconnect=False, tls_handshake_first=True,
+                servers=['tls://127.0.0.1:4224'],
+                allow_reconnect=False,
+                tls_handshake_first=True,
             )
 
     @async_test
     async def test_default_connect_using_tls_scheme_in_url(self):
-        if os.environ['NATS_SERVER_VERSION'] != 'main':
+        if os.environ.get('NATS_SERVER_VERSION') != 'main':
             pytest.skip("test requires nats-server@main")
 
         nc = NATS()
 
         # Will attempt to connect using TLS with default certs.
         with self.assertRaises(ssl.SSLError):
-            await nc.connect('tls://127.0.0.1:4224', allow_reconnect=False, tls_handshake_first=True)
+            await nc.connect(
+                'tls://127.0.0.1:4224',
+                allow_reconnect=False,
+                tls_handshake_first=True
+            )
 
     @async_test
     async def test_connect_tls_with_custom_hostname(self):
-        if os.environ['NATS_SERVER_VERSION'] != 'main':
+        if os.environ.get('NATS_SERVER_VERSION') != 'main':
             pytest.skip("test requires nats-server@main")
 
         nc = NATS()
@@ -1858,7 +1869,7 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
 
     @async_test
     async def test_subscribe(self):
-        if os.environ['NATS_SERVER_VERSION'] != 'main':
+        if os.environ.get('NATS_SERVER_VERSION') != 'main':
             pytest.skip("test requires nats-server@main")
 
         nc = NATS()
@@ -1868,7 +1879,11 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
             msgs.append(msg)
 
         payload = b'hello world'
-        await nc.connect(servers=['nats://127.0.0.1:4224'], tls=self.ssl_ctx, tls_handshake_first=True)
+        await nc.connect(
+            servers=['nats://127.0.0.1:4224'],
+            tls=self.ssl_ctx,
+            tls_handshake_first=True
+        )
         sub = await nc.subscribe("foo", cb=subscription_handler)
         await nc.publish("foo", payload)
         await nc.publish("bar", payload)
@@ -1886,6 +1901,7 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
         self.assertEqual(payload, msg.data)
         self.assertEqual(1, sub._received)
         await nc.close()
+
 
 class ClusterDiscoveryTest(ClusteringTestCase):
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,6 +21,7 @@ from tests.utils import (
     MultiTLSServerAuthTestCase,
     SingleServerTestCase,
     TLSServerTestCase,
+    TLSServerHandshakeFirstTestCase,
     NoAuthUserServerTestCase,
     async_test,
 )
@@ -1796,6 +1797,78 @@ class ClientTLSReconnectTest(MultiTLSServerAuthTestCase):
         self.assertEqual(1, reconnected_count)
         self.assertEqual(1, err_count)
 
+class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
+
+    @async_test
+    async def test_connect(self):
+        nc = await nats.connect('nats://127.0.0.1:4224', tls=self.ssl_ctx)
+        self.assertEqual(nc._server_info['max_payload'], nc.max_payload)
+        self.assertTrue(nc._server_info['tls_required'])
+        self.assertTrue(nc._server_info['tls_verify'])
+        self.assertTrue(nc.max_payload > 0)
+        self.assertTrue(nc.is_connected)
+        await nc.close()
+        self.assertTrue(nc.is_closed)
+        self.assertFalse(nc.is_connected)
+
+    @async_test
+    async def test_default_connect_using_tls_scheme(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with default certs.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect(
+                servers=['tls://127.0.0.1:4224'], allow_reconnect=False
+            )
+
+    @async_test
+    async def test_default_connect_using_tls_scheme_in_url(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with default certs.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect('tls://127.0.0.1:4224', allow_reconnect=False)
+
+    @async_test
+    async def test_connect_tls_with_custom_hostname(self):
+        nc = NATS()
+
+        # Will attempt to connect using TLS with an invalid hostname.
+        with self.assertRaises(ssl.SSLError):
+            await nc.connect(
+                servers=['nats://127.0.0.1:4224'],
+                tls=self.ssl_ctx,
+                tls_hostname="nats.example",
+                allow_reconnect=False,
+            )
+
+    @async_test
+    async def test_subscribe(self):
+        nc = NATS()
+        msgs = []
+
+        async def subscription_handler(msg):
+            msgs.append(msg)
+
+        payload = b'hello world'
+        await nc.connect(servers=['nats://127.0.0.1:4224'], tls=self.ssl_ctx)
+        sub = await nc.subscribe("foo", cb=subscription_handler)
+        await nc.publish("foo", payload)
+        await nc.publish("bar", payload)
+
+        with self.assertRaises(nats.errors.BadSubjectError):
+            await nc.publish("", b'')
+
+        # Wait a bit for message to be received.
+        await asyncio.sleep(0.2)
+
+        self.assertEqual(1, len(msgs))
+        msg = msgs[0]
+        self.assertEqual('foo', msg.subject)
+        self.assertEqual('', msg.reply)
+        self.assertEqual(payload, msg.data)
+        self.assertEqual(1, sub._received)
+        await nc.close()
 
 class ClusterDiscoveryTest(ClusteringTestCase):
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import asyncio
 import http.client
 import json
 import ssl
+import os
 import time
 import unittest
 import urllib
@@ -1801,7 +1802,10 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
 
     @async_test
     async def test_connect(self):
-        nc = await nats.connect('nats://127.0.0.1:4224', tls=self.ssl_ctx)
+        if os.environ['NATS_SERVER_VERSION'] != 'main':
+            pytest.skip("test requires nats-server@main")
+
+        nc = await nats.connect('nats://127.0.0.1:4224', tls=self.ssl_ctx, tls_handshake_first=True)
         self.assertEqual(nc._server_info['max_payload'], nc.max_payload)
         self.assertTrue(nc._server_info['tls_required'])
         self.assertTrue(nc._server_info['tls_verify'])
@@ -1813,24 +1817,33 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
 
     @async_test
     async def test_default_connect_using_tls_scheme(self):
+        if os.environ['NATS_SERVER_VERSION'] != 'main':
+            pytest.skip("test requires nats-server@main")
+
         nc = NATS()
 
         # Will attempt to connect using TLS with default certs.
         with self.assertRaises(ssl.SSLError):
             await nc.connect(
-                servers=['tls://127.0.0.1:4224'], allow_reconnect=False
+                servers=['tls://127.0.0.1:4224'], allow_reconnect=False, tls_handshake_first=True,
             )
 
     @async_test
     async def test_default_connect_using_tls_scheme_in_url(self):
+        if os.environ['NATS_SERVER_VERSION'] != 'main':
+            pytest.skip("test requires nats-server@main")
+
         nc = NATS()
 
         # Will attempt to connect using TLS with default certs.
         with self.assertRaises(ssl.SSLError):
-            await nc.connect('tls://127.0.0.1:4224', allow_reconnect=False)
+            await nc.connect('tls://127.0.0.1:4224', allow_reconnect=False, tls_handshake_first=True)
 
     @async_test
     async def test_connect_tls_with_custom_hostname(self):
+        if os.environ['NATS_SERVER_VERSION'] != 'main':
+            pytest.skip("test requires nats-server@main")
+
         nc = NATS()
 
         # Will attempt to connect using TLS with an invalid hostname.
@@ -1839,11 +1852,15 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
                 servers=['nats://127.0.0.1:4224'],
                 tls=self.ssl_ctx,
                 tls_hostname="nats.example",
+                tls_handshake_first=True,
                 allow_reconnect=False,
             )
 
     @async_test
     async def test_subscribe(self):
+        if os.environ['NATS_SERVER_VERSION'] != 'main':
+            pytest.skip("test requires nats-server@main")
+
         nc = NATS()
         msgs = []
 
@@ -1851,7 +1868,7 @@ class ClientTLSHandshakeFirstTest(TLSServerHandshakeFirstTestCase):
             msgs.append(msg)
 
         payload = b'hello world'
-        await nc.connect(servers=['nats://127.0.0.1:4224'], tls=self.ssl_ctx)
+        await nc.connect(servers=['nats://127.0.0.1:4224'], tls=self.ssl_ctx, tls_handshake_first=True)
         sub = await nc.subscribe("foo", cb=subscription_handler)
         await nc.publish("foo", payload)
         await nc.publish("bar", payload)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -259,7 +259,10 @@ class TLSServerHandshakeFirstTestCase(unittest.TestCase):
         super().setUp()
         self.loop = asyncio.new_event_loop()
 
-        self.natsd = NATSD(port=4224, config_file=get_config_file('conf/tls_handshake_first.conf'))
+        self.natsd = NATSD(
+            port=4224,
+            config_file=get_config_file('conf/tls_handshake_first.conf')
+        )
         start_natsd(self.natsd)
 
         self.ssl_ctx = ssl.create_default_context(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -253,6 +253,30 @@ class TLSServerTestCase(unittest.TestCase):
         self.loop.close()
 
 
+class TLSServerHandshakeFirstTestCase(unittest.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.loop = asyncio.new_event_loop()
+
+        self.natsd = NATSD(port=4224, config_file=get_config_file('conf/tls_handshake_first.conf'))
+        start_natsd(self.natsd)
+
+        self.ssl_ctx = ssl.create_default_context(
+            purpose=ssl.Purpose.SERVER_AUTH
+        )
+        # self.ssl_ctx.protocol = ssl.PROTOCOL_TLSv1_2
+        self.ssl_ctx.load_verify_locations(get_config_file('certs/ca.pem'))
+        self.ssl_ctx.load_cert_chain(
+            certfile=get_config_file('certs/client-cert.pem'),
+            keyfile=get_config_file('certs/client-key.pem')
+        )
+
+    def tearDown(self):
+        self.natsd.stop()
+        self.loop.close()
+
+
 class MultiTLSServerAuthTestCase(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
This supported in the main server at the moment.

```python
            await nc.connect(
                servers=['tls://127.0.0.1:4224'],
                tls_handshake_first=True,
            )
```