### PR TITLE
Fix issue where flusher task stops running

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -2084,7 +2084,9 @@ class Client:
                 # RuntimeError in case the event loop is closed
                 break
             finally:
-                future.set_result(None)
+                # future might have been cancelled.  See issue #624
+                if not future.done():
+                    future.set_result(None)
 
     async def _ping_interval(self) -> None:
         while True:


### PR DESCRIPTION
Fixes issue #624

A cancelled future in the flush_queue can cause the flusher task to fail with InvalidStateError, due to attempting to set the result on a "done" future.

Signed-off-by: Debby Mendez <debby@glance.net>
