### PR TITLE
Add MaxReconnectAttemptsExceededError for connection failure detection (#735) 

### DIFF
--- a/nats/aio/client.py
+++ b/nats/aio/client.py
@@ -1367,6 +1367,15 @@ class Client:
             if self.options["max_reconnect_attempts"] > 0:
                 if s.reconnects > self.options["max_reconnect_attempts"]:
                     # Discard server since already tried to reconnect too many times
+                    # Check if all remaining servers have also exceeded max reconnect attempts
+                    if len(self._server_pool) == 0 or all(
+                        srv.reconnects > self.options["max_reconnect_attempts"]
+                        for srv in self._server_pool
+                    ):
+                        # No more servers available or all have exceeded max attempts
+                        raise errors.MaxReconnectAttemptsExceededError(
+                            self.options["max_reconnect_attempts"]
+                        )
                     continue
 
             # Not yet exceeded max_reconnect_attempts so can still use

--- a/nats/errors.py
+++ b/nats/errors.py
@@ -196,3 +196,14 @@ class MsgAlreadyAckdError(Error):
 
     def __str__(self) -> str:
         return f"nats: message was already acknowledged: {self._msg}"
+
+
+class MaxReconnectAttemptsExceededError(Error):
+
+    def __init__(self, max_attempts: int | None = None) -> None:
+        self.max_attempts = max_attempts
+
+    def __str__(self) -> str:
+        if self.max_attempts is not None:
+            return f"nats: maximum reconnection attempts exceeded: {self.max_attempts}"
+        return "nats: maximum reconnection attempts exceeded"


### PR DESCRIPTION
Introduces a new MaxReconnectAttemptsExceededError that is raised when the NATS client exhausts all reconnection attempts across all servers in the pool. This allows applications to
  distinguish between temporary connection issues and permanent failures where all retry limits have been exceeded.