### PR TITLE
Fix EOF processing while client is connecting.

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1445,10 +1445,10 @@ class Client:
         try to switch the server to which it is currently connected
         otherwise it will disconnect.
         """
-        if self.is_connecting or self.is_closed or self.is_reconnecting:
+        if self.is_closed or self.is_reconnecting:
             return
 
-        if self.options["allow_reconnect"] and self.is_connected:
+        if self.options["allow_reconnect"] and (self.is_connected or self.is_connecting):
             self._status = Client.RECONNECTING
             self._ps.reset()
 
@@ -2156,7 +2156,7 @@ class Client:
                 should_bail = self.is_closed or self.is_reconnecting
                 if should_bail or self._transport is None:
                     break
-                if self.is_connected and self._transport.at_eof():
+                if self._transport.at_eof():
                     err = errors.UnexpectedEOF()
                     await self._error_cb(err)
                     await self._process_op_err(err)


### PR DESCRIPTION
Resolves https://github.com/nats-io/nats.py/issues/490

When the client status (`self._status`) is `CONNECTING` and the transport is eof (`self._transport.at_eof()`), the reading from the transport hangs indefinitely  (`b = await self._transport.read(DEFAULT_BUFFER_SIZE)` in `_read_loop`).

The solution is to process transport eof in the same way it is done when the client is connected.