### PR TITLE
fix: use `is None` instead of `== None` (PEP 8 E711)

### DIFF
--- a/nats/tests/test_client_v2.py
+++ b/nats/tests/test_client_v2.py
@@ -16,7 +16,7 @@ class HeadersTest(SingleServerTestCase):
         await nc.publish("foo", b"hello world", headers={"foo": "bar", "hello": "world-1"})
 
         msg = await sub.next_msg()
-        self.assertTrue(msg.headers != None)
+        self.assertTrue(msg.headers is not None)
         self.assertEqual(len(msg.headers), 2)
 
         self.assertEqual(msg.headers["foo"], "bar")
@@ -37,7 +37,7 @@ class HeadersTest(SingleServerTestCase):
         await nc.flush()
         msg = await nc.request("foo", b"hello world", headers={"foo": "bar", "hello": "world"})
 
-        self.assertTrue(msg.headers != None)
+        self.assertTrue(msg.headers is not None)
         self.assertEqual(len(msg.headers), 3)
         self.assertEqual(msg.headers["foo"], "bar")
         self.assertEqual(msg.headers["hello"], "world")
@@ -55,17 +55,17 @@ class HeadersTest(SingleServerTestCase):
         await nc.publish("foo", b"hello world", headers={"": ""})
 
         msg = await sub.next_msg()
-        self.assertTrue(msg.headers == None)
+        self.assertTrue(msg.headers is None)
 
         # Empty long key
         await nc.publish("foo", b"hello world", headers={"      ": ""})
         msg = await sub.next_msg()
-        self.assertTrue(msg.headers == None)
+        self.assertTrue(msg.headers is None)
 
         # Empty long key
         await nc.publish("foo", b"hello world", headers={"": "                  "})
         msg = await sub.next_msg()
-        self.assertTrue(msg.headers == None)
+        self.assertTrue(msg.headers is None)
 
         hdrs = {
             "timestamp": "2022-06-15T19:08:14.639020",


### PR DESCRIPTION
## Summary

Replaces `== None` / `!= None` comparisons with `is None` / `is not None` in test files, per PEP 8 E711 recommendation.

**Change:**
```python
# Before
if result == None:
    ...
if value != None:
    ...

# After
if result is None:
    ...
if value is not None:
    ...
```

## Why

- `is None` is the canonical way to test for `None` in Python. `None` is a singleton, so identity comparison is both faster and more correct.
- `== None` can produce unexpected behavior for objects that override `__eq__` (for example, NumPy arrays).
- Flagged by [PEP 8 E711](https://www.flake8rules.com/rules/E711.html) and by most linters (flake8, pylint, ruff).

## Testing

No behavior change for typical cases — only stylistic fixes.
