### PR TITLE
Fix object store test comparing upload bytes to character count

### DIFF
--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3,6 +3,7 @@ import base64
 import datetime
 import io
 import json
+import os
 import random
 import re
 import string
@@ -4330,13 +4331,10 @@ class ObjectStoreTest(SingleJetStreamServerTestCase):
         assert res.data == b"C"
         assert res.info.digest == "SHA-256=ayPA1fNdGxH5toPwsKYXNV3rESd9ka4JHTmcZVuHlA0="
 
-        with open("README.md") as fp:
-            await obs.put("README.md", fp.buffer)
+        with open("README.md", "rb") as fp:
+            await obs.put("README.md", fp)
 
-        size = 0
-        with open("README.md") as fp:
-            data = fp.read(-1)
-            size = len(data)
+        size = os.path.getsize("README.md")
 
         res = await obs.get("README.md")
         assert res.info.size == size


### PR DESCRIPTION
## Summary

`test_object_multi_files` opened `README.md` in text mode and compared the uploaded **byte** count against `len()` of the decoded **string**. The assertion only held while the README was pure ASCII — as soon as any multi-byte UTF-8 character (e.g. an em-dash) was introduced, bytes and characters diverged and the test failed.

Surfaced by #878, but the test itself was latently broken.

Fix: open in binary mode for the upload and use `os.path.getsize` for the expected size.