### PR TITLE
Handle non-binary WebSocket frame types

### DIFF
--- a/nats/src/nats/aio/transport.py
+++ b/nats/src/nats/aio/transport.py
@@ -238,10 +238,16 @@ class WebSocketTransport(Transport):
 
     async def readline(self):
         data = await self._ws.receive()
-        if data.type == aiohttp.WSMsgType.CLOSED:
-            # if the connection terminated abruptly, return empty binary data to raise unexpected EOF
-            return b""
-        return data.data
+        if data.type == aiohttp.WSMsgType.BINARY:
+            return data.data
+        if data.type == aiohttp.WSMsgType.ERROR:
+            # msg.data is the underlying aiohttp exception. Wrap it in a
+            # ConnectionError so the read loop's OSError handler triggers a
+            # reconnect instead of its generic-Exception log-and-break branch.
+            raise ConnectionError("nats: websocket error") from data.data
+        # CLOSE, CLOSING, CLOSED, TEXT, or any other unexpected frame type:
+        # signal EOF so the read loop goes through its normal reconnect path.
+        return b""
 
     async def drain(self):
         # send all the messages pending


### PR DESCRIPTION
The WebSocket transport was returning \`msg.data\` from \`aiohttp.WebSocketResponse.receive()\` for every frame type other than \`CLOSED\`. For \`CLOSE\`, \`msg.data\` is an \`int\` (the close code), which caused the NATS parser to crash with \`TypeError: can't extend bytearray with int\`, killing the read loop with no reconnect.

- \`BINARY\` → return \`msg.data\` (the bytes).
- \`ERROR\` → wrap the underlying aiohttp exception in \`ConnectionError\` (via \`raise ... from msg.data\`) so it lands in the read loop's \`OSError\` branch and reconnects.
- \`CLOSE\` / \`CLOSING\` / \`CLOSED\` / \`TEXT\` / anything else → return \`b""\` so the read loop treats it as EOF and reconnects.

Closes #673.