### PR TITLE
Add async publishing to JetStream

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1023,23 +1023,21 @@ class Client:
             msg = await self._request_new_style(
                 subject, payload, timeout=timeout, headers=headers
             )
-        if msg.headers and msg.headers.get(nats.js.api.Header.STATUS
-                                           ) == NO_RESPONDERS_STATUS:
-            raise errors.NoRespondersError
         return msg
 
-    async def _request_new_style(
+    async def _request_future(
         self,
         subject: str,
         payload: bytes,
         timeout: float = 1,
         headers: Optional[Dict[str, Any]] = None,
-    ) -> Msg:
+    ) -> asyncio.Future[Msg]:
         if self.is_draining_pubs:
             raise errors.ConnectionDrainingError
 
         if not self._resp_sub_prefix:
             await self._init_request_sub()
+
         assert self._resp_sub_prefix
 
         # Use a new NUID + couple of unique token bytes to identify the request,
@@ -1054,22 +1052,38 @@ class Client:
             subject, payload, reply=inbox.decode(), headers=headers
         )
 
-        # Wait for the response or give up on timeout.
-        try:
-            msg = await asyncio.wait_for(future, timeout)
-            return msg
-        except asyncio.TimeoutError:
+        async def wait_for_future() -> Msg:
             try:
-                # Double check that the token is there already.
-                self._resp_map.pop(token.decode())
-            except KeyError:
-                await self._error_cb(
-                    errors.
-                    Error(f"nats: missing response token '{token.decode()}'")
-                )
+                msg = await asyncio.wait_for(future, timeout)
+                if msg.headers and msg.headers.get(nats.js.api.Header.STATUS
+                                                   ) == NO_RESPONDERS_STATUS:
+                    raise errors.NoRespondersError
 
-            future.cancel()
-            raise errors.TimeoutError
+                return msg
+            except asyncio.TimeoutError:
+                try:
+                    # Double check that the token is there already.
+                    self._resp_map.pop(token.decode())
+                except KeyError:
+                    await self._error_cb(
+                        errors.Error(f"nats: missing response token '{token}'")
+                    )
+
+                future.cancel()
+                raise errors.TimeoutError
+
+        return asyncio.ensure_future(wait_for_future())
+
+    async def _request_new_style(
+        self,
+        subject: str,
+        payload: bytes,
+        timeout: float = 1,
+        headers: Optional[Dict[str, Any]] = None,
+    ) -> Msg:
+        future = await self._request_future(subject, payload, timeout, headers)
+        msg = await future
+        return msg
 
     def new_inbox(self) -> str:
         """

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -189,7 +189,6 @@ class JetStreamContext(JetStreamManager):
         self,
         subject: str,
         payload: bytes = b'',
-        timeout: Optional[float] = None,
         stream: Optional[str] = None,
         headers: Optional[Dict] = None,
     ) -> asyncio.Future[api.PubAck]:
@@ -205,9 +204,6 @@ class JetStreamContext(JetStreamManager):
         assert self._paf_sub_prefix
 
         hdr = headers
-        if timeout is None:
-            timeout = self._timeout
-
         if stream is not None:
             hdr = hdr or {}
             hdr[api.Header.EXPECTED_STREAM] = stream

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -227,6 +227,12 @@ class JetStreamContext(JetStreamManager):
 
         return future
 
+    async def publish_async_completed(self) -> None:
+        """
+        waits for all currently pending async publishes to be completed.
+        """
+        await asyncio.gather(*self._paf_map.values(), return_exceptions=True)
+
     async def subscribe(
         self,
         subject: str,

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -90,7 +90,7 @@ class JetStreamContext(JetStreamManager):
         prefix: str = api.DEFAULT_PREFIX,
         domain: Optional[str] = None,
         timeout: float = 5,
-        pending_acks_limit: int = 4096,
+        pending_acks_limit: int = 4000,
     ) -> None:
         self._prefix = prefix
         if domain is not None:

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -112,7 +112,6 @@ class JetStreamContext(JetStreamManager):
         )
 
     async def _init_paf_sub(self) -> None:
-        print("SETTING UP PAF SUB")
         self._paf_map = {}
 
         self._paf_sub_prefix = self._nc._inbox_prefix[:]
@@ -127,7 +126,6 @@ class JetStreamContext(JetStreamManager):
         )
 
     async def _paf_sub_callback(self, msg: Msg) -> None:
-        print("PAF SUB CALLBACK", msg)
         token = msg.subject[len(self._nc._inbox_prefix) + 22 + 2:]
         try:
             paf = self._paf_map.get(token)
@@ -136,7 +134,6 @@ class JetStreamContext(JetStreamManager):
 
             # Handle no responders
             if msg.headers and msg.headers.get(api.Header.STATUS) == NO_RESPONDERS_STATUS:
-                print("RAISING NO RESPONDER")
                 paf.set_exception(nats.js.errors.NoStreamResponseError)
                 return
 

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -223,6 +223,13 @@ class JetStreamContext(JetStreamManager):
 
         return future
 
+    async def publish_async_pending(self) -> int:
+        """
+        returns the number of pending async publishes.
+        """
+        return len(self._paf_map)
+
+
     async def publish_async_completed(self) -> None:
         """
         waits for all currently pending async publishes to be completed.

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -132,6 +132,7 @@ class NoStreamResponseError(Error):
     def __str__(self) -> str:
         return "nats: no response from stream"
 
+
 class TooManyStalledMsgsError(Error):
     """
     Raised when too many outstanding async messages are waiting for ack.
@@ -139,6 +140,7 @@ class TooManyStalledMsgsError(Error):
 
     def __str__(self) -> str:
         return "nats: stalled with too many outstanding async published messages"
+
 
 class FetchTimeoutError(nats.errors.TimeoutError):
     """

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -132,6 +132,13 @@ class NoStreamResponseError(Error):
     def __str__(self) -> str:
         return "nats: no response from stream"
 
+class TooManyStalledMsgsError(Error):
+    """
+    Raised when too many outstanding async messages are waiting for ack.
+    """
+
+    def __str__(self) -> str:
+        return "nats: stalled with too many outstanding async published messages"
 
 class FetchTimeoutError(nats.errors.TimeoutError):
     """

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -135,7 +135,7 @@ class NoStreamResponseError(Error):
 
 class TooManyStalledMsgsError(Error):
     """
-    Raised when too many outstanding async messages are waiting for ack.
+    Raised when too many outstanding async published messages are waiting for ack.
     """
 
     def __str__(self) -> str:

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -84,7 +84,7 @@ class PublishTest(SingleJetStreamServerTestCase):
     async def test_publish_async(self):
         nc = NATS()
         await nc.connect()
-        js = nc.jetstream(pending_acks_limit=10)
+        js = nc.jetstream(publish_async_max_pending=10)
 
         # Ensure that awaiting pending when there are none is fine.
         await js.publish_async_completed()


### PR DESCRIPTION
- Add a `JetStreamContext.publish_async` method which does not await for ack.
- Add a `JetStreamContext.publish_async_completed` method which awaits for all pending publish acks.
- Add a `JetStreamContext.publish_async_pending` method which returns the number of pending acks.