### PR TITLE
Add compression field in StreamConfig

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -211,6 +211,19 @@ class DiscardPolicy(str, Enum):
     NEW = "new"
 
 
+class Compression(str, Enum):
+    """
+    If stream is file-based and a compression algorithm is specified,
+    the stream data will be compressed on disk.
+
+    Valid options are nothing (empty string) or s2 for Snappy compression.
+    Introduced in nats-server 2.10.0.
+    """
+
+    NONE = ""
+    S2 = "s2"
+
+
 @dataclass
 class RePublish(Base):
     """
@@ -259,6 +272,9 @@ class StreamConfig(Base):
 
     # Allow higher performance and unified direct access for mirrors as well.
     mirror_direct: Optional[bool] = None
+
+    # Allow compressing messages.
+    compression: Optional[Compression] = None
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -274,7 +274,7 @@ class StreamConfig(Base):
     mirror_direct: Optional[bool] = None
 
     # Allow compressing messages.
-    compression: Optional[Compression] = None
+    compression: Optional[StoreCompression] = None
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -211,7 +211,7 @@ class DiscardPolicy(str, Enum):
     NEW = "new"
 
 
-class Compression(str, Enum):
+class StoreCompression(str, Enum):
     """
     If stream is file-based and a compression algorithm is specified,
     the stream data will be compressed on disk.


### PR DESCRIPTION
# Problem

The `StreamConfig` dataclass does not define a field named `compression`.

The compression feature has been mentioned in issue https://github.com/nats-io/nats.py/issues/520

# Proposed changes

Add the `compression` field to the `StreamConfig` dataclass:

```python
from nats.js.api import StoreCompression, StreamConfig


cfg = StreamConfig(
    name="demo",
    subjects=["one.two.three"],
    compression=StoreCompression.S2
)
```

According to the docs:

> If file-based and a compression algorithm is specified, the stream data will be compressed on disk. Valid options are nothing (empty string) or s2 for Snappy compression.

This PR introduces the `StoreCompression` enum which can take two values:

```python
class StoreCompression(str, Enum):
    NONE = ""
    S2 = "s2"
```

For backward compatibility, this field is optional and set to `None` by default.