### PR TITLE
Add close() and context manager to Consumer protocol

### DIFF
--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Literal,
     Protocol,
+    Self,
     overload,
 )
 
@@ -489,4 +490,16 @@ class Consumer(Protocol):
         max_bytes: int | None = None,
     ) -> MessageStream:
         """Get a message stream for continuous message consumption."""
+        ...
+
+    async def close(self) -> None:
+        """Close the consumer."""
+        ...
+
+    async def __aenter__(self) -> Self:
+        """Enter the consumer context."""
+        ...
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the consumer context."""
         ...

--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -500,6 +501,11 @@ class Consumer(Protocol):
         """Enter the consumer context."""
         ...
 
-    async def __aexit__(self, *args: object) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit the consumer context."""
         ...

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -8,6 +8,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Self,
     overload,
 )
 
@@ -518,6 +519,18 @@ class PullConsumer(Consumer):
     async def get_info(self) -> ConsumerInfo:
         # Refresh info from server
         return self._info
+
+    async def close(self) -> None:
+        """Close the consumer."""
+        pass
+
+    async def __aenter__(self) -> Self:
+        """Enter the consumer context."""
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        """Exit the consumer context."""
+        await self.close()
 
     async def next(
         self,

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import time
+from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -521,14 +522,24 @@ class PullConsumer(Consumer):
         return self._info
 
     async def close(self) -> None:
-        """Close the consumer."""
+        """Close the consumer.
+
+        No-op for pull consumers — server-side resources are left to expire
+        via inactive_threshold. Subclasses (e.g. OrderedConsumer) override
+        this to proactively delete ephemeral consumers.
+        """
         pass
 
     async def __aenter__(self) -> Self:
         """Enter the consumer context."""
         return self
 
-    async def __aexit__(self, *args: object) -> None:
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         """Exit the consumer context."""
         await self.close()
 


### PR DESCRIPTION
## Summary
- Adds `close()`, `__aenter__()`, and `__aexit__()` to the `Consumer` Protocol so consumers can be used as async context managers through the protocol type.

## Test plan
- [ ] Verify `uv run ruff check` passes
- [ ] Verify existing tests pass (`uv run pytest nats-jetstream/tests`)