### PR TITLE
Remove flake8 step from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,6 @@ jobs:
 
             - name: Run tests
               run: |
-                  uv run flake8 --ignore="W391, W503, W504, E501, E203" ./nats/src/nats/js/
                   uv run pytest -x -vv -s --continue-on-collection-errors ./nats/tests
               env:
                   PATH: $HOME/nats-server:$PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dev-dependencies = [
     "pytest-xdist>=3.0.0",
     "mypy>=1.0.0",
     "ruff>=0.1.0",
-    "flake8>=7.0.0",
 ]
 workspace = { members = ["nats", "nats-server"] }
 


### PR DESCRIPTION
Ruff runs in the check workflow, running flake8 for each test job is redundant and flake8 is quite slow.