### PR TITLE
Add validate_keys option to kv methods

### DIFF
--- a/nats/js/kv.py
+++ b/nats/js/kv.py
@@ -131,11 +131,16 @@ class KeyValue:
         self._js = js
         self._direct = direct
 
-    async def get(self, key: str, revision: Optional[int] = None) -> Entry:
+    async def get(
+        self,
+        key: str,
+        revision: Optional[int] = None,
+        validate_keys: bool = True
+    ) -> Entry:
         """
         get returns the latest value for the key.
         """
-        if not _is_key_valid(key):
+        if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError
 
         entry = None
@@ -189,27 +194,33 @@ class KeyValue:
 
         return entry
 
-    async def put(self, key: str, value: bytes) -> int:
+    async def put(
+        self, key: str, value: bytes, validate_keys: bool = True
+    ) -> int:
         """
         put will place the new value for the key into the store
         and return the revision number.
         """
-        if not _is_key_valid(key):
+        if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError(key)
 
         pa = await self._js.publish(f"{self._pre}{key}", value)
         return pa.seq
 
-    async def create(self, key: str, value: bytes) -> int:
+    async def create(
+        self, key: str, value: bytes, validate_keys: bool = True
+    ) -> int:
         """
         create will add the key/value pair iff it does not exist.
         """
-        if not _is_key_valid(key):
+        if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError(key)
 
         pa = None
         try:
-            pa = await self.update(key, value, last=0)
+            pa = await self.update(
+                key, value, last=0, validate_keys=validate_keys
+            )
         except nats.js.errors.KeyWrongLastSequenceError as err:
             # In case of attempting to recreate an already deleted key,
             # the client would get a KeyWrongLastSequenceError.  When this happens,
@@ -229,17 +240,26 @@ class KeyValue:
                 # to recreate using the last revision.
                 raise err
             except nats.js.errors.KeyDeletedError as err:
-                pa = await self.update(key, value, last=err.entry.revision)
+                pa = await self.update(
+                    key,
+                    value,
+                    last=err.entry.revision,
+                    validate_keys=validate_keys
+                )
 
         return pa
 
     async def update(
-        self, key: str, value: bytes, last: Optional[int] = None
+        self,
+        key: str,
+        value: bytes,
+        last: Optional[int] = None,
+        validate_keys: bool = True
     ) -> int:
         """
         update will update the value iff the latest revision matches.
         """
-        if not _is_key_valid(key):
+        if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError(key)
 
         hdrs = {}
@@ -262,11 +282,16 @@ class KeyValue:
                 raise err
         return pa.seq
 
-    async def delete(self, key: str, last: Optional[int] = None) -> bool:
+    async def delete(
+        self,
+        key: str,
+        last: Optional[int] = None,
+        validate_keys: bool = True
+    ) -> bool:
         """
         delete will place a delete marker and remove all previous revisions.
         """
-        if not _is_key_valid(key):
+        if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError(key)
 
         hdrs = {}

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -2462,6 +2462,45 @@ class KVTest(SingleJetStreamServerTestCase):
                     await kv.update(key, b'')
 
     @async_test
+    async def test_key_validation_bypass(self):
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        kv = await js.create_key_value(bucket="TEST", history=5, ttl=3600)
+        invalid_keys = [
+            "x!",
+            "x.>",
+            "x.*",
+        ]
+
+        for key in invalid_keys:
+            with self.subTest(key):
+                # Should succeed with validate_keys=False
+                seq = await kv.put(key, b'test_value', validate_keys=False)
+                assert seq > 0
+
+                # Should be able to get with validate_keys=False
+                entry = await kv.get(key, validate_keys=False)
+                assert entry.value == b'test_value'
+
+                # Should be able to update with validate_keys=False
+                seq2 = await kv.update(
+                    key, b'updated_value', last=seq, validate_keys=False
+                )
+                assert seq2 > seq
+
+                # Should be able to delete with validate_keys=False
+                result = await kv.delete(key, validate_keys=False)
+                assert result is True
+
+                # Should still fail with default validate_keys=True
+                with pytest.raises(InvalidKeyError):
+                    await kv.put(key, b'fail')
+
+                with pytest.raises(InvalidKeyError):
+                    await kv.get(key)
+
+    @async_test
     async def test_kv_basic(self):
         errors = []
 


### PR DESCRIPTION
Key validation enforced by default, but allow to opt out to avoid breaking apps depending on old behavior.