### PR TITLE
Fix stream info pagination and add test for empty stream list

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields, replace
 from enum import Enum
-from typing import Any, Dict, Optional, TypeVar, List
+from typing import Any, Dict, Optional, TypeVar, List, Iterable, Iterator
 
 _NANOSECOND = 10**9
 
@@ -377,6 +377,29 @@ class StreamInfo(Base):
         cls._convert(resp, 'sources', StreamSourceInfo)
         cls._convert(resp, 'cluster', ClusterInfo)
         return super().from_response(resp)
+
+
+@dataclass
+class StreamsListIterator(Iterable):
+    """
+    StreamsListIterator is an iterator for streams list responses from JetStream.
+    """
+    def __init__(self, offset: int, total: int, streams: List[Dict[str, any]]) -> None:
+        self.offset = offset
+        self.total = total
+        self.streams = streams
+        self._index = 0
+
+    def __iter__(self) -> Iterator[StreamInfo]:
+        return self
+
+    def __next__(self) -> StreamInfo:
+        if self._index < len(self.streams):
+            stream_info = StreamInfo.from_response(self.streams[self._index])
+            self._index += 1
+            return stream_info
+        else:
+            raise StopIteration
 
 
 class AckPolicy(str, Enum):

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1252,6 +1252,24 @@ class JSMTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_jsm_stream_management_with_offset(self):
+        nc = NATS()
+        await nc.connect()
+        js = nc.jetstream()
+        jsm = nc.jsm()
+
+        for i in range(300):
+            await jsm.add_stream(name=f"stream_{i}")
+
+        streams_page_1 = await jsm.streams_info(offset=0)
+        streams_page_2 = await jsm.streams_info(offset=256)
+
+        assert len(streams_page_1) == 256
+        assert len(streams_page_2) == 44
+
+        await nc.close()
+
+    @async_test
     async def test_jsm_consumer_management(self):
         nc = NATS()
         await nc.connect()


### PR DESCRIPTION
Fix:  streams_info Method Only Returns First Page of Streams #591 

Observed behavior
The method only returns the first page of streams (up to 256 streams) and does not paginate through the remaining streams.

Expected behavior
This merge request adds a test to verify that the `streams_info` method correctly handles offsets, ensuring proper pagination when retrieving streams. Additionally, it implements the necessary changes to the `streams_info` method to support pagination.

- Added a test to verify the `streams_info` method handles offsets correctly.
- Implemented pagination in the `streams_info` method to support retrieving streams with an offset.
- Implemented `streams_info_iterator` method to retrieve a list of streams as an iterator.
- Created `StreamsListIterator` class to handle iteration over the list of streams.