### PR TITLE
Validate stream and consumer names before API requests

### DIFF
--- a/nats/src/nats/js/manager.py
+++ b/nats/src/nats/js/manager.py
@@ -31,6 +31,24 @@ NATS_HDR_LINE_SIZE = len(NATS_HDR_LINE)
 _CRLF_ = b"\r\n"
 _CRLF_LEN_ = len(_CRLF_)
 
+# Characters the server cannot use as part of a filesystem path for stream or
+# consumer storage. Matches nats.go's validateStreamName / validateConsumerName.
+_INVALID_NAME_CHARS = ">*. /\\\t\r\n"
+
+
+def _validate_stream_name(name: str) -> None:
+    if not name:
+        raise ValueError("nats: stream name is required")
+    if any(c in _INVALID_NAME_CHARS for c in name):
+        raise ValueError(f"nats: invalid stream name: {name!r}")
+
+
+def _validate_consumer_name(name: str) -> None:
+    if not name:
+        raise ValueError("nats: consumer name is required")
+    if any(c in _INVALID_NAME_CHARS for c in name):
+        raise ValueError(f"nats: invalid consumer name: {name!r}")
+
 
 class JetStreamManager:
     """
@@ -68,6 +86,7 @@ class JetStreamManager:
         """
         Get the latest StreamInfo by stream name.
         """
+        _validate_stream_name(name)
         req_data = ""
         if subjects_filter:
             req_data = json.dumps({"subjects_filter": subjects_filter})
@@ -89,18 +108,7 @@ class JetStreamManager:
         stream_name = config.name
         if stream_name is None:
             raise ValueError("nats: stream name is required")
-
-        # Validate stream name
-        invalid_chars = set(".*>/\\")
-        has_invalid_chars = any(char in stream_name for char in invalid_chars)
-        has_whitespace = any(char.isspace() for char in stream_name)
-        is_not_printable = not stream_name.isprintable()
-
-        if has_invalid_chars or has_whitespace or is_not_printable:
-            raise ValueError(
-                f"nats: stream name ({stream_name}) is invalid. Names cannot contain whitespace, '.', '*', '>', "
-                "path separators (forward or backward slash), or non-printable characters."
-            )
+        _validate_stream_name(stream_name)
 
         data = json.dumps(config.as_dict())
         resp = await self._api_request(
@@ -119,6 +127,7 @@ class JetStreamManager:
         config = config.evolve(**params)
         if config.name is None:
             raise ValueError("nats: stream name is required")
+        _validate_stream_name(config.name)
 
         data = json.dumps(config.as_dict())
         resp = await self._api_request(
@@ -134,6 +143,7 @@ class JetStreamManager:
 
         :param name: The name of the stream to delete.
         """
+        _validate_stream_name(name)
         resp = await self._api_request(f"{self._prefix}.STREAM.DELETE.{name}", timeout=self._timeout)
         return resp["success"]
 
@@ -147,6 +157,7 @@ class JetStreamManager:
         """
         Purge a stream by name.
         """
+        _validate_stream_name(name)
         stream_req: Dict[str, Any] = {}
         if seq:
             stream_req["seq"] = seq
@@ -160,7 +171,8 @@ class JetStreamManager:
         return resp["success"]
 
     async def consumer_info(self, stream: str, consumer: str, timeout: Optional[float] = None):
-        # TODO: Validate the stream and consumer names.
+        _validate_stream_name(stream)
+        _validate_consumer_name(consumer)
         if timeout is None:
             timeout = self._timeout
         resp = await self._api_request(f"{self._prefix}.CONSUMER.INFO.{stream}.{consumer}", b"", timeout=timeout)
@@ -200,12 +212,17 @@ class JetStreamManager:
         timeout: Optional[float] = None,
         **params,
     ) -> api.ConsumerInfo:
+        _validate_stream_name(stream)
         if not timeout:
             timeout = self._timeout
         if config is None:
             config = api.ConsumerConfig()
         config = config.evolve(**params)
         durable_name = config.durable_name
+        if config.name:
+            _validate_consumer_name(config.name)
+        if durable_name:
+            _validate_consumer_name(durable_name)
         req = {"stream_name": stream, "config": config.as_dict()}
         req_data = json.dumps(req).encode()
 
@@ -236,6 +253,8 @@ class JetStreamManager:
         :param stream: The name of the stream from which the consumer should be deleted.
         :param consumer: The name of the consumer to be deleted.
         """
+        _validate_stream_name(stream)
+        _validate_consumer_name(consumer)
         resp = await self._api_request(
             f"{self._prefix}.CONSUMER.DELETE.{stream}.{consumer}",
             b"",
@@ -266,6 +285,8 @@ class JetStreamManager:
         Note:
             Requires nats-server 2.11.0 or later
         """
+        _validate_stream_name(stream)
+        _validate_consumer_name(consumer)
         if timeout is None:
             timeout = self._timeout
 
@@ -312,6 +333,7 @@ class JetStreamManager:
         :param stream: stream to get consumers
         :param offset: consumers list offset
         """
+        _validate_stream_name(stream)
         resp = await self._api_request(
             f"{self._prefix}.CONSUMER.LIST.{stream}",
             b"" if offset is None else json.dumps({"offset": offset}).encode(),
@@ -334,6 +356,7 @@ class JetStreamManager:
         """
         get_msg retrieves a message from a stream.
         """
+        _validate_stream_name(stream_name)
         req_subject = None
         req: Dict[str, Any] = {}
         if seq:
@@ -417,6 +440,7 @@ class JetStreamManager:
         :param stream_name: The name of the stream from which the message should be deleted.
         :param seq: The sequence id to delete
         """
+        _validate_stream_name(stream_name)
         req_subject = f"{self._prefix}.STREAM.MSG.DELETE.{stream_name}"
         req = {"seq": seq}
         data = json.dumps(req)

--- a/nats/src/nats/js/manager.py
+++ b/nats/src/nats/js/manager.py
@@ -36,14 +36,14 @@ _CRLF_LEN_ = len(_CRLF_)
 _INVALID_NAME_CHARS = ">*. /\\\t\r\n"
 
 
-def _validate_stream_name(name: str) -> None:
+def _validate_stream_name(name: Optional[str]) -> None:
     if not name:
         raise ValueError("nats: stream name is required")
     if any(c in _INVALID_NAME_CHARS for c in name):
         raise ValueError(f"nats: invalid stream name: {name!r}")
 
 
-def _validate_consumer_name(name: str) -> None:
+def _validate_consumer_name(name: Optional[str]) -> None:
     if not name:
         raise ValueError("nats: consumer name is required")
     if any(c in _INVALID_NAME_CHARS for c in name):
@@ -106,8 +106,6 @@ class JetStreamManager:
         config = config.evolve(**params)
 
         stream_name = config.name
-        if stream_name is None:
-            raise ValueError("nats: stream name is required")
         _validate_stream_name(stream_name)
 
         data = json.dumps(config.as_dict())
@@ -125,8 +123,6 @@ class JetStreamManager:
         if config is None:
             config = api.StreamConfig()
         config = config.evolve(**params)
-        if config.name is None:
-            raise ValueError("nats: stream name is required")
         _validate_stream_name(config.name)
 
         data = json.dumps(config.as_dict())

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -5547,6 +5547,12 @@ class BadStreamNamesTest(SingleJetStreamServerTestCase):
         with pytest.raises(ValueError, match="nats: invalid consumer name"):
             await js.delete_consumer("OK", "bad.consumer")
 
+        with pytest.raises(ValueError, match="nats: invalid consumer name"):
+            await js.add_consumer("OK", name="bad.consumer")
+
+        with pytest.raises(ValueError, match="nats: invalid consumer name"):
+            await js.add_consumer("OK", durable_name="bad.durable")
+
         await js.delete_stream("OK")
         await nc.close()
 

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -5502,18 +5502,53 @@ class BadStreamNamesTest(SingleJetStreamServerTestCase):
             "stream\\name\\with\\backslashes",
             "stream\nname\nwith\nnewlines",
             "stream\tname\twith\ttabs",
-            "stream\x00name\x00with\x00nulls",
         ]
 
         for name in invalid_names:
-            with pytest.raises(
-                ValueError,
-                match=(
-                    f"nats: stream name \\({re.escape(name)}\\) is invalid. Names cannot contain whitespace, '\\.', "
-                    "'\\*', '>', path separators \\(forward or backward slash\\), or non-printable characters."
-                ),
-            ):
+            with pytest.raises(ValueError, match="nats: invalid stream name"):
                 await js.add_stream(name=name)
+
+        await nc.close()
+
+    @async_test
+    async def test_stream_methods_reject_invalid_names(self):
+        # Regression for #305: stream_info() on an invalid name used to time
+        # out instead of surfacing a clear validation error.
+        nc = NATS()
+        await nc.connect()
+        js = nc.jetstream()
+
+        bad = "stream.with.dots"
+        for op in (
+            js.stream_info(bad),
+            js.update_stream(name=bad),
+            js.delete_stream(bad),
+            js.purge_stream(bad),
+            js.get_msg(bad, seq=1),
+            js.delete_msg(bad, 1),
+            js.consumers_info(bad),
+        ):
+            with pytest.raises(ValueError, match="nats: invalid stream name"):
+                await op
+
+        await nc.close()
+
+    @async_test
+    async def test_consumer_methods_reject_invalid_names(self):
+        nc = NATS()
+        await nc.connect()
+        js = nc.jetstream()
+
+        await js.add_stream(name="OK", subjects=["ok"])
+
+        with pytest.raises(ValueError, match="nats: invalid consumer name"):
+            await js.consumer_info("OK", "bad.consumer")
+
+        with pytest.raises(ValueError, match="nats: invalid consumer name"):
+            await js.delete_consumer("OK", "bad.consumer")
+
+        await js.delete_stream("OK")
+        await nc.close()
 
     @async_test
     async def test_object_watch_updates_only(self):


### PR DESCRIPTION
Missing validation on stream_info and the rest of the JetStream manager meant an invalid name (e.g. one containing a dot) led to a generic nats: timeout with no hint about the real cause.

Closes #305.
Closes #641.