### PR TITLE
Fix test_object_list

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
             matrix:
                 python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-                nats_version: ["v2.10.29", "v2.11.6", "main"]
+                nats_version: ["v2.10.29", "v2.11.8", "main"]
                 include:
                     - nats_version: "main"
                       continue-on-error: true

--- a/tests/test_js.py
+++ b/tests/test_js.py
@@ -4057,12 +4057,10 @@ class ObjectStoreTest(SingleJetStreamServerTestCase):
             "TEST_LIST",
             config=nats.js.api.ObjectStoreConfig(description="listing", ),
         )
-        await asyncio.gather(
-            obs.put("A", b"AAA"),
-            obs.put("B", b"BBB"),
-            obs.put("C", b"CCC"),
-            obs.put("D", b"DDD"),
-        )
+        await obs.put("A", b"AAA")
+        await obs.put("B", b"BBB")
+        await obs.put("C", b"CCC")
+        await obs.put("D", b"DDD")
         entries = await obs.list()
         assert len(entries) == 4
         assert entries[0].name == "A"


### PR DESCRIPTION
If we want to test order in which objects are inserted, we want to insert them sequentially.
asyncio.gather doc say:
>Coroutines will be wrapped in a future and scheduled in the event     loop. They will not necessarily be scheduled in the same order as     passed in.

Starting with this PR the test started to fail:
https://github.com/nats-io/nats-server/pull/7125
