### PR TITLE
Release/v2.11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
             matrix:
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
                 nats_version: ["v2.10.29", "v2.11.4", "main"]
+                include:
+                    - nats_version: "main"
+                      continue-on-error: true
 
         steps:
             - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-                nats_version: ["v2.10.29", "v2.11.4", "main"]
+                nats_version: ["v2.10.29", "v2.11.6", "main"]
                 include:
                     - nats_version: "main"
                       continue-on-error: true

--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -59,7 +59,7 @@ from .subscription import (
 )
 from .transport import TcpTransport, Transport, WebSocketTransport
 
-__version__ = "2.10.0"
+__version__ = "2.11.0"
 __lang__ = "python3"
 _logger = logging.getLogger(__name__)
 PROTOCOL = 1

--- a/nats/js/api.py
+++ b/nats/js/api.py
@@ -164,7 +164,7 @@ class StreamSource(Base):
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()
         if self.subject_transforms:
-            result["subject_transform"] = [
+            result["subject_transforms"] = [
                 tr.as_dict() for tr in self.subject_transforms
             ]
         return result

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 # These are here for GitHub's dependency graph and help with setuptools support in some environments.
 setup(
     name="nats-py",
-    version="2.10.0",
+    version="2.11.0",
     license="Apache 2 License",
     extras_require={
         "nkeys": ["nkeys"],


### PR DESCRIPTION
### Added

* Added `validate_keys` option to KV methods for controlling key validation [#706](https://github.com/nats-io/nats.py/pull/706)

    ```python
    # Key validation enforced by default
    await kv.put("valid-key", b"value")
    
    # Opt out of validation for backwards compatibility  
    await kv.put("invalid.key.", b"value", validate_keys=False)
    ```

### Fixed

* Remove risk of getting `coroutine 'Queue.get' was never awaited` warning [#687](https://github.com/nats-io/nats.py/pull/687)
* Avoid `RuntimeWarning: coroutine 'Queue.get' was never awaited` in test [#691](https://github.com/nats-io/nats.py/pull/691)
* Consume the pending messages rather than asserting pending message count [#690](https://github.com/nats-io/nats.py/pull/690)
* Fix typo when using `subject_transforms`

### Improved

* Regenerate test certificates to work with Python v3.13 [#699](https://github.com/nats-io/nats.py/pull/699)
* Remove Travis CI configuration [#688](https://github.com/nats-io/nats.py/pull/688)
