### PR TITLE
Add consumer-configured `inbox_prefix` usage to jetstream `pull_subscribe` and `pull_subscribe_bind`

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -545,7 +545,7 @@ class JetStreamContext(JetStreamManager):
         config: Optional[api.ConsumerConfig] = None,
         pending_msgs_limit: int = DEFAULT_JS_SUB_PENDING_MSGS_LIMIT,
         pending_bytes_limit: int = DEFAULT_JS_SUB_PENDING_BYTES_LIMIT,
-        inbox_prefix: bytes = api.INBOX_PREFIX,
+        inbox_prefix: Optional[bytes] = None,
     ) -> JetStreamContext.PullSubscription:
         """Create consumer and pull subscription.
 
@@ -620,7 +620,7 @@ class JetStreamContext(JetStreamManager):
         self,
         consumer: Optional[str] = None,
         stream: Optional[str] = None,
-        inbox_prefix: bytes = api.INBOX_PREFIX,
+        inbox_prefix: Optional[bytes] = None,
         pending_msgs_limit: int = DEFAULT_JS_SUB_PENDING_MSGS_LIMIT,
         pending_bytes_limit: int = DEFAULT_JS_SUB_PENDING_BYTES_LIMIT,
         name: Optional[str] = None,
@@ -654,6 +654,10 @@ class JetStreamContext(JetStreamManager):
         """
         if not stream:
             raise ValueError("nats: stream name is required")
+
+        if inbox_prefix is None:
+            inbox_prefix = bytes(self._nc._inbox_prefix[:]) + b"."
+
         deliver = inbox_prefix + self._nc._nuid.next()
         sub = await self._nc.subscribe(
             deliver.decode(),


### PR DESCRIPTION
Fixes #777 