### PR TITLE
Added support to export subjects when fetching js.stream_info()

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -181,6 +181,7 @@ class StreamState(Base):
     deleted: Optional[List[int]] = None
     num_deleted: Optional[int] = None
     lost: Optional[LostStreamData] = None
+    subjects: Optional[Dict[str, int]] = None
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -68,12 +68,13 @@ class JetStreamManager:
             raise NotFoundError
         return info['streams'][0]
 
-    async def stream_info(self, name: str) -> api.StreamInfo:
+    async def stream_info(self, name: str, subjects_filter: str = '>') -> api.StreamInfo:
         """
         Get the latest StreamInfo by stream name.
         """
+        req_data = json.dumps({"subjects_filter": subjects_filter})
         resp = await self._api_request(
-            f"{self._prefix}.STREAM.INFO.{name}", timeout=self._timeout
+            f"{self._prefix}.STREAM.INFO.{name}", req_data.encode(), timeout=self._timeout
         )
         return api.StreamInfo.from_response(resp)
 


### PR DESCRIPTION
I added support for the python client to query subjects held in a stream.

The PR adds a field `subjects` to the js StreamState class (js/api.py)
and populates it through the JetStreamManager.stream_info() method.  It also adds a `subject_filter` keyword parameter to stream_info()