### PR TITLE
fix streamsource serialization

### DIFF
--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -164,7 +164,7 @@ class StreamSource(Base):
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()
         if self.subject_transforms:
-            result["subject_transform"] = [
+            result["subject_transforms"] = [
                 tr.as_dict() for tr in self.subject_transforms
             ]
         return result


### PR DESCRIPTION
The stream create API call currently silently fails to configure subject transforms when creating a sourcing stream. The nats server does warn about unknown field "subject_transform"

subject_transforms in go sdk with the correct json serialization key: https://github.com/nats-io/nats.go/blob/main/jsm.go#L282