### PR TITLE
Mark nats-server package as private

### DIFF
--- a/nats-server/pyproject.toml
+++ b/nats-server/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
+  "Private :: Do Not Upload",
 ]
 dependencies = []
 


### PR DESCRIPTION
> To prevent a package from being uploaded to PyPI, use the special Private :: Do Not Upload classifier. PyPI will always reject packages with classifiers beginning with Private ::.

See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/