### PR TITLE
JetStream updates and fixes

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -65,7 +65,7 @@ from .subscription import (
 )
 from .transport import TcpTransport, Transport, WebSocketTransport
 
-__version__ = '2.5.0'
+__version__ = '2.6.0'
 __lang__ = 'python3'
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -50,6 +50,7 @@ from nats.protocol import command as prot_command
 from nats.protocol.parser import (
     AUTHORIZATION_VIOLATION,
     PERMISSIONS_ERR,
+    PING,
     PONG,
     STALE_CONNECTION,
     Parser,
@@ -1705,7 +1706,7 @@ class Client:
 
         # Process flow control messages in case of using a JetStream context.
         ctrl_msg = None
-        fcReply = None
+        fc_reply = None
         if sub._jsi:
             #########################################
             #                                       #
@@ -1713,6 +1714,7 @@ class Client:
             #                                       #
             #########################################
             jsi = sub._jsi
+            jsi._active = True
             if hdr:
                 ctrl_msg = self._is_control_message(data, hdr)
 
@@ -1720,7 +1722,7 @@ class Client:
                 # so, the value is the FC reply to send a nil message to.
                 # We will send it at the end of this function.
                 if ctrl_msg and ctrl_msg.startswith("Idle"):
-                    fcReply = hdr.get(nats.js.api.Header.CONSUMER_STALLED)
+                    fc_reply = hdr.get(nats.js.api.Header.CONSUMER_STALLED)
 
             # OrderedConsumer: checkOrderedMsgs
             if not ctrl_msg and jsi._ordered and msg.reply:
@@ -1788,15 +1790,15 @@ class Client:
             # DATA message that was received before this flow control message, which
             # has sequence `jsi.fciseq`. However, it is possible that this message
             # has already been delivered, in that case, we need to send the FC reply now.
-            if sub.delivered >= sub._jsi._fciseq:
-                fcReply = msg.reply
+            if sub._jsi.get_js_delivered() >= sub._jsi._fciseq:
+                fc_reply = msg.reply
             else:
                 # Schedule a reply after the previous message is delivered.
                 sub._jsi.schedule_flow_control_response(msg.reply)
 
         # Handle flow control response.
-        if fcReply:
-            await self.publish(fcReply)
+        if fc_reply:
+            await self.publish(fc_reply)
 
         if ctrl_msg and not msg.reply and ctrl_msg.startswith("Idle"):
             if sub._jsi:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -588,7 +588,7 @@ class JetStreamContext(JetStreamManager):
                     self._active = False
                     if not active:
                         if self._ordered:
-                            did_reset = await self.reset_ordered_consumer(
+                            await self.reset_ordered_consumer(
                                 self._sseq + 1
                             )
                 except asyncio.CancelledError:
@@ -600,13 +600,12 @@ class JetStreamContext(JetStreamManager):
                     if self._conn.is_closed:
                         break
 
-                    if (self._fciseq -
-                            self._psub._pending_queue.qsize()) >= self._fcd:
+                    if (self._fciseq - self._psub._pending_queue.qsize()) >= self._fcd:
                         fc_reply = self._fcr
                         try:
                             if fc_reply:
                                 await self._conn.publish(fc_reply)
-                        except Exception as e:
+                        except Exception:
                             pass
                         self._fcr = None
                         self._fcd = 0

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -771,7 +771,7 @@ class JetStreamContext(JetStreamManager):
             next_msg can be used to retrieve the next message from a stream of messages using
             await syntax, this only works when not passing a callback on `subscribe`::
             """
-            msg = await super().next_msg(timeout)
+            msg = await self._sub.next_msg(timeout)
 
             # In case there is a flow control reply present need to handle here.
             if self._sub and self._sub._jsi:

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -298,7 +298,8 @@ class KeyValue:
 
         def __init__(self, js):
             self._js = js
-            self._updates: asyncio.Queue[KeyValue.Entry | None] = asyncio.Queue(maxsize=256)
+            self._updates: asyncio.Queue[KeyValue.Entry
+                                         | None] = asyncio.Queue(maxsize=256)
             self._sub = None
             self._pending: Optional[int] = None
 

--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -298,8 +298,7 @@ class KeyValue:
 
         def __init__(self, js):
             self._js = js
-            self._updates: asyncio.Queue[KeyValue.Entry
-                                         | None] = asyncio.Queue(maxsize=256)
+            self._updates: asyncio.Queue[KeyValue.Entry | None] = asyncio.Queue(maxsize=256)
             self._sub = None
             self._pending: Optional[int] = None
 

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -64,6 +64,8 @@ class JetStreamManager:
         info = await self._api_request(
             req_sub, req_data.encode(), timeout=self._timeout
         )
+        if not info['streams']:
+            raise NotFoundError
         return info['streams'][0]
 
     async def stream_info(self, name: str) -> api.StreamInfo:

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2021 The NATS Authors
+# Copyright 2016-2023 The NATS Authors
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -63,7 +63,7 @@ ERR_OP_SIZE = len(ERR_OP)
 # States
 AWAITING_CONTROL_LINE = 1
 AWAITING_MSG_PAYLOAD = 2
-MAX_CONTROL_LINE_SIZE = 1024
+MAX_CONTROL_LINE_SIZE = 4096
 
 # Protocol Errors
 STALE_CONNECTION = "stale connection"

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -165,10 +165,9 @@ class Parser:
                     del self.buf[:info.end()]
                     continue
 
-                if len(self.buf
-                       ) < MAX_CONTROL_LINE_SIZE and _CRLF_ in self.buf:
+                if len(self.buf) < MAX_CONTROL_LINE_SIZE and _CRLF_ in self.buf:
                     # FIXME: By default server uses a max protocol
-                    # line of 1024 bytes but it can be tuned in latest
+                    # line of 4096 bytes but it can be tuned in latest
                     # releases, in that case we won't reach here but
                     # client ping/pong interval would disconnect
                     # eventually.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # These are here for GitHub's dependency graph and help with setuptools support in some environments.
 setup(
     name="nats-py",
-    version='2.5.0',
+    version='2.6.0',
     license='Apache 2 License',
     extras_require={
         'nkeys': ['nkeys'],

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1903,7 +1903,7 @@ class OrderedConsumerTest(SingleJetStreamServerTestCase):
 
         tasks = []
         async def producer():
-            mlen = 50 * 1024 * 1024
+            mlen = 10 * 1024 * 1024
             msg = b'A' * mlen
 
             # Send it in chunks

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -595,7 +595,7 @@ def async_test(test_case_fun, timeout=5):
     return wrapper
 
 
-def async_long_test(test_case_fun, timeout=10):
+def async_long_test(test_case_fun, timeout=20):
 
     @wraps(test_case_fun)
     def wrapper(test_case, *args, **kw):


### PR DESCRIPTION
- Add support to ephemeral pull consumers (#412)
- Fix ordered consumer implementation not being recreated when deleted (#510)
- Fix accounting issue pending data which would have caused slow consumers on ordered consumers using `next_msg`
- Update default max control line to 4K as in the server since v2.2
- Fix subscribe to missing stream not raising NotFoundError (#499 )