### PR TITLE
fix: missing _python38_iso_parsing method

### DIFF
--- a/nats/src/nats/js/api.py
+++ b/nats/src/nats/js/api.py
@@ -86,6 +86,17 @@ class Base:
         return int(val * _NANOSECOND)
 
     @classmethod
+    def _python38_iso_parsing(cls, time_string: str):
+        # Replace Z with UTC offset
+        s = time_string.replace("Z", "+00:00")
+        # Trim fractional seconds to 6 digits
+        date_part, frac_tz = s.split(".", 1)
+        frac, tz = frac_tz.split("+")
+        frac = frac[:6]  # keep only microseconds
+        s = f"{date_part}.{frac}+{tz}"
+        return s
+
+    @classmethod
     def from_response(cls: type[_B], resp: Dict[str, Any]) -> _B:
         """Read the class instance from a server response.
 
@@ -710,17 +721,6 @@ class RawStreamMsg(Base):
         header returns the headers from a message.
         """
         return self.headers
-
-    @classmethod
-    def _python38_iso_parsing(cls, time_string: str):
-        # Replace Z with UTC offset
-        s = time_string.replace("Z", "+00:00")
-        # Trim fractional seconds to 6 digits
-        date_part, frac_tz = s.split(".", 1)
-        frac, tz = frac_tz.split("+")
-        frac = frac[:6]  # keep only microseconds
-        s = f"{date_part}.{frac}+{tz}"
-        return s
 
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):


### PR DESCRIPTION
Fix for https://github.com/nats-io/nats.py/issues/818 introduced in https://github.com/nats-io/nats.py/pull/766