### PR TITLE
Use credentials embedded in the connect URL

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1522,6 +1522,17 @@ async def connect(
     host = parsed_url.hostname or "localhost"
     port = parsed_url.port or 4222
 
+    # URL-embedded credentials act as defaults for unset arguments.
+    # Username with no password is treated as a token, matching the Go client.
+    if parsed_url.username is not None and parsed_url.password is None:
+        if token is None:
+            token = parsed_url.username
+    else:
+        if user is None and parsed_url.username is not None:
+            user = parsed_url.username
+        if password is None and parsed_url.password is not None:
+            password = parsed_url.password
+
     logger.info("Connecting to %s:%s", host, port)
 
     ssl_context = None

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -2953,3 +2953,97 @@ async def test_lame_duck_mode_callback_exception_is_isolated(client, server):
     server.lame_duck_mode()
     await asyncio.wait_for(second_called.wait(), timeout=5.0)
     assert calls == ["bad", "good"]
+
+
+def _inject_userinfo(url: str, userinfo: str) -> str:
+    """Return ``url`` with ``userinfo`` inserted before the host component."""
+    scheme, rest = url.split("://", 1)
+    return f"{scheme}://{userinfo}@{rest}"
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_user_password_from_url():
+    """URL-embedded ``user:pass@`` is used when no explicit credentials are passed."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_user_pass.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        url = _inject_userinfo(server.client_url, "testuser:testpass")
+        client = await connect(url, timeout=1.0, allow_reconnect=False)
+        try:
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_explicit_credentials_override_url():
+    """Explicit user/password arguments take precedence over URL-embedded credentials."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_user_pass.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        url = _inject_userinfo(server.client_url, "wronguser:wrongpass")
+        client = await connect(
+            url,
+            timeout=1.0,
+            user="testuser",
+            password="testpass",
+            allow_reconnect=False,
+        )
+        try:
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_url_credentials_reject_wrong_value():
+    """URL-embedded credentials are actually sent — a wrong value fails the connect."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_user_pass.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        url = _inject_userinfo(server.client_url, "testuser:wrongpass")
+        with pytest.raises(ConnectionError):
+            await connect(url, timeout=1.0, allow_reconnect=False)
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_connect_uses_token_from_url():
+    """URL ``user@host`` with no password is sent as a token, matching the Go client."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_token.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        url = _inject_userinfo(server.client_url, "test_token_123")
+        client = await connect(url, timeout=1.0, allow_reconnect=False)
+        try:
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_explicit_token_overrides_url():
+    """Explicit ``token`` argument takes precedence over URL-embedded token."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_token.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        url = _inject_userinfo(server.client_url, "wrong_token")
+        client = await connect(url, timeout=1.0, token="test_token_123", allow_reconnect=False)
+        try:
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()


### PR DESCRIPTION
Explicit function arguments take precedence.