### PR TITLE
Avoid cancelling current task on close

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -734,13 +734,23 @@ class Client:
         # Kick the flusher once again so that Task breaks and avoid pending futures.
         await self._flush_pending()
 
-        if self._reading_task is not None and not self._reading_task.cancelled():
+        # Avoid cancelling the current task when _close is called from within
+        # one of these tasks (e.g. _read_loop via _process_op_err), otherwise
+        # the cancellation fires during the asyncio.sleep(0) below and the
+        # disconnect/close callbacks are never invoked.
+        current = asyncio.current_task()
+
+        if self._reading_task is not None and not self._reading_task.cancelled() and self._reading_task is not current:
             self._reading_task.cancel()
 
-        if self._ping_interval_task is not None and not self._ping_interval_task.cancelled():
+        if (
+            self._ping_interval_task is not None
+            and not self._ping_interval_task.cancelled()
+            and self._ping_interval_task is not current
+        ):
             self._ping_interval_task.cancel()
 
-        if self._flusher_task is not None and not self._flusher_task.cancelled():
+        if self._flusher_task is not None and not self._flusher_task.cancelled() and self._flusher_task is not current:
             self._flusher_task.cancel()
 
         if self._reconnection_task is not None and not self._reconnection_task.done():

--- a/nats/tests/test_client.py
+++ b/nats/tests/test_client.py
@@ -3018,6 +3018,35 @@ class ClientDisconnectTest(SingleServerTestCase):
         disconnected_states[0] == NATS.RECONNECTING
         disconnected_states[1] == NATS.CLOSED
 
+    @async_test
+    async def test_disconnected_cb_called_when_allow_reconnect_false(self):
+        disconnected = asyncio.Future()
+        closed = asyncio.Future()
+
+        async def disconnected_cb():
+            if not disconnected.done():
+                disconnected.set_result(True)
+
+        async def closed_cb():
+            if not closed.done():
+                closed.set_result(True)
+
+        nc = await nats.connect(
+            "localhost:4222",
+            allow_reconnect=False,
+            disconnected_cb=disconnected_cb,
+            closed_cb=closed_cb,
+        )
+        self.assertTrue(nc.is_connected)
+
+        # Kill the server to trigger a connection loss.
+        await asyncio.get_running_loop().run_in_executor(None, self.server_pool[0].stop)
+
+        # Both callbacks should fire even with allow_reconnect=False.
+        await asyncio.wait_for(disconnected, 5)
+        await asyncio.wait_for(closed, 5)
+        self.assertTrue(nc.is_closed)
+
 
 class ClientServerPoolTest(MultiServerAuthTestCase):
     @async_test


### PR DESCRIPTION
Skip cancelling background tasks if they are the current asyncio task to avoid cancellations during asyncio.sleep(0) that can prevent callbacks.

Fixes https://github.com/nats-io/nats.py/issues/806