### PR TITLE
Support merging with namespace packages via pkgutil.extend_path

### DIFF
--- a/nats/__init__.py
+++ b/nats/__init__.py
@@ -11,11 +11,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+import pkgutil
+
 from __future__ import annotations
 
 from typing import List, Union
 
 from .aio.client import Client as NATS
+
+# For compatability with other namespace based packages in the ecosystem (e.g nats-jetstream).
+__path__ = pkgutil.extend_path(__path__, __name__)
 
 
 async def connect(


### PR DESCRIPTION
Add `pkgutil.extend_path()` to the package’s `__init__.py` to allow coexistence with PEP 420-compliant namespace packages. This enables importing submodules from separately distributed packages under the same namespace.