### PR TITLE
Fix NotFoundError by adding stream name to ObjectStore.watcher._sub

### DIFF
--- a/nats/src/nats/js/object_store.py
+++ b/nats/src/nats/js/object_store.py
@@ -200,7 +200,11 @@ class ObjectStore:
             return result
 
         chunk_subj = OBJ_CHUNKS_PRE_TEMPLATE.format(bucket=self._name, obj=info.nuid)
-        sub = await self._js.subscribe(subject=chunk_subj, ordered_consumer=True)
+        sub = await self._js.subscribe(
+            subject=chunk_subj,
+            stream=self._stream,
+            ordered_consumer=True,
+        )
 
         h = sha256()
 
@@ -488,7 +492,7 @@ class ObjectStore:
             deliver_policy = api.DeliverPolicy.LAST_PER_SUBJECT
 
         watcher._sub = await self._js.subscribe(
-            all_meta,
+            subject=all_meta,
             stream=self._stream,
             cb=watch_updates,
             ordered_consumer=True,


### PR DESCRIPTION
When using object store, it always raises NotFoundError when doing object_store.list(), even when the status detects content
(status: ObjectStore.ObjectStoreStatus = await object_store.status())

With this fix it should work from now on.

Probably fixes the issue https://github.com/nats-io/nats.py/issues/505