### PR TITLE
Introduce `uuid_utils` as optional dependency 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - export PATH=$HOME/nats-server:$PATH
 
 install:
-  - pip install -e .[nkeys,aiohttp,fast-mail-parser,orjson]
+  - pip install -e .[nkeys,aiohttp,fast-mail-parser,orjson,uuid_utils]
 
 script:
   - make ci
@@ -39,7 +39,7 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
-  - name: "Python: 3.13/orjson"
+  - name: "Python: 3.13/orjson + uuid_utils"
     python: "3.13"
     before_install:
       - sudo apt update && sudo apt install gcc build-essential -y
@@ -48,7 +48,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
-      - pip install -e .[fast-mail-parser,orjson]
+      - pip install -e .[fast-mail-parser,orjson,uuid_utils]
   - name: "Python: 3.12"
     python: "3.12"
     before_install:
@@ -59,7 +59,7 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
-  - name: "Python: 3.12/orjson"
+  - name: "Python: 3.12/orjson + uuid_utils"
     python: "3.12"
     before_install:
       - sudo apt update && sudo apt install gcc build-essential -y
@@ -68,7 +68,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
-      - pip install -e .[fast-mail-parser,orjson]
+      - pip install -e .[fast-mail-parser,orjson,uuid_utils]
   - name: "Python: 3.11"
     python: "3.11"
     before_install:
@@ -79,7 +79,7 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
-  - name: "Python: 3.11/orjson"
+  - name: "Python: 3.11/orjson + uuid_utils"
     python: "3.11"
     before_install:
       - sudo apt update && sudo apt install gcc build-essential -y
@@ -88,7 +88,7 @@ jobs:
       - pip install --upgrade pip
       - bash ./scripts/install_nats.sh
     install:
-      - pip install -e .[fast-mail-parser,orjson]
+      - pip install -e .[fast-mail-parser,orjson,uuid_utils]
   - name: "Python: 3.11/uvloop"
     python: "3.11"
     before_install:
@@ -115,10 +115,10 @@ jobs:
   allow_failures:
     - name: "Python: 3.8"
     - name: "Python: 3.11"
-    - name: "Python: 3.11/orjson"
+    - name: "Python: 3.11/orjson + uuid_utils"
     - name: "Python: 3.11/uvloop"
     - name: "Python: 3.11 (nats-server@main)"
     - name: "Python: 3.12"
-    - name: "Python: 3.12/orjson"
+    - name: "Python: 3.12/orjson + uuid_utils"
     - name: "Python: 3.13"
-    - name: "Python: 3.13/orjson"
+    - name: "Python: 3.13/orjson + uuid_utils"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - export PATH=$HOME/nats-server:$PATH
 
 install:
-  - pip install -e .[nkeys,aiohttp,fast-mail-parser]
+  - pip install -e .[nkeys,aiohttp,fast-mail-parser,orjson]
 
 script:
   - make ci
@@ -39,6 +39,16 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
+  - name: "Python: 3.13/orjson"
+    python: "3.13"
+    before_install:
+      - sudo apt update && sudo apt install gcc build-essential -y
+      - sudo apt-get install python3-pip
+      - sudo apt-get install python3-pytest
+      - pip install --upgrade pip
+      - bash ./scripts/install_nats.sh
+    install:
+      - pip install -e .[fast-mail-parser,orjson]
   - name: "Python: 3.12"
     python: "3.12"
     before_install:
@@ -49,6 +59,16 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
+  - name: "Python: 3.12/orjson"
+    python: "3.12"
+    before_install:
+      - sudo apt update && sudo apt install gcc build-essential -y
+      - sudo apt-get install python3-pip
+      - sudo apt-get install python3-pytest
+      - pip install --upgrade pip
+      - bash ./scripts/install_nats.sh
+    install:
+      - pip install -e .[fast-mail-parser,orjson]
   - name: "Python: 3.11"
     python: "3.11"
     before_install:
@@ -59,6 +79,16 @@ jobs:
       - bash ./scripts/install_nats.sh
     install:
       - pip install -e .[fast-mail-parser]
+  - name: "Python: 3.11/orjson"
+    python: "3.11"
+    before_install:
+      - sudo apt update && sudo apt install gcc build-essential -y
+      - sudo apt-get install python3-pip
+      - sudo apt-get install python3-pytest
+      - pip install --upgrade pip
+      - bash ./scripts/install_nats.sh
+    install:
+      - pip install -e .[fast-mail-parser,orjson]
   - name: "Python: 3.11/uvloop"
     python: "3.11"
     before_install:
@@ -85,7 +115,10 @@ jobs:
   allow_failures:
     - name: "Python: 3.8"
     - name: "Python: 3.11"
+    - name: "Python: 3.11/orjson"
     - name: "Python: 3.11/uvloop"
     - name: "Python: 3.11 (nats-server@main)"
     - name: "Python: 3.12"
+    - name: "Python: 3.12/orjson"
     - name: "Python: 3.13"
+    - name: "Python: 3.13/orjson"

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1583,8 +1583,8 @@ class Client:
         if self.options["no_echo"] is not None:
             options["echo"] = not self.options["no_echo"]
 
-        connect_opts = json.dumps(options, sort_keys=True)
-        return b"".join([CONNECT_OP + _SPC_ + connect_opts.encode() + _CRLF_])
+        connect_opts = json.dump_bytes(options, sort_keys=True)
+        return b"".join([CONNECT_OP + _SPC_ + connect_opts + _CRLF_])
 
     async def _process_ping(self) -> None:
         """

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import ipaddress
-import json
 import logging
 import ssl
 import string
@@ -31,6 +30,8 @@ from random import shuffle
 from secrets import token_hex
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import ParseResult, urlparse
+
+from nats.json_util import JsonUtil as json
 
 try:
     from fast_mail_parser import parse_email

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -132,7 +132,7 @@ class Msg:
         if delay:
             json_args["delay"] = int(delay * 10**9)  # from seconds to ns
         if json_args:
-            payload += b" " + json.dumps(json_args).encode()
+            payload += b" " + json.dump_bytes(json_args)
         await self._client.publish(self.reply, payload)
         self._ackd = True
 

--- a/nats/aio/msg.py
+++ b/nats/aio/msg.py
@@ -14,11 +14,11 @@
 from __future__ import annotations
 
 import datetime
-import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from nats.errors import Error, MsgAlreadyAckdError, NotJSMessageError
+from nats.json_util import JsonUtil as json
 
 if TYPE_CHECKING:
     from nats import NATS

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -15,11 +15,17 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    List,
+    Optional,
+)
 from uuid import uuid4
 
 from nats import errors
-
 # Default Pending Limits of Subscriptions
 from nats.aio.msg import Msg
 

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -15,17 +15,11 @@
 from __future__ import annotations
 
 import asyncio
-from typing import (
-    TYPE_CHECKING,
-    AsyncIterator,
-    Awaitable,
-    Callable,
-    List,
-    Optional,
-)
+from typing import TYPE_CHECKING, AsyncIterator, Awaitable, Callable, List, Optional
 from uuid import uuid4
 
 from nats import errors
+
 # Default Pending Limits of Subscriptions
 from nats.aio.msg import Msg
 

--- a/nats/aio/subscription.py
+++ b/nats/aio/subscription.py
@@ -23,11 +23,16 @@ from typing import (
     List,
     Optional,
 )
-from uuid import uuid4
 
 from nats import errors
 # Default Pending Limits of Subscriptions
 from nats.aio.msg import Msg
+
+# Use uuid_utils if available, otherwise use the standard library
+try:
+    from uuid_utils import uuid4
+except ImportError:
+    from uuid import uuid4
 
 if TYPE_CHECKING:
     from nats.js import JetStreamContext

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -15,19 +15,10 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import time
 from email.parser import BytesParser
 from secrets import token_hex
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    List,
-    Optional,
-)
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
 
 import nats.errors
 import nats.js.errors
@@ -50,6 +41,7 @@ from nats.js.object_store import (
     VALID_BUCKET_RE,
     ObjectStore,
 )
+from nats.json_util import JsonUtil as json
 
 if TYPE_CHECKING:
     from nats import NATS

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -18,7 +18,15 @@ import asyncio
 import time
 from email.parser import BytesParser
 from secrets import token_hex
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, List, Optional
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Awaitable,
+    Callable,
+    Dict,
+    List,
+    Optional,
+)
 
 import nats.errors
 import nats.js.errors

--- a/nats/js/client.py
+++ b/nats/js/client.py
@@ -1127,7 +1127,7 @@ class JetStreamContext(JetStreamManager):
 
             await self._nc.publish(
                 self._nms,
-                json.dumps(next_req).encode(),
+                json.dump_bytes(next_req),
                 self._deliver,
             )
 
@@ -1212,7 +1212,7 @@ class JetStreamContext(JetStreamManager):
             next_req["no_wait"] = True
             await self._nc.publish(
                 self._nms,
-                json.dumps(next_req).encode(),
+                json.dump_bytes(next_req),
                 self._deliver,
             )
             await asyncio.sleep(0)
@@ -1278,7 +1278,7 @@ class JetStreamContext(JetStreamManager):
 
             await self._nc.publish(
                 self._nms,
-                json.dumps(next_req).encode(),
+                json.dump_bytes(next_req),
                 self._deliver,
             )
             await asyncio.sleep(0)

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -173,9 +173,7 @@ class JetStreamManager:
 
         req = json.dump_bytes(stream_req)
         resp = await self._api_request(
-            f"{self._prefix}.STREAM.PURGE.{name}",
-            req,
-            timeout=self._timeout
+            f"{self._prefix}.STREAM.PURGE.{name}", req, timeout=self._timeout
         )
         return resp["success"]
 
@@ -198,9 +196,7 @@ class JetStreamManager:
         """
         resp = await self._api_request(
             f"{self._prefix}.STREAM.LIST",
-            json.dump_bytes({
-                "offset": offset
-            }),
+            json.dump_bytes({"offset": offset}),
             timeout=self._timeout,
         )
         streams = []
@@ -216,9 +212,7 @@ class JetStreamManager:
         """
         resp = await self._api_request(
             f"{self._prefix}.STREAM.LIST",
-            json.dump_bytes({
-                "offset": offset
-            }),
+            json.dump_bytes({"offset": offset}),
             timeout=self._timeout,
         )
 
@@ -283,9 +277,7 @@ class JetStreamManager:
         """
         resp = await self._api_request(
             f"{self._prefix}.CONSUMER.LIST.{stream}",
-            b"" if offset is None else json.dump_bytes({
-                "offset": offset
-            }),
+            b"" if offset is None else json.dump_bytes({"offset": offset}),
             timeout=self._timeout,
         )
         consumers = []

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -338,7 +338,7 @@ class JetStreamManager:
         # Non Direct form
         req_subject = f"{self._prefix}.STREAM.MSG.GET.{stream_name}"
         resp_data = await self._api_request(
-            req_subject, data.encode(), timeout=self._timeout
+            req_subject, data, timeout=self._timeout
         )
 
         raw_msg = api.RawStreamMsg.from_response(resp_data["message"])

--- a/nats/js/manager.py
+++ b/nats/js/manager.py
@@ -15,13 +15,13 @@
 from __future__ import annotations
 
 import base64
-import json
 from email.parser import BytesParser
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from nats.errors import NoRespondersError
 from nats.js import api
 from nats.js.errors import APIError, NotFoundError, ServiceUnavailableError
+from nats.json_util import JsonUtil as json
 
 if TYPE_CHECKING:
     from nats import NATS

--- a/nats/js/object_store.py
+++ b/nats/js/object_store.py
@@ -343,7 +343,7 @@ class ObjectStore:
         try:
             await self._js.publish(
                 meta_subj,
-                json.dumps(info.as_dict()).encode(),
+                json.dump_bytes(info.as_dict()),
                 headers={api.Header.ROLLUP: MSG_ROLLUP_SUBJECT},
             )
         except Exception as err:
@@ -412,7 +412,7 @@ class ObjectStore:
         try:
             await self._js.publish(
                 meta_subj,
-                json.dumps(info.as_dict()).encode(),
+                json.dump_bytes(info.as_dict()),
                 headers={api.Header.ROLLUP: MSG_ROLLUP_SUBJECT},
             )
         except Exception as err:
@@ -538,7 +538,7 @@ class ObjectStore:
         try:
             await self._js.publish(
                 meta_subj,
-                json.dumps(info.as_dict()).encode(),
+                json.dump_bytes(info.as_dict()),
                 headers={api.Header.ROLLUP: MSG_ROLLUP_SUBJECT},
             )
         finally:

--- a/nats/js/object_store.py
+++ b/nats/js/object_store.py
@@ -15,7 +15,6 @@
 import asyncio
 import base64
 import io
-import json
 import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -34,6 +33,7 @@ from nats.js.errors import (
     ObjectNotFoundError,
 )
 from nats.js.kv import MSG_ROLLUP_SUBJECT
+from nats.json_util import JsonUtil as json
 
 VALID_BUCKET_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 VALID_KEY_RE = re.compile(r"^[-/_=\.a-zA-Z0-9]+$")

--- a/nats/json_util.py
+++ b/nats/json_util.py
@@ -19,19 +19,34 @@ class JsonUtil:
     """
 
     @staticmethod
+    def _handle_sort_keys(kwargs):
+        """Internal helper to handle sort_keys parameter for orjson compatibility.
+        Args:
+            kwargs: The keyword arguments dictionary to modify
+        Returns:
+            Modified kwargs dictionary
+        """
+        if kwargs.pop("sort_keys", False):
+            option = kwargs.get("option", 0) | orjson.OPT_SORT_KEYS
+            kwargs["option"] = option
+        return kwargs
+
+    @staticmethod
     def dumps(obj, *args, **kwargs) -> str:
         """Convert a Python object into a json string.
         Args:
             obj: The data to be converted
-            *args: Extra arguments to pass to the orjson.dumps() function
-            **kwargs: Extra keyword arguments to pass to the orjson.dumps() function
+            *args: Extra arguments to pass to the dumps() function
+            **kwargs: Extra keyword arguments to pass to the dumps() function.
+                     Special handling for 'sort_keys' which is translated to
+                     orjson.OPT_SORT_KEYS when using orjson.
         Returns:
             The json string representation of obj
         """
-
         if orjson is None:
             return json.dumps(obj, *args, **kwargs)
         else:
+            kwargs = JsonUtil._handle_sort_keys(kwargs)
             return orjson.dumps(obj, *args, **kwargs).decode("utf-8")
 
     @staticmethod
@@ -39,15 +54,17 @@ class JsonUtil:
         """Convert a Python object into a bytes string.
         Args:
             obj: The data to be converted
-            *args: Extra arguments to pass to the orjson.dumps() function
-            **kwargs: Extra keyword arguments to pass to the orjson.dumps() function
+            *args: Extra arguments to pass to the dumps() function
+            **kwargs: Extra keyword arguments to pass to the dumps() function.
+                     Special handling for 'sort_keys' which is translated to
+                     orjson.OPT_SORT_KEYS when using orjson.
         Returns:
-            The json string representation of obj
+            The json string representation of obj as bytes
         """
-
         if orjson is None:
             return json.dumps(obj, *args, **kwargs).encode("utf-8")
         else:
+            kwargs = JsonUtil._handle_sort_keys(kwargs)
             return orjson.dumps(obj, *args, **kwargs)
 
     @staticmethod

--- a/nats/json_util.py
+++ b/nats/json_util.py
@@ -10,12 +10,20 @@ except ImportError:
 
 
 class JsonUtil:
-    """A utility class for handling JSON-related operations.
-    This class provides static methods for formatting JSON strings, and
-    for converting between Python objects and JSON strings/files. It uses
-    the `orjson` library where possible for its speed advantages, but reverts
-    to the standard `json` library where `orjson` does not support the required
-    functionality.
+    """A utility class for handling JSON serialization operations.
+    This class provides static methods for converting between Python objects and JSON
+    strings/bytes. It uses the `orjson` library when available for its performance
+    advantages, falling back to the standard `json` library when `orjson` is not
+    installed.
+
+    The class handles compatibility between the two libraries, particularly for options
+    like 'sort_keys' which have different implementations in each library. All methods
+    maintain consistent behavior regardless of which JSON library is being used.
+
+    Methods:
+        dumps(obj, *args, **kwargs) -> str: Converts object to JSON string
+        dump_bytes(obj, *args, **kwargs) -> bytes: Converts object to JSON bytes
+        loads(s, *args, **kwargs) -> Any: Parses JSON string into Python object
     """
 
     @staticmethod
@@ -24,7 +32,7 @@ class JsonUtil:
         Args:
             kwargs: The keyword arguments dictionary to modify
         Returns:
-            Modified kwargs dictionary
+            Modified kwargs dictionary with orjson-compatible options
         """
         if kwargs.pop("sort_keys", False):
             option = kwargs.get("option", 0) | orjson.OPT_SORT_KEYS
@@ -33,7 +41,7 @@ class JsonUtil:
 
     @staticmethod
     def dumps(obj, *args, **kwargs) -> str:
-        """Convert a Python object into a json string.
+        """Convert a Python object into a JSON string.
         Args:
             obj: The data to be converted
             *args: Extra arguments to pass to the dumps() function
@@ -41,7 +49,7 @@ class JsonUtil:
                      Special handling for 'sort_keys' which is translated to
                      orjson.OPT_SORT_KEYS when using orjson.
         Returns:
-            The json string representation of obj
+            str: A JSON string representation of obj
         """
         if orjson is None:
             return json.dumps(obj, *args, **kwargs)
@@ -51,7 +59,7 @@ class JsonUtil:
 
     @staticmethod
     def dump_bytes(obj, *args, **kwargs) -> bytes:
-        """Convert a Python object into a bytes string.
+        """Convert a Python object into a JSON bytes string.
         Args:
             obj: The data to be converted
             *args: Extra arguments to pass to the dumps() function
@@ -59,7 +67,7 @@ class JsonUtil:
                      Special handling for 'sort_keys' which is translated to
                      orjson.OPT_SORT_KEYS when using orjson.
         Returns:
-            The json string representation of obj as bytes
+            bytes: A JSON bytes string representation of obj
         """
         if orjson is None:
             return json.dumps(obj, *args, **kwargs).encode("utf-8")

--- a/nats/json_util.py
+++ b/nats/json_util.py
@@ -1,0 +1,66 @@
+"""A module providing a utility class for handling JSON-related operations."""
+
+import json
+from typing import Any
+
+try:
+    import orjson
+except ImportError:
+    orjson = None
+
+
+class JsonUtil:
+    """A utility class for handling JSON-related operations.
+    This class provides static methods for formatting JSON strings, and
+    for converting between Python objects and JSON strings/files. It uses
+    the `orjson` library where possible for its speed advantages, but reverts
+    to the standard `json` library where `orjson` does not support the required
+    functionality.
+    """
+
+    @staticmethod
+    def dumps(obj, *args, **kwargs) -> str:
+        """Convert a Python object into a json string.
+        Args:
+            obj: The data to be converted
+            *args: Extra arguments to pass to the orjson.dumps() function
+            **kwargs: Extra keyword arguments to pass to the orjson.dumps() function
+        Returns:
+            The json string representation of obj
+        """
+
+        if orjson is None:
+            return json.dumps(obj, *args, **kwargs)
+        else:
+            return orjson.dumps(obj, *args, **kwargs).decode("utf-8")
+
+    @staticmethod
+    def dump_bytes(obj, *args, **kwargs) -> bytes:
+        """Convert a Python object into a bytes string.
+        Args:
+            obj: The data to be converted
+            *args: Extra arguments to pass to the orjson.dumps() function
+            **kwargs: Extra keyword arguments to pass to the orjson.dumps() function
+        Returns:
+            The json string representation of obj
+        """
+
+        if orjson is None:
+            return json.dumps(obj, *args, **kwargs).encode("utf-8")
+        else:
+            return orjson.dumps(obj, *args, **kwargs)
+
+    @staticmethod
+    def loads(s: str, *args, **kwargs) -> Any:
+        """Parse a JSON string into a Python object.
+        Args:
+            s: The JSON string to be parsed
+            *args: Extra arguments to pass to the orjson.loads() function
+            **kwargs: Extra keyword arguments to pass to the orjson.loads() function
+        Returns:
+            The Python representation of s
+        """
+        if orjson is None:
+            return json.loads(s, *args, **kwargs)
+        else:
+            return orjson.loads(s, *args, **kwargs)

--- a/nats/micro/service.py
+++ b/nats/micro/service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import re
 import time
 from asyncio import Event
@@ -21,6 +20,7 @@ from typing import (
 from nats.aio.client import Client
 from nats.aio.msg import Msg
 from nats.aio.subscription import Subscription
+from nats.json_util import JsonUtil as json
 
 from .request import Handler, Request, ServiceError
 

--- a/nats/micro/service.py
+++ b/nats/micro/service.py
@@ -859,18 +859,18 @@ class Service(AsyncContextManager):
             metadata=self._metadata,
         ).to_dict()
 
-        await msg.respond(data=json.dumps(ping).encode())
+        await msg.respond(data=json.dump_bytes(ping))
 
     async def _handle_info_request(self, msg: Msg) -> None:
         """Handle an info message."""
         info = self.info().to_dict()
 
-        await msg.respond(data=json.dumps(info).encode())
+        await msg.respond(data=json.dump_bytes(info))
 
     async def _handle_stats_request(self, msg: Msg) -> None:
         """Handle a stats message."""
         stats = self.stats().to_dict()
-        await msg.respond(data=json.dumps(stats).encode())
+        await msg.respond(data=json.dump_bytes(stats))
 
 
 def control_subject(

--- a/nats/protocol/parser.py
+++ b/nats/protocol/parser.py
@@ -17,11 +17,11 @@ NATS network protocol parser.
 
 from __future__ import annotations
 
-import json
 import re
 from typing import Any, Dict
 
 from nats.errors import ProtocolError
+from nats.json_util import JsonUtil as json
 
 MSG_RE = re.compile(
     b"\\AMSG\\s+([^\\s]+)\\s+([^\\s]+)\\s+(([^\\s]+)[^\\S\r\n]+)?(\\d+)\r\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ nkeys = ['nkeys']
 aiohttp = ['aiohttp']
 fast_parse = ['fast-mail-parser']
 orjson = ['orjson']
+uuid_utils = ['uuid_utils']
 
 [tool.setuptools]
 zip-safe = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 nkeys = ['nkeys']
 aiohttp = ['aiohttp']
 fast_parse = ['fast-mail-parser']
+orjson = ['orjson']
 
 [tool.setuptools]
 zip-safe = true

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "aiohttp": ["aiohttp"],
         "fast_parse": ["fast-mail-parser"],
         "orjson": ["orjson"],
+        "uuid_utils": ["uuid_utils"],
     },
     packages=["nats", "nats.aio", "nats.micro", "nats.protocol", "nats.js"],
     package_data={"nats": ["py.typed"]},

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "nkeys": ["nkeys"],
         "aiohttp": ["aiohttp"],
         "fast_parse": ["fast-mail-parser"],
+        "orjson": ["orjson"],
     },
     packages=["nats", "nats.aio", "nats.micro", "nats.protocol", "nats.js"],
     package_data={"nats": ["py.typed"]},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,6 +40,7 @@ class ClientUtilsTest(unittest.TestCase):
 
         try:
             import orjson
+
             # If using orjson, expected string is without spaces
             expected = expected.replace(" ", "")
         except ImportError:
@@ -59,6 +60,7 @@ class ClientUtilsTest(unittest.TestCase):
 
         try:
             import orjson
+
             # If using orjson, expected string is without spaces
             expected = expected.replace(" ", "")
         except ImportError:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,7 +37,7 @@ class ClientUtilsTest(unittest.TestCase):
         nc.options["no_echo"] = False
         got = nc._connect_command()
         expected = f'CONNECT {{"echo": true, "lang": "python3", "pedantic": false, "protocol": 1, "verbose": false, "version": "{__version__}"}}\r\n'
-        
+
         try:
             import orjson
             # If using orjson, expected string is without spaces

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -41,11 +41,10 @@ class ClientUtilsTest(unittest.TestCase):
         try:
             import orjson
 
-            # If using orjson, expected string is without spaces
-            expected = expected.replace(" ", "")
+            # If using orjson, expected string is without spaces (except for first space after CONNECT)
+            expected = expected.replace(" ", "").replace("CONNECT", "CONNECT ")
         except ImportError:
             pass
-
         self.assertEqual(expected.encode(), got)
 
     def test_default_connect_command_with_name(self):
@@ -61,8 +60,8 @@ class ClientUtilsTest(unittest.TestCase):
         try:
             import orjson
 
-            # If using orjson, expected string is without spaces
-            expected = expected.replace(" ", "")
+            # If using orjson, expected string is without spaces (except for first space after CONNECT)
+            expected = expected.replace(" ", "").replace("CONNECT", "CONNECT ")
         except ImportError:
             pass
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,6 +37,14 @@ class ClientUtilsTest(unittest.TestCase):
         nc.options["no_echo"] = False
         got = nc._connect_command()
         expected = f'CONNECT {{"echo": true, "lang": "python3", "pedantic": false, "protocol": 1, "verbose": false, "version": "{__version__}"}}\r\n'
+        
+        try:
+            import orjson
+            # If using orjson, expected string is without spaces
+            expected = expected.replace(" ", "")
+        except ImportError:
+            pass
+
         self.assertEqual(expected.encode(), got)
 
     def test_default_connect_command_with_name(self):
@@ -48,6 +56,14 @@ class ClientUtilsTest(unittest.TestCase):
         nc.options["no_echo"] = False
         got = nc._connect_command()
         expected = f'CONNECT {{"echo": true, "lang": "python3", "name": "secret", "pedantic": false, "protocol": 1, "verbose": false, "version": "{__version__}"}}\r\n'
+
+        try:
+            import orjson
+            # If using orjson, expected string is without spaces
+            expected = expected.replace(" ", "")
+        except ImportError:
+            pass
+
         self.assertEqual(expected.encode(), got)
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,5 @@
 import asyncio
 import http.client
-import json
 import os
 import ssl
 import time
@@ -12,6 +11,7 @@ import nats
 import nats.errors
 import pytest
 from nats.aio.client import Client as NATS, __version__
+from nats.json_util import JsonUtil as json
 from tests.utils import (
     ClusteringDiscoveryAuthTestCase,
     ClusteringTestCase,

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import os
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -9,6 +8,7 @@ from unittest import TestCase, skipIf
 
 import nats
 from nats.aio.subscription import Subscription
+from nats.json_util import JsonUtil as json
 from nats.micro.request import ServiceError
 from nats.micro.service import (
     EndpointConfig,

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import datetime
 import io
-import json
 import random
 import re
 import string
@@ -20,6 +19,7 @@ from nats.aio.errors import *
 from nats.aio.msg import Msg
 from nats.errors import *
 from nats.js.errors import *
+from nats.json_util import JsonUtil as json
 from tests.utils import *
 
 try:

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -8,7 +8,6 @@ import string
 import tempfile
 import time
 import unittest
-import uuid
 from hashlib import sha256
 
 import nats
@@ -27,6 +26,10 @@ try:
 except ImportError:
     parse_email = None
 
+try:
+    import uuid_utils as uuid
+except ImportError:
+    import uuid
 
 class PublishTest(SingleJetStreamServerTestCase):
 

--- a/tests/test_micro_service.py
+++ b/tests/test_micro_service.py
@@ -79,10 +79,10 @@ class MicroServiceTest(SingleServerTestCase):
         for _ in range(50):
             await nc.request(
                 "svc.add",
-                json.dumps({
+                json.dump_bytes({
                     "x": 22,
                     "y": 11
-                }).encode("utf-8")
+                })
             )
 
         for svc in svcs:

--- a/tests/test_micro_service.py
+++ b/tests/test_micro_service.py
@@ -77,13 +77,7 @@ class MicroServiceTest(SingleServerTestCase):
             svcs.append(svc)
 
         for _ in range(50):
-            await nc.request(
-                "svc.add",
-                json.dump_bytes({
-                    "x": 22,
-                    "y": 11
-                })
-            )
+            await nc.request("svc.add", json.dump_bytes({"x": 22, "y": 11}))
 
         for svc in svcs:
             info = svc.info()


### PR DESCRIPTION
Closes #661

Because `uuid_utils` is significantly faster than the default `uuid` library - see above-linked issue for more info.

___

Leaving as draft because this depends on #662.
Decided to merge the Travis jobs testing `orjson` functionality together with `uuid_utils`, to avoid unnecessary extra runs.
I also believe that both `orjson` and `uuid_utils` should become the new defaults for the library, but it will probably need some shelf-life of being used in production before that call can be made.