### PR TITLE
Add jetstream consumer priority groups (ADR-42)

### DIFF
--- a/nats/src/nats/js/errors.py
+++ b/nats/src/nats/js/errors.py
@@ -83,6 +83,8 @@ class APIError(Error):
             raise ServiceUnavailableError(**err)
         elif code == 500:
             raise ServerError(**err)
+        elif code == 423:
+            raise PinIdMismatchError(**err)
         elif code == 404:
             raise NotFoundError(**err)
         elif code == 400:
@@ -107,6 +109,17 @@ class ServiceUnavailableError(APIError):
 class ServerError(APIError):
     """
     A 500 error
+    """
+
+    pass
+
+
+class PinIdMismatchError(APIError):
+    """
+    A 423 error
+
+    PinIdMismatchError is returned when Pin ID sent in the request does not match
+    the currently pinned consumer subscriber ID on the server.
     """
 
     pass

--- a/nats/src/nats/js/manager.py
+++ b/nats/src/nats/js/manager.py
@@ -420,6 +420,15 @@ class JetStreamManager:
         """
         return await self.get_msg(stream_name, subject=subject, direct=direct)
 
+    async def unpin_consumer(self, stream_name: str, consumer_name: str, group: str) -> None:
+        """
+        unpin_consumer unpins a pinned consumer.
+        """
+        req_subject = f"{self._prefix}.CONSUMER.UNPIN.{stream_name}.{consumer_name}"
+        req = {"group": group}
+        data = json.dumps(req)
+        _ = await self._api_request(req_subject, data.encode())
+
     async def _api_request(
         self,
         req_subject: str,


### PR DESCRIPTION
Stacked on #788 

Closes #784 

Implements support for [ADR-42](https://github.com/nats-io/nats-architecture-and-design/blob/main/adr/ADR-42.md)

---

This is mostly a port of the implementation in nats.go – but adapted to try be in-line with the way things are done in nats.py. 