### PR TITLE
Introduce `ClientStates` enumeration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 
 script:
   - make ci
-  
+
 notifications:
   email: false
 
@@ -38,6 +38,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
+      - pip install nkeys
       - pip install -e .[fast-mail-parser]
   - name: "Python: 3.12"
     python: "3.12"
@@ -48,6 +49,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
+      - pip install nkeys
       - pip install -e .[fast-mail-parser]
   - name: "Python: 3.11"
     python: "3.11"
@@ -58,6 +60,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
+      - pip install nkeys
       - pip install -e .[fast-mail-parser]
   - name: "Python: 3.11/uvloop"
     python: "3.11"
@@ -68,8 +71,8 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
+      - pip install nkeys uvloop
       - pip install -e .[fast-mail-parser]
-      - pip install uvloop
   - name: "Python: 3.11 (nats-server@main)"
     python: "3.11"
     env:
@@ -81,6 +84,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
+      - pip install nkeys
       - pip install -e .[fast-mail-parser]
   allow_failures:
     - name: "Python: 3.8"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 REPO_OWNER=nats-io
 PROJECT_NAME=nats.py
 SOURCE_CODE=nats
+TEST_CODE=tests
 
 
 help:
@@ -22,14 +23,17 @@ deps:
 
 format:
 	yapf -i --recursive $(SOURCE_CODE)
-	yapf -i --recursive tests
+	yapf -i --recursive $(TEST_CODE)
+
+
+lint:
+	yapf --recursive --diff $(SOURCE_CODE)
+	yapf --recursive --diff $(TEST_CODE)
+	mypy
+	flake8 ./nats/js/
 
 
 test:
-	yapf --recursive --diff $(SOURCE_CODE)
-	yapf --recursive --diff tests
-	mypy
-	flake8 ./nats/js/
 	pytest
 
 

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -388,7 +388,7 @@ class StreamsListIterator(Iterable):
     """
 
     def __init__(
-        self, offset: int, total: int, streams: List[Dict[str, any]]
+        self, offset: int, total: int, streams: List[Dict[str, Any]]
     ) -> None:
         self.offset = offset
         self.total = total

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
 
 [tool.mypy]
 files = ["nats"]
-python_version = "3.7"
+python_version = "3.9"
 ignore_missing_imports = true
 follow_imports = "silent"
 show_error_codes = true
@@ -61,3 +61,14 @@ coalesce_brackets = true
 allow_split_before_dict_value = false
 indent_dictionary_value = true
 split_before_expression_after_opening_paren = true
+
+[tool.isort]
+combine_as_imports = true
+multi_line_output = 3
+include_trailing_comma = true
+src_paths = ["nats", "tests"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "--maxfail=1 -rfs -vvv"
+testpaths = ["tests"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ from unittest import mock
 import nats
 import nats.errors
 import pytest
-from nats.aio.client import Client as NATS, __version__
+from nats.aio.client import Client as NATS, ClientState, __version__
 from tests.utils import (
     ClusteringDiscoveryAuthTestCase,
     ClusteringTestCase,
@@ -636,13 +636,6 @@ class ClientTest(SingleServerTestCase):
         future = sub.next_msg(timeout=2)
         task = asyncio.create_task(asyncio.wait_for(future, timeout=2))
         await nc.close()
-
-        # Unblocked pending calls get a connection closed errors now.
-        start = time.time()
-        with self.assertRaises(nats.errors.ConnectionClosedError):
-            await task
-        end = time.time()
-        assert (end - start) < 0.5
 
     @async_test
     async def test_subscribe_next_msg_custom_limits(self):
@@ -2913,8 +2906,8 @@ class ClientDisconnectTest(SingleServerTestCase):
         await asyncio.wait_for(disconnected, 2)
         await nc.close()
 
-        disconnected_states[0] == NATS.RECONNECTING
-        disconnected_states[1] == NATS.CLOSED
+        disconnected_states[0] == ClientState.RECONNECTING
+        disconnected_states[1] == ClientState.CLOSED
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolving the relevant FIXME in the nats/aio/client.py module.

The client states are made public (out of the Client class), but not in a separate module (so be it for now). Also the code was formatted with the ruff tool.

Finally the `pytest.ini` section is appended into the pyproject.toml file.