### PR TITLE
fix: add error code 10164 for CAS wrong last sequence

### DIFF
--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -279,7 +279,7 @@ class KeyValue:
             pa = await self._js.publish(f"{self._pre}{key}", value, headers=hdrs, msg_ttl=msg_ttl)
         except nats.js.errors.APIError as err:
             # Check for a BadRequest::KeyWrongLastSequenceError error code.
-            if err.err_code == 10071:
+            if err.err_code in (10071, 10164):
                 raise nats.js.errors.KeyWrongLastSequenceError(description=err.description)
             else:
                 raise err


### PR DESCRIPTION
## Summary
Fixes #782.
**Root cause:** Server returns error code 10164 (`JSStreamWrongLastSequenceConstantErr`) but the client only mapped 10071 to `KeyWrongLastSequenceError`, causing the CAS error to not be properly identified.
**Fix:** Added error code 10164 mapping to `KeyWrongLastSequenceError`.
## Changes
- Added 10164 error code mapping alongside existing 10071
## Testing
- Verified fix correctly maps both error codes
- Change is minimal and follows existing error mapping patterns

Made with [Cursor](https://cursor.com)