### PR TITLE
Add subject_transform field to StreamConfig

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -223,6 +223,13 @@ class RePublish(Base):
 
 
 @dataclass
+class SubjectTransform(Base):
+    """Subject transform to apply to matching messages."""
+    src: str
+    dest: str
+
+
+@dataclass
 class StreamConfig(Base):
     """
     StreamConfig represents the configuration of a stream.
@@ -253,6 +260,7 @@ class StreamConfig(Base):
 
     # Allow republish of the message after being sequenced and stored.
     republish: Optional[RePublish] = None
+    subject_transform: Optional[SubjectTransform] = None
 
     # Allow higher performance, direct access to get individual messages. E.g. KeyValue
     allow_direct: Optional[bool] = None
@@ -268,6 +276,7 @@ class StreamConfig(Base):
         cls._convert(resp, 'mirror', StreamSource)
         cls._convert(resp, 'sources', StreamSource)
         cls._convert(resp, 'republish', RePublish)
+        cls._convert(resp, 'subject_transform', SubjectTransform)
         return super().from_response(resp)
 
     def as_dict(self) -> Dict[str, object]:


### PR DESCRIPTION
# Problem

The `StreamConfig` dataclass does not define a field named `subject_transform`.

The subject transform feature has been mentioned in issue https://github.com/nats-io/nats.py/issues/414

# Proposed changes

Add the `subject_transform` field to the `StreamConfig` dataclass:

```python
from nats.js.api import SubjectTransform


cfg = StreamConfig(
    name="demo",
    subjects=["one.two.three"],
    subject_transform=SubjectTransform(src=">", dest="uno.>")
)
```

>Example is taken from the [the ADR](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-30.md#example-transforms)