### PR TITLE
Add isort check to CICD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
           pipenv install --dev
           bash ./scripts/install_nats.sh
 
+      - name: Run isort check
+        run: pipenv run isort --check-only --diff .
+
       - name: Run tests
         run: |
           pipenv run flake8 --ignore=W391 ./nats/js/

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,5 @@
+[settings]
+combine_as_imports = true
+multi_line_output = 3
+include_trailing_comma = true
+src_paths = ["nats", "tests"]

--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,4 @@ pytest-cov = "*"
 yapf = "*"
 toml = "*"  # see https://github.com/google/yapf/issues/936
 exceptiongroup = "*"
+isort = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1220820085e149c2e02ab3ec1c792084d31d4c4fae3a09c39e5864ab1800abf9"
+            "sha256": "f8589a2c02ef93a3fcfbd81924d98f8f4b9921c48df05446e94b309373d200b6"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -20,85 +20,107 @@
                 "toml"
             ],
             "hashes": [
-                "sha256:06a9a2be0b5b576c3f18f1a241f0473575c4a26021b52b2a85263a00f034d51f",
-                "sha256:06fb182e69f33f6cd1d39a6c597294cff3143554b64b9825d1dc69d18cc2fff2",
-                "sha256:0a5f9e1dbd7fbe30196578ca36f3fba75376fb99888c395c5880b355e2875f8a",
-                "sha256:0e1f928eaf5469c11e886fe0885ad2bf1ec606434e79842a879277895a50942a",
-                "sha256:171717c7cb6b453aebac9a2ef603699da237f341b38eebfee9be75d27dc38e01",
-                "sha256:1e9d683426464e4a252bf70c3498756055016f99ddaec3774bf368e76bbe02b6",
-                "sha256:201e7389591af40950a6480bd9edfa8ed04346ff80002cec1a66cac4549c1ad7",
-                "sha256:245167dd26180ab4c91d5e1496a30be4cd721a5cf2abf52974f965f10f11419f",
-                "sha256:2aee274c46590717f38ae5e4650988d1af340fe06167546cc32fe2f58ed05b02",
-                "sha256:2e07b54284e381531c87f785f613b833569c14ecacdcb85d56b25c4622c16c3c",
-                "sha256:31563e97dae5598556600466ad9beea39fb04e0229e61c12eaa206e0aa202063",
-                "sha256:33d6d3ea29d5b3a1a632b3c4e4f4ecae24ef170b0b9ee493883f2df10039959a",
-                "sha256:3d376df58cc111dc8e21e3b6e24606b5bb5dee6024f46a5abca99124b2229ef5",
-                "sha256:419bfd2caae268623dd469eff96d510a920c90928b60f2073d79f8fe2bbc5959",
-                "sha256:48c19d2159d433ccc99e729ceae7d5293fbffa0bdb94952d3579983d1c8c9d97",
-                "sha256:49969a9f7ffa086d973d91cec8d2e31080436ef0fb4a359cae927e742abfaaa6",
-                "sha256:52edc1a60c0d34afa421c9c37078817b2e67a392cab17d97283b64c5833f427f",
-                "sha256:537891ae8ce59ef63d0123f7ac9e2ae0fc8b72c7ccbe5296fec45fd68967b6c9",
-                "sha256:54b896376ab563bd38453cecb813c295cf347cf5906e8b41d340b0321a5433e5",
-                "sha256:58c2ccc2f00ecb51253cbe5d8d7122a34590fac9646a960d1430d5b15321d95f",
-                "sha256:5b7540161790b2f28143191f5f8ec02fb132660ff175b7747b95dcb77ac26562",
-                "sha256:5baa06420f837184130752b7c5ea0808762083bf3487b5038d68b012e5937dbe",
-                "sha256:5e330fc79bd7207e46c7d7fd2bb4af2963f5f635703925543a70b99574b0fea9",
-                "sha256:61b9a528fb348373c433e8966535074b802c7a5d7f23c4f421e6c6e2f1697a6f",
-                "sha256:63426706118b7f5cf6bb6c895dc215d8a418d5952544042c8a2d9fe87fcf09cb",
-                "sha256:6d040ef7c9859bb11dfeb056ff5b3872436e3b5e401817d87a31e1750b9ae2fb",
-                "sha256:6f48351d66575f535669306aa7d6d6f71bc43372473b54a832222803eb956fd1",
-                "sha256:7ee7d9d4822c8acc74a5e26c50604dff824710bc8de424904c0982e25c39c6cb",
-                "sha256:81c13a1fc7468c40f13420732805a4c38a105d89848b7c10af65a90beff25250",
-                "sha256:8d13c64ee2d33eccf7437961b6ea7ad8673e2be040b4f7fd4fd4d4d28d9ccb1e",
-                "sha256:8de8bb0e5ad103888d65abef8bca41ab93721647590a3f740100cd65c3b00511",
-                "sha256:8fa03bce9bfbeeef9f3b160a8bed39a221d82308b4152b27d82d8daa7041fee5",
-                "sha256:924d94291ca674905fe9481f12294eb11f2d3d3fd1adb20314ba89e94f44ed59",
-                "sha256:975d70ab7e3c80a3fe86001d8751f6778905ec723f5b110aed1e450da9d4b7f2",
-                "sha256:976b9c42fb2a43ebf304fa7d4a310e5f16cc99992f33eced91ef6f908bd8f33d",
-                "sha256:9e31cb64d7de6b6f09702bb27c02d1904b3aebfca610c12772452c4e6c21a0d3",
-                "sha256:a342242fe22407f3c17f4b499276a02b01e80f861f1682ad1d95b04018e0c0d4",
-                "sha256:a3d33a6b3eae87ceaefa91ffdc130b5e8536182cd6dfdbfc1aa56b46ff8c86de",
-                "sha256:a895fcc7b15c3fc72beb43cdcbdf0ddb7d2ebc959edac9cef390b0d14f39f8a9",
-                "sha256:afb17f84d56068a7c29f5fa37bfd38d5aba69e3304af08ee94da8ed5b0865833",
-                "sha256:b1c546aca0ca4d028901d825015dc8e4d56aac4b541877690eb76490f1dc8ed0",
-                "sha256:b29019c76039dc3c0fd815c41392a044ce555d9bcdd38b0fb60fb4cd8e475ba9",
-                "sha256:b46517c02ccd08092f4fa99f24c3b83d8f92f739b4657b0f146246a0ca6a831d",
-                "sha256:b7aa5f8a41217360e600da646004f878250a0d6738bcdc11a0a39928d7dc2050",
-                "sha256:b7b4c971f05e6ae490fef852c218b0e79d4e52f79ef0c8475566584a8fb3e01d",
-                "sha256:ba90a9563ba44a72fda2e85302c3abc71c5589cea608ca16c22b9804262aaeb6",
-                "sha256:cb017fd1b2603ef59e374ba2063f593abe0fc45f2ad9abdde5b4d83bd922a353",
-                "sha256:d22656368f0e6189e24722214ed8d66b8022db19d182927b9a248a2a8a2f67eb",
-                "sha256:d2c2db7fd82e9b72937969bceac4d6ca89660db0a0967614ce2481e81a0b771e",
-                "sha256:d39b5b4f2a66ccae8b7263ac3c8170994b65266797fb96cbbfd3fb5b23921db8",
-                "sha256:d62a5c7dad11015c66fbb9d881bc4caa5b12f16292f857842d9d1871595f4495",
-                "sha256:e7d9405291c6928619403db1d10bd07888888ec1abcbd9748fdaa971d7d661b2",
-                "sha256:e84606b74eb7de6ff581a7915e2dab7a28a0517fbe1c9239eb227e1354064dcd",
-                "sha256:eb393e5ebc85245347950143969b241d08b52b88a3dc39479822e073a1a8eb27",
-                "sha256:ebba1cd308ef115925421d3e6a586e655ca5a77b5bf41e02eb0e4562a111f2d1",
-                "sha256:ee57190f24fba796e36bb6d3aa8a8783c643d8fa9760c89f7a98ab5455fbf818",
-                "sha256:f2f67fe12b22cd130d34d0ef79206061bfb5eda52feb6ce0dba0644e20a03cf4",
-                "sha256:f6951407391b639504e3b3be51b7ba5f3528adbf1a8ac3302b687ecababf929e",
-                "sha256:f75f7168ab25dd93110c8a8117a22450c19976afbc44234cbf71481094c1b850",
-                "sha256:fdec9e8cbf13a5bf63290fc6013d216a4c7232efb51548594ca3631a7f13c3a3"
+                "sha256:06a737c882bd26d0d6ee7269b20b12f14a8704807a01056c80bb881a4b2ce6ca",
+                "sha256:07e2ca0ad381b91350c0ed49d52699b625aab2b44b65e1b4e02fa9df0e92ad2d",
+                "sha256:0c0420b573964c760df9e9e86d1a9a622d0d27f417e1a949a8a66dd7bcee7bc6",
+                "sha256:0dbde0f4aa9a16fa4d754356a8f2e36296ff4d83994b2c9d8398aa32f222f989",
+                "sha256:1125ca0e5fd475cbbba3bb67ae20bd2c23a98fac4e32412883f9bcbaa81c314c",
+                "sha256:13b0a73a0896988f053e4fbb7de6d93388e6dd292b0d87ee51d106f2c11b465b",
+                "sha256:166811d20dfea725e2e4baa71fffd6c968a958577848d2131f39b60043400223",
+                "sha256:170d444ab405852903b7d04ea9ae9b98f98ab6d7e63e1115e82620807519797f",
+                "sha256:1f4aa8219db826ce6be7099d559f8ec311549bfc4046f7f9fe9b5cea5c581c56",
+                "sha256:225667980479a17db1048cb2bf8bfb39b8e5be8f164b8f6628b64f78a72cf9d3",
+                "sha256:260933720fdcd75340e7dbe9060655aff3af1f0c5d20f46b57f262ab6c86a5e8",
+                "sha256:2bdb062ea438f22d99cba0d7829c2ef0af1d768d1e4a4f528087224c90b132cb",
+                "sha256:2c09f4ce52cb99dd7505cd0fc8e0e37c77b87f46bc9c1eb03fe3bc9991085388",
+                "sha256:3115a95daa9bdba70aea750db7b96b37259a81a709223c8448fa97727d546fe0",
+                "sha256:3e0cadcf6733c09154b461f1ca72d5416635e5e4ec4e536192180d34ec160f8a",
+                "sha256:3f1156e3e8f2872197af3840d8ad307a9dd18e615dc64d9ee41696f287c57ad8",
+                "sha256:4421712dbfc5562150f7554f13dde997a2e932a6b5f352edcce948a815efee6f",
+                "sha256:44df346d5215a8c0e360307d46ffaabe0f5d3502c8a1cefd700b34baf31d411a",
+                "sha256:502753043567491d3ff6d08629270127e0c31d4184c4c8d98f92c26f65019962",
+                "sha256:547f45fa1a93154bd82050a7f3cddbc1a7a4dd2a9bf5cb7d06f4ae29fe94eaf8",
+                "sha256:5621a9175cf9d0b0c84c2ef2b12e9f5f5071357c4d2ea6ca1cf01814f45d2391",
+                "sha256:609b06f178fe8e9f89ef676532760ec0b4deea15e9969bf754b37f7c40326dbc",
+                "sha256:645786266c8f18a931b65bfcefdbf6952dd0dea98feee39bd188607a9d307ed2",
+                "sha256:6878ef48d4227aace338d88c48738a4258213cd7b74fd9a3d4d7582bb1d8a155",
+                "sha256:6a89ecca80709d4076b95f89f308544ec8f7b4727e8a547913a35f16717856cb",
+                "sha256:6db04803b6c7291985a761004e9060b2bca08da6d04f26a7f2294b8623a0c1a0",
+                "sha256:6e2cd258d7d927d09493c8df1ce9174ad01b381d4729a9d8d4e38670ca24774c",
+                "sha256:6e81d7a3e58882450ec4186ca59a3f20a5d4440f25b1cff6f0902ad890e6748a",
+                "sha256:702855feff378050ae4f741045e19a32d57d19f3e0676d589df0575008ea5004",
+                "sha256:78b260de9790fd81e69401c2dc8b17da47c8038176a79092a89cb2b7d945d060",
+                "sha256:7bb65125fcbef8d989fa1dd0e8a060999497629ca5b0efbca209588a73356232",
+                "sha256:7dea0889685db8550f839fa202744652e87c60015029ce3f60e006f8c4462c93",
+                "sha256:8284cf8c0dd272a247bc154eb6c95548722dce90d098c17a883ed36e67cdb129",
+                "sha256:877abb17e6339d96bf08e7a622d05095e72b71f8afd8a9fefc82cf30ed944163",
+                "sha256:8929543a7192c13d177b770008bc4e8119f2e1f881d563fc6b6305d2d0ebe9de",
+                "sha256:8ae539519c4c040c5ffd0632784e21b2f03fc1340752af711f33e5be83a9d6c6",
+                "sha256:8f59d57baca39b32db42b83b2a7ba6f47ad9c394ec2076b084c3f029b7afca23",
+                "sha256:9054a0754de38d9dbd01a46621636689124d666bad1936d76c0341f7d71bf569",
+                "sha256:953510dfb7b12ab69d20135a0662397f077c59b1e6379a768e97c59d852ee51d",
+                "sha256:95cae0efeb032af8458fc27d191f85d1717b1d4e49f7cb226cf526ff28179778",
+                "sha256:9bc572be474cafb617672c43fe989d6e48d3c83af02ce8de73fff1c6bb3c198d",
+                "sha256:9c56863d44bd1c4fe2abb8a4d6f5371d197f1ac0ebdee542f07f35895fc07f36",
+                "sha256:9e0b2df163b8ed01d515807af24f63de04bebcecbd6c3bfeff88385789fdf75a",
+                "sha256:a09ece4a69cf399510c8ab25e0950d9cf2b42f7b3cb0374f95d2e2ff594478a6",
+                "sha256:a1ac0ae2b8bd743b88ed0502544847c3053d7171a3cff9228af618a068ed9c34",
+                "sha256:a318d68e92e80af8b00fa99609796fdbcdfef3629c77c6283566c6f02c6d6704",
+                "sha256:a4acd025ecc06185ba2b801f2de85546e0b8ac787cf9d3b06e7e2a69f925b106",
+                "sha256:a6d3adcf24b624a7b778533480e32434a39ad8fa30c315208f6d3e5542aeb6e9",
+                "sha256:a78d169acd38300060b28d600344a803628c3fd585c912cacc9ea8790fe96862",
+                "sha256:a95324a9de9650a729239daea117df21f4b9868ce32e63f8b650ebe6cef5595b",
+                "sha256:abd5fd0db5f4dc9289408aaf34908072f805ff7792632250dcb36dc591d24255",
+                "sha256:b06079abebbc0e89e6163b8e8f0e16270124c154dc6e4a47b413dd538859af16",
+                "sha256:b43c03669dc4618ec25270b06ecd3ee4fa94c7f9b3c14bae6571ca00ef98b0d3",
+                "sha256:b48f312cca9621272ae49008c7f613337c53fadca647d6384cc129d2996d1133",
+                "sha256:b5d7b556859dd85f3a541db6a4e0167b86e7273e1cdc973e5b175166bb634fdb",
+                "sha256:b9f222de8cded79c49bf184bdbc06630d4c58eec9459b939b4a690c82ed05657",
+                "sha256:c3c02d12f837d9683e5ab2f3d9844dc57655b92c74e286c262e0fc54213c216d",
+                "sha256:c44fee9975f04b33331cb8eb272827111efc8930cfd582e0320613263ca849ca",
+                "sha256:cf4b19715bccd7ee27b6b120e7e9dd56037b9c0681dcc1adc9ba9db3d417fa36",
+                "sha256:d0c212c49b6c10e6951362f7c6df3329f04c2b1c28499563d4035d964ab8e08c",
+                "sha256:d3296782ca4eab572a1a4eca686d8bfb00226300dcefdf43faa25b5242ab8a3e",
+                "sha256:d85f5e9a5f8b73e2350097c3756ef7e785f55bd71205defa0bfdaf96c31616ff",
+                "sha256:da511e6ad4f7323ee5702e6633085fb76c2f893aaf8ce4c51a0ba4fc07580ea7",
+                "sha256:e05882b70b87a18d937ca6768ff33cc3f72847cbc4de4491c8e73880766718e5",
+                "sha256:e61c0abb4c85b095a784ef23fdd4aede7a2628478e7baba7c5e3deba61070a02",
+                "sha256:e6a08c0be454c3b3beb105c0596ebdc2371fab6bb90c0c0297f4e58fd7e1012c",
+                "sha256:e9a6e0eb86070e8ccaedfbd9d38fec54864f3125ab95419970575b42af7541df",
+                "sha256:ed37bd3c3b063412f7620464a9ac1314d33100329f39799255fb8d3027da50d3",
+                "sha256:f1adfc8ac319e1a348af294106bc6a8458a0f1633cc62a1446aebc30c5fa186a",
+                "sha256:f5796e664fe802da4f57a168c85359a8fbf3eab5e55cd4e4569fbacecc903959",
+                "sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234",
+                "sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==7.2.7"
+            "markers": "python_version >= '3.8'",
+            "version": "==7.6.1"
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
-                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
+                "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b",
+                "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"
             ],
             "index": "pypi",
-            "version": "==1.1.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.2.2"
         },
         "flake8": {
             "hashes": [
-                "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7",
-                "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"
+                "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38",
+                "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213"
             ],
             "index": "pypi",
-            "version": "==6.0.0"
+            "markers": "python_full_version >= '3.8.1'",
+            "version": "==7.1.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b",
+                "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==8.5.0"
         },
         "iniconfig": {
             "hashes": [
@@ -107,6 +129,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109",
+                "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
+            ],
+            "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==5.13.2"
         },
         "mccabe": {
             "hashes": [
@@ -118,35 +149,37 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703",
-                "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf",
-                "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4",
-                "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85",
-                "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd",
-                "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae",
-                "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd",
-                "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca",
-                "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305",
-                "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409",
-                "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c",
-                "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb",
-                "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee",
-                "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a",
-                "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228",
-                "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897",
-                "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d",
-                "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f",
-                "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152",
-                "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf",
-                "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8",
-                "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11",
-                "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017",
-                "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929",
-                "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e",
-                "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"
+                "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36",
+                "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce",
+                "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6",
+                "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b",
+                "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca",
+                "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24",
+                "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383",
+                "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7",
+                "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86",
+                "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d",
+                "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4",
+                "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8",
+                "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987",
+                "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385",
+                "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79",
+                "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef",
+                "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6",
+                "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70",
+                "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca",
+                "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70",
+                "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12",
+                "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104",
+                "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a",
+                "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318",
+                "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1",
+                "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b",
+                "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"
             ],
             "index": "pypi",
-            "version": "==1.3.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.11.2"
         },
         "mypy-extensions": {
             "hashes": [
@@ -158,51 +191,61 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61",
-                "sha256:a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+                "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002",
+                "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==23.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==24.1"
+        },
+        "platformdirs": {
+            "hashes": [
+                "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907",
+                "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.3.6"
         },
         "pluggy": {
             "hashes": [
-                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
-                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+                "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1",
+                "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.0.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.5.0"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053",
-                "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"
+                "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3",
+                "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.10.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.12.1"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf",
-                "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"
+                "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f",
+                "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.2.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362",
-                "sha256:434afafd78b1d78ed0addf160ad2b77a30d35d4bdf8af234fe621919d9ed15e3"
+                "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181",
+                "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"
             ],
             "index": "pypi",
-            "version": "==7.3.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.3"
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6",
-                "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"
+                "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652",
+                "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
             ],
             "index": "pypi",
-            "version": "==4.1.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==5.0.0"
         },
         "toml": {
             "hashes": [
@@ -210,6 +253,7 @@
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "tomli": {
@@ -222,19 +266,28 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
-                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==4.6.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==4.12.2"
         },
         "yapf": {
             "hashes": [
-                "sha256:4c2b59bd5ffe46f3a7da48df87596877189148226ce267c16e8b44240e51578d",
-                "sha256:da62bdfea3df3673553351e6246abed26d9fe6780e548a5af9e70f6d2b4f5b9a"
+                "sha256:4dab8a5ed7134e26d57c1647c7483afb3f136878b579062b786c9ba16b94637b",
+                "sha256:adc8b5dd02c0143108878c499284205adb258aad6db6634e5b869e7ee2bd548b"
             ],
             "index": "pypi",
-            "version": "==0.33.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.40.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350",
+                "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.20.2"
         }
     }
 }

--- a/benchmark/latency_perf.py
+++ b/benchmark/latency_perf.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import sys
 import time
-from random import randint
 
 import nats
 

--- a/benchmark/sub_perf.py
+++ b/benchmark/sub_perf.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import sys
 import time
-from random import randint
 
 import nats
 

--- a/examples/advanced.py
+++ b/examples/advanced.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 from nats.errors import NoServersError, TimeoutError
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -1,7 +1,8 @@
 import asyncio
+
 import nats
-from nats.errors import TimeoutError
 from common import args
+from nats.errors import TimeoutError
 
 
 async def main():

--- a/examples/client.py
+++ b/examples/client.py
@@ -1,8 +1,9 @@
 import asyncio
 from datetime import datetime
+
+from common import args
 from nats.aio.client import Client as NATS
 from nats.errors import ConnectionClosedError, TimeoutError
-from common import args
 
 
 class Client:

--- a/examples/clustered.py
+++ b/examples/clustered.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime
+
 import nats
 from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrConnectionClosed, ErrNoServers, ErrTimeout

--- a/examples/clustered.py
+++ b/examples/clustered.py
@@ -2,7 +2,6 @@ import asyncio
 from datetime import datetime
 
 import nats
-from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrConnectionClosed, ErrNoServers, ErrTimeout
 
 

--- a/examples/component.py
+++ b/examples/component.py
@@ -1,7 +1,9 @@
 import asyncio
-import time
 import signal
+import time
+
 import nats
+
 
 class Component:
     def __init__(self):

--- a/examples/connect.py
+++ b/examples/connect.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 from common import args
 

--- a/examples/context-manager.py
+++ b/examples/context-manager.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 from common import args
 

--- a/examples/drain-sub.py
+++ b/examples/drain-sub.py
@@ -1,6 +1,7 @@
 import asyncio
-from nats.aio.client import Client as NATS
+
 from common import args
+from nats.aio.client import Client as NATS
 
 
 async def main():

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,8 +1,8 @@
 import asyncio
-from nats.aio.client import Client as NATS
-from nats.errors import ConnectionClosedError
 
 from common import args
+from nats.aio.client import Client as NATS
+from nats.errors import ConnectionClosedError
 
 
 async def main():

--- a/examples/jetstream.py
+++ b/examples/jetstream.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 from nats.errors import TimeoutError
 

--- a/examples/kv.py
+++ b/examples/kv.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 
 

--- a/examples/nats-pub/__main__.py
+++ b/examples/nats-pub/__main__.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import sys
+
 import nats
 
 

--- a/examples/nats-req/__main__.py
+++ b/examples/nats-req/__main__.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import sys
+
 import nats
 
 

--- a/examples/nats-sub/__main__.py
+++ b/examples/nats-sub/__main__.py
@@ -16,6 +16,7 @@ import argparse
 import asyncio
 import signal
 import sys
+
 import nats
 
 

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 from common import args
 

--- a/examples/service.py
+++ b/examples/service.py
@@ -1,5 +1,6 @@
 import asyncio
 import signal
+
 from nats.aio.client import Client as NATS
 
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,4 +1,5 @@
 import asyncio
+
 import nats
 
 

--- a/examples/subscribe.py
+++ b/examples/subscribe.py
@@ -1,7 +1,8 @@
 import asyncio
 import signal
-from nats.aio.client import Client as NATS
+
 from common import args
+from nats.aio.client import Client as NATS
 
 
 async def main():

--- a/examples/tls.py
+++ b/examples/tls.py
@@ -1,5 +1,6 @@
 import asyncio
 import ssl
+
 from nats.aio.client import Client as NATS
 from nats.errors import TimeoutError
 

--- a/examples/wildcard.py
+++ b/examples/wildcard.py
@@ -1,6 +1,7 @@
 import asyncio
-from nats.aio.client import Client as NATS
+
 from common import args
+from nats.aio.client import Client as NATS
 
 
 async def run(loop):

--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 from typing import List, Union
+
 from .aio.client import Client as NATS
 
 

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -20,10 +20,12 @@ import ipaddress
 import json
 import logging
 import ssl
-import time
 import string
+import time
+from collections import UserString
 from dataclasses import dataclass
 from email.parser import BytesParser
+from io import BytesIO
 from random import shuffle
 from secrets import token_hex
 from typing import (
@@ -39,8 +41,6 @@ from typing import (
     Union,
 )
 from urllib.parse import ParseResult, urlparse
-from collections import UserString
-from io import BytesIO
 
 try:
     from fast_mail_parser import parse_email
@@ -533,6 +533,7 @@ class Client:
     def _setup_nkeys_jwt_connect(self) -> None:
         assert self._user_credentials, "_user_credentials required"
         import os
+
         import nkeys
 
         creds: Credentials = self._user_credentials
@@ -636,6 +637,7 @@ class Client:
     def _setup_nkeys_seed_connect(self) -> None:
         assert self._nkeys_seed or self._nkeys_seed_str, "Client.connect must be called first"
         import os
+
         import nkeys
 
         def _get_nkeys_seed() -> nkeys.KeyPair:

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -28,18 +28,7 @@ from email.parser import BytesParser
 from io import BytesIO
 from random import shuffle
 from secrets import token_hex
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Literal,
-    Optional,
-    Tuple,
-    TypedDict,
-    Union,
-)
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlparse
 
 try:
@@ -54,7 +43,6 @@ from nats.protocol import command as prot_command
 from nats.protocol.parser import (
     AUTHORIZATION_VIOLATION,
     PERMISSIONS_ERR,
-    PING,
     PONG,
     STALE_CONNECTION,
     Parser,
@@ -636,7 +624,6 @@ class Client:
 
     def _setup_nkeys_seed_connect(self) -> None:
         assert self._nkeys_seed or self._nkeys_seed_str, "Client.connect must be called first"
-        import os
 
         import nkeys
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import datetime
 import json
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Dict, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from nats.errors import Error, MsgAlreadyAckdError, NotJSMessageError
 

--- a/nats/aio/transport.py
+++ b/nats/aio/transport.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import abc
 import asyncio
 import ssl
+from typing import List, Optional, Union
 from urllib.parse import ParseResult
-from typing import List, Union, Optional
 
 try:
     import aiohttp

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, fields, replace
 from enum import Enum
-from typing import Any, Dict, Optional, TypeVar, List, Iterable, Iterator
+from typing import Any, Dict, Iterable, Iterator, List, Optional, TypeVar
 
 _NANOSECOND = 10**9
 

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -19,19 +19,36 @@ import json
 import time
 from email.parser import BytesParser
 from secrets import token_hex
-from typing import TYPE_CHECKING, Awaitable, Callable, Optional, List, Dict, Any
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+)
 
 import nats.errors
 import nats.js.errors
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 from nats.js import api
-from nats.js.errors import BadBucketError, BucketNotFoundError, InvalidBucketNameError, NotFoundError, FetchTimeoutError
+from nats.js.errors import (
+    BadBucketError,
+    BucketNotFoundError,
+    FetchTimeoutError,
+    InvalidBucketNameError,
+    NotFoundError,
+)
 from nats.js.kv import KeyValue
 from nats.js.manager import JetStreamManager
 from nats.js.object_store import (
-    VALID_BUCKET_RE, OBJ_ALL_CHUNKS_PRE_TEMPLATE, OBJ_ALL_META_PRE_TEMPLATE,
-    OBJ_STREAM_TEMPLATE, ObjectStore
+    OBJ_ALL_CHUNKS_PRE_TEMPLATE,
+    OBJ_ALL_META_PRE_TEMPLATE,
+    OBJ_STREAM_TEMPLATE,
+    VALID_BUCKET_RE,
+    ObjectStore,
 )
 
 if TYPE_CHECKING:

--- a/nats/js/errors.py
+++ b/nats/js/errors.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, NoReturn, Optional, Dict
+from typing import TYPE_CHECKING, Any, Dict, NoReturn, Optional
 
 import nats.errors
 from nats.js import api

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import base64
 import json
 from email.parser import BytesParser
-from typing import TYPE_CHECKING, Any, List, Optional, Dict, Iterable
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from nats.errors import NoRespondersError
 from nats.js import api

--- a/nats/js/object_store.py
+++ b/nats/js/object_store.py
@@ -12,21 +12,26 @@
 # limitations under the License.
 #
 
+import asyncio
 import base64
-import re
 import io
+import json
+import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from hashlib import sha256
-from dataclasses import dataclass
-import json
-import asyncio
-from typing import TYPE_CHECKING, Optional, Union, List
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import nats.errors
 from nats.js import api
 from nats.js.errors import (
-    BadObjectMetaError, DigestMismatchError, ObjectAlreadyExists,
-    ObjectDeletedError, ObjectNotFoundError, NotFoundError, LinkIsABucketError
+    BadObjectMetaError,
+    DigestMismatchError,
+    LinkIsABucketError,
+    NotFoundError,
+    ObjectAlreadyExists,
+    ObjectDeletedError,
+    ObjectNotFoundError,
 )
 from nats.js.kv import MSG_ROLLUP_SUBJECT
 

--- a/nats/micro/__init__.py
+++ b/nats/micro/__init__.py
@@ -13,11 +13,12 @@
 #
 
 from dataclasses import replace
-from nats.aio.client import Client
 from typing import Optional
 
+from nats.aio.client import Client
+
+from .request import Handler, Request
 from .service import Service, ServiceConfig
-from .request import Request, Handler
 
 
 async def add_service(

--- a/nats/micro/request.py
+++ b/nats/micro/request.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 from nats.aio.msg import Msg
 

--- a/nats/micro/request.py
+++ b/nats/micro/request.py
@@ -15,7 +15,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 from nats.aio.msg import Msg

--- a/nats/micro/service.py
+++ b/nats/micro/service.py
@@ -1,30 +1,28 @@
 from __future__ import annotations
 
+import json
+import re
+import time
 from asyncio import Event
-from dataclasses import dataclass, replace, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
 from enum import Enum
+from typing import (
+    Any,
+    AsyncContextManager,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Protocol,
+    overload,
+)
+
 from nats.aio.client import Client
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
 
-from typing import (
-    Any,
-    AsyncContextManager,
-    Optional,
-    Protocol,
-    Dict,
-    List,
-    overload,
-    Callable,
-)
-
-import re
-import json
-import time
-
-from .request import Request, Handler, ServiceError
-
+from .request import Handler, Request, ServiceError
 
 DEFAULT_QUEUE_GROUP = "q"
 """Queue Group name used across all services."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,3 @@ coalesce_brackets = true
 allow_split_before_dict_value = false
 indent_dictionary_value = true
 split_before_expression_after_opening_paren = true
-
-[tool.isort]
-combine_as_imports = true
-multi_line_output = 3
-include_trailing_comma = true
-src_paths = ["nats", "tests"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,17 +1,16 @@
 import asyncio
 import http.client
 import json
-import ssl
 import os
+import ssl
 import time
 import unittest
 import urllib
 from unittest import mock
 
-import pytest
-
 import nats
 import nats.errors
+import pytest
 from nats.aio.client import Client as NATS, __version__
 from nats.aio.errors import *
 from tests.utils import (
@@ -20,10 +19,10 @@ from tests.utils import (
     MultiServerAuthTestCase,
     MultiServerAuthTokenTestCase,
     MultiTLSServerAuthTestCase,
-    SingleServerTestCase,
-    TLSServerTestCase,
-    TLSServerHandshakeFirstTestCase,
     NoAuthUserServerTestCase,
+    SingleServerTestCase,
+    TLSServerHandshakeFirstTestCase,
+    TLSServerTestCase,
     async_test,
 )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,6 @@ import nats
 import nats.errors
 import pytest
 from nats.aio.client import Client as NATS, __version__
-from nats.aio.errors import *
 from tests.utils import (
     ClusteringDiscoveryAuthTestCase,
     ClusteringTestCase,
@@ -2773,7 +2772,7 @@ class ClientDrainTest(SingleServerTestCase):
     @async_test
     async def test_drain_cancelled_errors_raised(self):
         try:
-            from unittest.mock import AsyncMock
+            pass
         except ImportError:
             pytest.skip("skip since cannot use AsyncMock")
 

--- a/tests/test_client_async_await.py
+++ b/tests/test_client_async_await.py
@@ -1,9 +1,6 @@
 import asyncio
-import sys
-import unittest
 
 from nats.aio.client import Client as NATS
-from nats.aio.errors import ErrTimeout
 from nats.errors import SlowConsumerError, TimeoutError
 from tests.utils import SingleServerTestCase, async_test
 

--- a/tests/test_client_nkeys.py
+++ b/tests/test_client_nkeys.py
@@ -10,8 +10,7 @@ try:
 except ModuleNotFoundError:
     nkeys_installed = False
 
-from nats.aio.client import Client as NATS
-from nats.aio.client import RawCredentials
+from nats.aio.client import Client as NATS, RawCredentials
 from nats.aio.errors import *
 from nats.errors import *
 from tests.utils import (

--- a/tests/test_client_v2.py
+++ b/tests/test_client_v2.py
@@ -1,15 +1,6 @@
-import asyncio
-import http.client
-import json
-import shutil
-import ssl
-import tempfile
-import time
 import unittest
-from unittest import mock
 
 import nats
-from nats.aio.client import Client as NATS, __version__
 from nats.aio.errors import *
 from tests.utils import *
 

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -8,8 +8,8 @@ import time
 import unittest
 from unittest import mock
 
-import pytest
 import nats
+import pytest
 from nats.aio.client import Client as NATS, __version__
 from nats.aio.errors import *
 from tests.utils import *

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -1,21 +1,12 @@
 import asyncio
-import http.client
-import json
-import shutil
-import ssl
-import tempfile
-import time
 import unittest
-from unittest import mock
 
 import nats
 import pytest
-from nats.aio.client import Client as NATS, __version__
 from nats.aio.errors import *
 from tests.utils import *
 
 try:
-    import aiohttp
     aiohttp_installed = True
 except ModuleNotFoundError:
     aiohttp_installed = False

--- a/tests/test_client_websocket.py
+++ b/tests/test_client_websocket.py
@@ -7,6 +7,7 @@ from nats.aio.errors import *
 from tests.utils import *
 
 try:
+    import aiohttp
     aiohttp_installed = True
 except ModuleNotFoundError:
     aiohttp_installed = False

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -4,17 +4,15 @@ import asyncio
 import json
 import os
 from dataclasses import dataclass, field
-from typing import Any, Dict, Generic, List, Optional
+from typing import Any, Dict, List, Optional
 from unittest import TestCase, skipIf
 
 import nats
 from nats.aio.subscription import Subscription
 from nats.micro.request import ServiceError
 from nats.micro.service import (
-    SUBJECT_REGEX,
     EndpointConfig,
     EndpointStats,
-    GroupConfig,
     Request,
     Service,
     ServiceConfig,

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,25 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import json
-import nats
-
-from nats.aio.subscription import Subscription
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Generic, List, Optional
 from unittest import TestCase, skipIf
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Any, Optional, Generic
+import nats
+from nats.aio.subscription import Subscription
+from nats.micro.request import ServiceError
 from nats.micro.service import (
     SUBJECT_REGEX,
+    EndpointConfig,
     EndpointStats,
     GroupConfig,
-    ServiceConfig,
-    Service,
-    EndpointConfig,
     Request,
+    Service,
+    ServiceConfig,
 )
-from nats.micro.request import ServiceError
 
 from .utils import *
 

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1,25 +1,25 @@
 import asyncio
 import base64
 import datetime
-from hashlib import sha256
+import io
+import json
 import random
+import re
 import string
+import tempfile
 import time
 import unittest
-from unittest import mock
 import uuid
-import json
-import io
-import tempfile
+from hashlib import sha256
+from unittest import mock
 from unittest.mock import AsyncMock
-import re
 
-import pytest
 import nats
 import nats.js.api
-from nats.aio.msg import Msg
+import pytest
 from nats.aio.client import Client as NATS, __version__
 from nats.aio.errors import *
+from nats.aio.msg import Msg
 from nats.errors import *
 from nats.js.errors import *
 from tests.utils import *

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -11,13 +11,11 @@ import time
 import unittest
 import uuid
 from hashlib import sha256
-from unittest import mock
-from unittest.mock import AsyncMock
 
 import nats
 import nats.js.api
 import pytest
-from nats.aio.client import Client as NATS, __version__
+from nats.aio.client import Client as NATS
 from nats.aio.errors import *
 from nats.aio.msg import Msg
 from nats.errors import *

--- a/tests/test_micro_service.py
+++ b/tests/test_micro_service.py
@@ -6,11 +6,7 @@ import nats.micro
 from nats.micro import *
 from nats.micro.request import *
 from nats.micro.service import *
-from tests.utils import (
-    SingleJetStreamServerTestCase,
-    SingleServerTestCase,
-    async_test,
-)
+from tests.utils import SingleServerTestCase, async_test
 
 
 class MicroServiceTest(SingleServerTestCase):

--- a/tests/test_micro_service.py
+++ b/tests/test_micro_service.py
@@ -1,14 +1,16 @@
-from tests.utils import SingleJetStreamServerTestCase, SingleServerTestCase, async_test
+import asyncio
+import random
 
 import nats
-import random
-import asyncio
-
 import nats.micro
-
 from nats.micro import *
-from nats.micro.service import *
 from nats.micro.request import *
+from nats.micro.service import *
+from tests.utils import (
+    SingleJetStreamServerTestCase,
+    SingleServerTestCase,
+    async_test,
+)
 
 
 class MicroServiceTest(SingleServerTestCase):

--- a/tests/test_nuid.py
+++ b/tests/test_nuid.py
@@ -12,7 +12,6 @@
 # limitations under the License.
 #
 
-import sys
 import unittest
 from collections import Counter
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 import unittest
 
 from nats.aio.client import Subscription


### PR DESCRIPTION
Pending #608

👷 Adds an isort check to the cicd.
➕ For that, I needed to add isort as a dev dependency to the Pipfile. 
⬆️ Updated lock file (_lots_ of version bumps! Last updated Jun 2023)
🔧 And, define `.isort.cfg`, which includes the pyproject.toml `[tool.isort]` settings, because they weren't being picked up.