### PR TITLE
Use base64url without padding for nonce signatures

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1336,7 +1336,7 @@ def _setup_nkey_auth(
     def signature_handler(nonce: str) -> bytes:
         kp = nkeys.from_seed(seed_bytes)
         sig = kp.sign(nonce.encode())
-        return base64.b64encode(sig)
+        return base64.urlsafe_b64encode(sig).rstrip(b"=")
 
     return public_key_handler, signature_handler
 
@@ -1413,7 +1413,7 @@ def _setup_jwt_auth(
     def signature_handler(nonce: str) -> bytes:
         kp = nkeys.from_seed(seed_bytes)
         sig = kp.sign(nonce.encode())
-        return base64.b64encode(sig)
+        return base64.urlsafe_b64encode(sig).rstrip(b"=")
 
     return jwt_handler, signature_handler
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -312,7 +312,7 @@ def nkey_handlers():
     def signature_handler(nonce: str) -> bytes:
         kp = nkeys.from_seed(seed_bytes)
         sig = kp.sign(nonce.encode())
-        return base64.b64encode(sig)
+        return base64.urlsafe_b64encode(sig).rstrip(b"=")
 
     return (public_key_handler, signature_handler)
 
@@ -348,7 +348,7 @@ def jwt_handlers():
     def signature_handler(nonce: str) -> bytes:
         kp = nkeys.from_seed(seed_bytes)
         sig = kp.sign(nonce.encode())
-        return base64.b64encode(sig)
+        return base64.urlsafe_b64encode(sig).rstrip(b"=")
 
     return (jwt_handler, signature_handler)
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 import os
 import sys
 import uuid
@@ -2865,6 +2866,72 @@ async def test_reconnect_with_jwt(jwt):
             await server.shutdown()
         except Exception:
             pass
+
+
+@pytest.mark.parametrize(
+    "auth_kwargs",
+    [
+        {"nkey": "SUAEIV5COV7ADQZE52WTYHVJQRV7WKJE5J7IBBJGATJTUUT2LVFGVXDPRQ"},
+        {"jwt": Path(__file__).parent / "jwts" / "foo-user.creds"},
+    ],
+    ids=["nkey", "jwt"],
+)
+@pytest.mark.asyncio
+async def test_nonce_signature_is_base64url_without_padding(auth_kwargs):
+    """The signature sent in CONNECT is base64url-encoded without padding (ADR-14)."""
+    captured: asyncio.Future[dict] = asyncio.get_running_loop().create_future()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        info = {
+            "server_id": "test",
+            "server_name": "test",
+            "version": "test",
+            "proto": 1,
+            "go": "test",
+            "host": "127.0.0.1",
+            "port": 4222,
+            "max_payload": 1048576,
+            "headers": True,
+            "auth_required": True,
+            "nonce": "test_nonce",
+        }
+        writer.write(f"INFO {json.dumps(info)}\r\n".encode())
+        await writer.drain()
+
+        connect_line = await reader.readline()
+        if connect_line.startswith(b"CONNECT ") and not captured.done():
+            captured.set_result(json.loads(connect_line[len(b"CONNECT ") :].rstrip(b"\r\n")))
+
+        await reader.readline()  # consume PING
+        writer.write(b"PONG\r\n")
+        await writer.drain()
+
+        # Hold the connection open until the client closes it.
+        while await reader.read(4096):
+            pass
+
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    url = f"nats://{host}:{port}"
+
+    try:
+        client = await connect(url, timeout=1.0, allow_reconnect=False, **auth_kwargs)
+        await client.close()
+        connect_msg = await asyncio.wait_for(captured, timeout=5.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    sig = connect_msg["sig"]
+    assert "=" not in sig
+    assert "+" not in sig
+    assert "/" not in sig
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
ADR-14 and Go (base64.RawURLEncoding) specify URL-safe base64 without padding for the nonce signature sent in CONNECT.

The nkey and JWT signature handlers were emitting standard base64 (+/ with = padding), which strict servers reject.