### PR TITLE
Reject oversize publishes locally against server max_payload

### DIFF
--- a/nats-core/benches/bench_protocol.py
+++ b/nats-core/benches/bench_protocol.py
@@ -41,36 +41,40 @@ def test_bench_encode_hpub_single_header(benchmark):
     """Benchmark encoding HPUB command with single header."""
     subject = "test.subject"
     payload = b"hello world"
-    headers = {"X-Custom": "value"}
+    header_data = command.encode_headers({"X-Custom": "value"})
 
-    benchmark(command.encode_hpub, subject, payload, headers=headers)
+    benchmark(command.encode_hpub, subject, payload, header_data=header_data)
 
 
 def test_bench_encode_hpub_multiple_headers(benchmark):
     """Benchmark encoding HPUB command with multiple headers."""
     subject = "test.subject"
     payload = b"hello world"
-    headers = {
-        "X-Custom-1": "value1",
-        "X-Custom-2": "value2",
-        "X-Custom-3": "value3",
-        "Content-Type": "application/json",
-        "X-Request-ID": "12345-67890-abcdef",
-    }
+    header_data = command.encode_headers(
+        {
+            "X-Custom-1": "value1",
+            "X-Custom-2": "value2",
+            "X-Custom-3": "value3",
+            "Content-Type": "application/json",
+            "X-Request-ID": "12345-67890-abcdef",
+        }
+    )
 
-    benchmark(command.encode_hpub, subject, payload, headers=headers)
+    benchmark(command.encode_hpub, subject, payload, header_data=header_data)
 
 
 def test_bench_encode_hpub_multivalue_headers(benchmark):
     """Benchmark encoding HPUB command with multi-value headers."""
     subject = "test.subject"
     payload = b"hello world"
-    headers = {
-        "X-Custom": ["value1", "value2", "value3"],
-        "X-Tags": ["tag1", "tag2", "tag3", "tag4"],
-    }
+    header_data = command.encode_headers(
+        {
+            "X-Custom": ["value1", "value2", "value3"],
+            "X-Tags": ["tag1", "tag2", "tag3", "tag4"],
+        }
+    )
 
-    benchmark(command.encode_hpub, subject, payload, headers=headers)
+    benchmark(command.encode_hpub, subject, payload, header_data=header_data)
 
 
 def test_bench_encode_hpub_with_reply(benchmark):
@@ -78,9 +82,9 @@ def test_bench_encode_hpub_with_reply(benchmark):
     subject = "test.subject"
     payload = b"hello world"
     reply = "reply.subject"
-    headers = {"X-Custom": "value"}
+    header_data = command.encode_headers({"X-Custom": "value"})
 
-    benchmark(command.encode_hpub, subject, payload, reply=reply, headers=headers)
+    benchmark(command.encode_hpub, subject, payload, reply=reply, header_data=header_data)
 
 
 def test_bench_encode_sub(benchmark):

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -43,6 +43,7 @@ from nats.client.errors import MaxPayloadError, NoRespondersError, SlowConsumerE
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
     encode_connect,
+    encode_headers,
     encode_hpub,
     encode_ping,
     encode_pong,
@@ -972,23 +973,32 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        max_payload = self._server_info.max_payload
-        if max_payload > 0 and len(payload) > max_payload:
-            raise MaxPayloadError(len(payload), max_payload)
-
         if isinstance(subject, str):
             subject = subject.encode()
 
         if isinstance(reply, str):
             reply = reply.encode()
 
+        # HPUB is what the server measures against max_payload, so include the
+        # encoded header block in the size check. Encode headers once and reuse.
+        header_data: bytes | None = None
         if headers:
             headers_dict = headers.asdict() if isinstance(headers, Headers) else headers
+            header_data = encode_headers(headers_dict)  # type: ignore[arg-type]
+            size = len(header_data) + len(payload)
+        else:
+            size = len(payload)
+
+        max_payload = self._server_info.max_payload
+        if max_payload > 0 and size > max_payload:
+            raise MaxPayloadError(size, max_payload)
+
+        if header_data is not None:
             message_data = encode_hpub(
                 subject,
                 payload,
                 reply=reply,
-                headers=headers_dict,  # type: ignore[arg-type]
+                header_data=header_data,
             )
         else:
             message_data = encode_pub(

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -39,7 +39,7 @@ from urllib.parse import urlparse
 
 import nkeys
 from nats.client.connection import Connection, open_tcp_connection
-from nats.client.errors import NoRespondersError, SlowConsumerError, StatusError
+from nats.client.errors import MaxPayloadError, NoRespondersError, SlowConsumerError, StatusError
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
     encode_connect,
@@ -963,10 +963,18 @@ class Client(AbstractAsyncContextManager["Client"]):
             payload: Message payload
             reply: Optional reply subject (str or bytes for zero-copy optimization)
             headers: Optional message headers
+
+        Raises:
+            RuntimeError: Connection is closed.
+            MaxPayloadError: The payload is larger than the server's ``max_payload``.
         """
         if self._status in (ClientStatus.CLOSED, ClientStatus.CLOSING):
             msg = "Connection is closed"
             raise RuntimeError(msg)
+
+        max_payload = self._server_info.max_payload
+        if max_payload > 0 and len(payload) > max_payload:
+            raise MaxPayloadError(len(payload), max_payload)
 
         if isinstance(subject, str):
             subject = subject.encode()
@@ -1674,4 +1682,5 @@ __all__ = [
     "ClientStatistics",
     "StatusError",
     "NoRespondersError",
+    "MaxPayloadError",
 ]

--- a/nats-core/src/nats/client/errors.py
+++ b/nats-core/src/nats/client/errors.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
-__all__ = ["StatusError", "NoRespondersError", "SlowConsumerError"]
+__all__ = ["MaxPayloadError", "NoRespondersError", "SlowConsumerError", "StatusError"]
+
+
+class MaxPayloadError(ValueError):
+    """Raised when a published payload exceeds the server's ``max_payload``.
+
+    The client checks this locally against the ``max_payload`` value advertised
+    by the server in its INFO message, so callers see a clear error before the
+    frame is written to the wire instead of an opaque server-side disconnect.
+    """
+
+    size: int
+    max_payload: int
+
+    def __init__(self, size: int, max_payload: int) -> None:
+        self.size = size
+        self.max_payload = max_payload
+        super().__init__(f"payload of {size} bytes exceeds server max_payload of {max_payload} bytes")
 
 
 class StatusError(Exception):

--- a/nats-core/src/nats/client/protocol/command.py
+++ b/nats-core/src/nats/client/protocol/command.py
@@ -49,12 +49,20 @@ def encode_pub(
     return command + payload + b"\r\n"
 
 
+def encode_headers(headers: dict[str, str | list[str]]) -> bytes:
+    """Encode a headers dict into the ``NATS/1.0`` wire form, including the trailing blank line."""
+    header_lines = ["NATS/1.0"] + [
+        f"{key}: {item}" for key, value in headers.items() for item in (value if isinstance(value, list) else [value])
+    ]
+    return ("\r\n".join(header_lines) + "\r\n\r\n").encode()
+
+
 def encode_hpub(
     subject: bytes,
     payload: bytes,
     *,
     reply: bytes | None = None,
-    headers: dict[str, str | list[str]],
+    header_data: bytes,
 ) -> bytes:
     """Encode HPUB command.
 
@@ -62,17 +70,11 @@ def encode_hpub(
         subject: Subject to publish to
         payload: Message payload
         reply: Optional reply subject
-        headers: Headers to include with the message
+        header_data: Pre-encoded header block (see :func:`encode_headers`)
 
     Returns:
         Encoded HPUB command with headers and payload
     """
-    header_lines = ["NATS/1.0"] + [
-        f"{key}: {item}" for key, value in headers.items() for item in (value if isinstance(value, list) else [value])
-    ]
-
-    header_data = ("\r\n".join(header_lines) + "\r\n\r\n").encode()
-
     hdr_len = len(header_data)
     total_len = hdr_len + len(payload)
 

--- a/nats-core/tests/configs/server_max_payload.conf
+++ b/nats-core/tests/configs/server_max_payload.conf
@@ -1,0 +1,2 @@
+# NATS server config for testing max_payload enforcement.
+max_payload: 1024

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -11,6 +11,7 @@ from nacl.signing import SigningKey
 from nats.client import (
     ClientStatistics,
     ClientStatus,
+    MaxPayloadError,
     NoRespondersError,
     SlowConsumerError,
     connect,
@@ -2888,5 +2889,46 @@ async def test_connect_with_nkey_and_jwt_precedence():
             # Expected - JWT auth attempted (and failed on nkey server)
             pass
 
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_max_payload_error_before_send():
+    """publish() rejects oversize payloads locally with MaxPayloadError, not via server disconnect."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_max_payload.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        client = await connect(server.client_url, timeout=1.0)
+        try:
+            assert client.server_info is not None
+            max_payload = client.server_info.max_payload
+            assert max_payload == 1024
+
+            subject = f"test.maxpayload.{uuid.uuid4()}"
+            subscription = await client.subscribe(subject)
+            await client.flush()
+
+            # Within limit — delivered normally.
+            ok_payload = b"x" * max_payload
+            await client.publish(subject, ok_payload)
+            message = await subscription.next(timeout=1.0)
+            assert len(message.data) == max_payload
+
+            # Over limit — rejected locally before the frame is written.
+            oversize = b"x" * (max_payload + 1)
+            with pytest.raises(MaxPayloadError) as exc_info:
+                await client.publish(subject, oversize)
+            assert exc_info.value.size == max_payload + 1
+            assert exc_info.value.max_payload == max_payload
+
+            # Connection must still be usable after the rejected publish.
+            assert client.status == ClientStatus.CONNECTED
+            await client.publish(subject, b"after-reject")
+            message = await subscription.next(timeout=1.0)
+            assert message.data == b"after-reject"
+        finally:
+            await client.close()
     finally:
         await server.shutdown()

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -2893,7 +2893,6 @@ async def test_connect_with_nkey_and_jwt_precedence():
         await server.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_publish_raises_max_payload_error_before_send():
     """publish() rejects oversize payloads locally with MaxPayloadError, not via server disconnect."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_max_payload.conf")
@@ -2928,6 +2927,40 @@ async def test_publish_raises_max_payload_error_before_send():
             await client.publish(subject, b"after-reject")
             message = await subscription.next(timeout=1.0)
             assert message.data == b"after-reject"
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_publish_with_headers_counts_header_bytes_against_max_payload():
+    """HPUB is measured by the server as (header bytes + payload bytes)."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_max_payload.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        client = await connect(server.client_url, timeout=1.0)
+        try:
+            max_payload = client.server_info.max_payload
+            assert max_payload == 1024
+
+            subject = f"test.maxpayload.hpub.{uuid.uuid4()}"
+
+            # Payload alone is under the limit, but the encoded headers push the
+            # HPUB frame over it.
+            payload = b"x" * 500
+            headers = {"X-Large": "v" * 600}
+            with pytest.raises(MaxPayloadError) as exc_info:
+                await client.publish(subject, payload, headers=headers)
+            assert exc_info.value.size > max_payload
+            assert exc_info.value.max_payload == max_payload
+
+            # HPUB under the limit still succeeds.
+            subscription = await client.subscribe(subject)
+            await client.flush()
+            await client.publish(subject, b"ok", headers={"X-Small": "v"})
+            message = await subscription.next(timeout=1.0)
+            assert message.data == b"ok"
         finally:
             await client.close()
     finally:

--- a/nats-core/tests/test_protocol.py
+++ b/nats-core/tests/test_protocol.py
@@ -6,6 +6,7 @@ import json
 import pytest
 from nats.client.protocol.command import (
     encode_connect,
+    encode_headers,
     encode_hpub,
     encode_ping,
     encode_pong,
@@ -183,9 +184,10 @@ def test_encode_hpub():
     """Test encoding HPUB command."""
     headers = {"foo": "bar", "multi": ["val1", "val2"]}
     payload = b"hello"
+    header_data = encode_headers(headers)
 
     # Test without reply
-    command = encode_hpub(b"foo.bar", payload, headers=headers)
+    command = encode_hpub(b"foo.bar", payload, header_data=header_data)
     assert isinstance(command, bytes)
     assert command.startswith(b"HPUB foo.bar")
     assert b"NATS/1.0\r\n" in command
@@ -196,7 +198,7 @@ def test_encode_hpub():
     assert b"multi: val2" in command
 
     # Test with reply
-    command = encode_hpub(b"foo.bar", payload, reply=b"reply.to", headers=headers)
+    command = encode_hpub(b"foo.bar", payload, reply=b"reply.to", header_data=header_data)
     assert isinstance(command, bytes)
     assert command.startswith(b"HPUB foo.bar reply.to")
     assert b"NATS/1.0\r\n" in command


### PR DESCRIPTION
Client publish() now compares the payload length against the max_payload value from the server's INFO and raises MaxPayloadError before writing the frame.

Previously the client would queue the frame and the server would tear down the connection on receipt, giving callers an opaque error instead of a targeted one.