### PR TITLE
Validate stream name in `add_stream` method

### DIFF
--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -98,11 +98,11 @@ class JetStreamManager:
 
         # Validate stream name
         invalid_chars = set(".*>/\\")
-        if (
-            any(char in stream_name for char in invalid_chars) or  # No invalid characters
-            any(char.isspace() for char in stream_name) or  # No whitespace
-            not stream_name.isprintable()  # Must be printable
-        ):
+        has_invalid_chars = any(char in stream_name for char in invalid_chars)
+        has_whitespace = any(char.isspace() for char in stream_name)
+        is_not_printable = not stream_name.isprintable()
+
+        if has_invalid_chars or has_whitespace or is_not_printable:
             raise ValueError(
                 f"nats: stream name ({stream_name}) is invalid. Names cannot contain whitespace, '.', '*', '>', "
                 "path separators (forward or backward slash), or non-printable characters."

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -91,17 +91,17 @@ class JetStreamManager:
         if config is None:
             config = api.StreamConfig()
         config = config.evolve(**params)
-        
+
         stream_name = config.name
         if stream_name is None:
             raise ValueError("nats: stream name is required")
-        
+
         # Validate stream name
         invalid_chars = set(".*>/\\")
         if (
-            any(char in stream_name for char in invalid_chars)  # No invalid characters
-            or any(char.isspace() for char in stream_name)  # No whitespace
-            or not stream_name.isprintable()  # Must be printable
+            any(char in stream_name for char in invalid_chars) or  # No invalid characters
+            any(char.isspace() for char in stream_name) or  # No whitespace
+            not stream_name.isprintable()  # Must be printable
         ):
             raise ValueError(
                 f"nats: stream name ({stream_name}) is invalid. Names cannot contain whitespace, '.', '*', '>', "


### PR DESCRIPTION
Fixes #471, and hopefully saves someone else time who would encounter the same issue. :-)

A less verbose error message / more succinct "valid name" rule may be preferable. So, feedback or suggestions welcome. I just went off of what I found in these docs: https://docs.nats.io/nats-concepts/jetstream/streams#configuration:

```md
Names cannot contain whitespace, `.`, `*`, `>`, path separators (forward or backwards slash), and non-printable characters.
```