### PR TITLE
Fix docs and CI alignment

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,8 @@ on:
     pull_request:
         branches:
             - "*"
+permissions:
+    contents: read
 jobs:
     format:
         runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
         branches:
             - "**"
 
+permissions:
+    contents: read
+
 jobs:
     nats:
         runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ uv run pytest
 
 # Run tests for specific package
 uv run pytest nats/tests
+uv run pytest nats-core/tests
+uv run pytest nats-jetstream/tests
 uv run pytest nats-server/tests
 
 # Run tests in parallel
@@ -44,30 +46,23 @@ uv run pytest --cov
 ### Type Checking
 
 ```bash
-uv run mypy nats/src
+uv run ty check
 ```
 
 ### Formatting
 
 ```bash
 # Format code
-uv run yapf -i -r nats/src nats-server/src
+uv run ruff format
 
 # Check formatting
-uv run yapf -d -r nats/src nats-server/src
+uv run ruff format --check
 ```
 
 ### Linting
 
 ```bash
-# Run ruff
-uv run ruff check nats/src nats-server/src
-
-# Run flake8 (for nats-py)
-uv run flake8 nats/src/nats/js/
-
-# Run isort
-uv run isort nats/src nats-server/src
+uv run ruff check
 ```
 
 ## Updating Documentation

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,14 @@ deps:
 
 
 format:
-	uv run yapf -i --recursive $(SOURCE_CODE)
-	uv run yapf -i --recursive nats/tests
+	uv run ruff format $(SOURCE_CODE) nats/tests
 
 
 test:
-	uv run yapf --recursive --diff $(SOURCE_CODE)
-	uv run yapf --recursive --diff nats/tests
-	uv run mypy
+	uv run ruff format --check $(SOURCE_CODE) nats/tests
 	uv run ruff check $(SOURCE_CODE)
+	uv run codespell
+	uv run ty check
 	uv run pytest
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Python workspace for [NATS messaging system](https://nats.io), containing:
 The main NATS client for Python, providing async/await support for pub/sub and JetStream.
 
 **Installation:** `pip install nats-py`  
-**Documentation:** See [Getting Started](#getting-started) and [Examples](#examples) below
+**Documentation:** See [Getting Started](#getting-started) and [JetStream](#jetstream) below
 
 ### nats-server
 


### PR DESCRIPTION
CONTRIBUTING.md and Makefile reference yapf, mypy, flake8, and isort but CI uses ruff and ty. Aligns docs and Makefile with CI. Also fixes broken README anchor and adds workflow permissions.