### PR TITLE
Add stop() to MessageStream protocol

### DIFF
--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -414,6 +414,10 @@ class MessageStream(AsyncIterable, Protocol):
         """Get the next message from the stream."""
         ...
 
+    async def stop(self) -> None:
+        """Stop the message stream."""
+        ...
+
 
 class Consumer(Protocol):
     """Protocol for a JetStream consumer."""

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -469,7 +469,7 @@ class PullMessageStream(MessageStream):
             # If heartbeat monitor fails, don't terminate the stream
             pass
 
-    async def stop(self):
+    async def stop(self) -> None:
         """Stop the message stream and clean up resources."""
         await self._cleanup()
 


### PR DESCRIPTION
## Summary
- Adds `async def stop()` to the `MessageStream` Protocol so callers can stop a stream through the protocol type without needing a cast to the concrete implementation.
- Both `PullMessageStream` and `_OrderedMessageStream` already implement `stop()`.

## Test plan
- [ ] Verify `uv run ruff check` passes
- [ ] Verify existing tests pass (`uv run pytest nats-jetstream/tests`)