### PR TITLE
Fix flush hanging when internal tasks are cancelled externally

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -1192,6 +1192,15 @@ class Client:
         if self.is_closed:
             raise errors.ConnectionClosedError
 
+        # If the internal loops are dead (e.g. cancelled externally by
+        # Python < 3.11 SIGINT handling), fall back to a direct flush
+        # since a PING/PONG round-trip requires the read loop.
+        if (self._reading_task is None or self._reading_task.done()) or (
+            self._flusher_task is None or self._flusher_task.done()
+        ):
+            await self._flush_pending()
+            return
+
         future: asyncio.Future = asyncio.Future()
         try:
             await self._send_ping(future)
@@ -1371,6 +1380,18 @@ class Client:
         try:
             future: asyncio.Future = asyncio.Future()
             if not self.is_connected:
+                future.set_result(None)
+                return future
+
+            # If the flusher task is dead (e.g. cancelled externally by
+            # Python < 3.11 SIGINT handling), flush inline instead of
+            # queueing a future that will never be resolved.
+            if self._flusher_task is None or self._flusher_task.done():
+                if self._pending_data_size > 0:
+                    self._transport.writelines(self._pending[:])
+                    self._pending = []
+                    self._pending_data_size = 0
+                    await self._transport.drain()
                 future.set_result(None)
                 return future
 

--- a/nats/tests/test_client.py
+++ b/nats/tests/test_client.py
@@ -1095,6 +1095,38 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(0, err_count)
 
     @async_test
+    async def test_flush_and_close_after_task_cancellation(self):
+        """
+        Simulate what Python < 3.11 does on CTRL-C: cancel all running tasks.
+        After external cancellation of internal tasks, flush() and close()
+        should not hang.
+        See https://github.com/nats-io/nats.py/issues/287
+        """
+        nc = NATS()
+        await nc.connect()
+        await nc.flush()
+
+        # Cancel internal tasks to simulate Python < 3.11 SIGINT behavior.
+        for task in [nc._reading_task, nc._flusher_task, nc._ping_interval_task]:
+            if task and not task.done():
+                task.cancel()
+
+        # Let the cancellations propagate.
+        await asyncio.sleep(0.5)
+
+        # flush() should not hang even though the flusher and read loop are dead.
+        try:
+            await asyncio.wait_for(nc.flush(), timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self.fail("flush() should not hang after internal tasks are cancelled")
+
+        # close() should not hang either.
+        try:
+            await asyncio.wait_for(nc.close(), timeout=2)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self.fail("close() should not hang after internal tasks are cancelled")
+
+    @async_test
     async def test_connect_after_close(self):
         nc = await nats.connect()
         with self.assertRaises(nats.errors.NoRespondersError):


### PR DESCRIPTION
Closes https://github.com/nats-io/nats.py/issues/287
Closes https://github.com/nats-io/nats.py/issues/469

Supersedes #642 