### PR TITLE
Make `timeout` an optional param in `KeyWatcher.updates`

### DIFF
--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -318,7 +318,7 @@ class KeyValue:
             """
             await self._sub.unsubscribe()
 
-        async def updates(self, timeout=5.0):
+        async def updates(self, timeout: Optional[float] = 5.0):
             """
             updates fetches the next update from a watcher.
             """


### PR DESCRIPTION
Since `asyncio.wait_for` accepts `None` to indicate no timeout, it'd be helpful to also accept `None` here. Since the default value is 5.0 seconds, the type hint defaults to type `float` instead of `float | None`. 