### PR TITLE
use pull subscriber configured name if provided

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -601,6 +601,8 @@ class JetStreamContext(JetStreamManager):
             if durable:
                 config.name = durable
                 config.durable_name = durable
+            elif config.name:
+                consumer_name = config.name
             else:
                 consumer_name = self._nc._nuid.next().decode()
                 config.name = consumer_name


### PR DESCRIPTION
Currently when defining an ephemeral pull_subscriber with a name, the name is not actually sent to NATS and a random one is generated (in the else block below my addition).