### PR TITLE
Consume the pending messages rather than asserting pending message count.

### DIFF
--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -1615,11 +1615,11 @@ class SubscribeTest(SingleJetStreamServerTestCase):
 
         # Create a sync subscriber now.
         sub2 = await js.subscribe("pbound", durable="two")
-        msg = await sub2.next_msg()
-        assert msg.data == b"Hello World 0"
-        assert msg.metadata.sequence.stream == 1
-        assert msg.metadata.sequence.consumer == 1
-        assert sub2.pending_msgs == 9
+        for i in range(10):
+            msg = await sub2.next_msg()
+            assert msg.data == f"Hello World {i}".encode()
+            assert msg.metadata.sequence.stream == i + 1
+            assert msg.metadata.sequence.consumer == i + 1
 
         await nc.close()
 


### PR DESCRIPTION
This fixes flakiness in `test_subscribe_push_bound()` where the client-side pending message queue occasionally did not contain all the pending messages from the server by the time the test function inspected the queue, due to a race condition between the task fetching messages from the server and the task running the test function.

Resolves #689.

Signed-off-by: Knut Aksel Røysland <knutroy@ifi.uio.no>