### PR TITLE
Enforce server max_payload on publish

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -39,7 +39,7 @@ from urllib.parse import urlparse
 
 import nkeys
 from nats.client.connection import Connection, open_tcp_connection
-from nats.client.errors import NoRespondersError, SlowConsumerError, StatusError
+from nats.client.errors import MaxPayloadError, NoRespondersError, SlowConsumerError, StatusError
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
     encode_connect,
@@ -968,6 +968,9 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
+        if self._server_info is not None and len(payload) > self._server_info.max_payload:
+            raise MaxPayloadError(len(payload), self._server_info.max_payload)
+
         if isinstance(subject, str):
             subject = subject.encode()
 
@@ -1674,4 +1677,6 @@ __all__ = [
     "ClientStatistics",
     "StatusError",
     "NoRespondersError",
+    "SlowConsumerError",
+    "MaxPayloadError",
 ]

--- a/nats-core/src/nats/client/errors.py
+++ b/nats-core/src/nats/client/errors.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__all__ = ["StatusError", "NoRespondersError", "SlowConsumerError"]
+__all__ = ["MaxPayloadError", "NoRespondersError", "SlowConsumerError", "StatusError"]
 
 
 class StatusError(Exception):
@@ -56,6 +56,18 @@ class NoRespondersError(StatusError):
             subject: The subject that caused the error (optional)
         """
         super().__init__(status, description, subject)
+
+
+class MaxPayloadError(ValueError):
+    """Error raised when a published payload exceeds the server's max_payload."""
+
+    size: int
+    max_payload: int
+
+    def __init__(self, size: int, max_payload: int) -> None:
+        self.size = size
+        self.max_payload = max_payload
+        super().__init__(f"payload of {size} bytes exceeds server max_payload of {max_payload} bytes")
 
 
 class SlowConsumerError(Exception):

--- a/nats-core/tests/configs/server_max_payload.conf
+++ b/nats-core/tests/configs/server_max_payload.conf
@@ -1,0 +1,1 @@
+max_payload: 1024

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -11,6 +11,7 @@ from nacl.signing import SigningKey
 from nats.client import (
     ClientStatistics,
     ClientStatus,
+    MaxPayloadError,
     NoRespondersError,
     SlowConsumerError,
     connect,
@@ -761,6 +762,45 @@ async def test_publish_with_byte_reply_subject(client):
     assert message.data == test_payload
     assert message.subject == test_subject
     assert message.reply == reply_subject_str
+
+
+@pytest.mark.asyncio
+async def test_publish_rejects_payload_exceeding_max_payload():
+    """Publishing a payload larger than the server's max_payload raises MaxPayloadError."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_max_payload.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+    try:
+        client = await connect(server.client_url, timeout=1.0)
+        try:
+            assert client.server_info is not None
+            max_payload = client.server_info.max_payload
+            oversized = b"x" * (max_payload + 1)
+            with pytest.raises(MaxPayloadError) as excinfo:
+                await client.publish(f"test.{uuid.uuid4()}", oversized)
+            assert excinfo.value.size == len(oversized)
+            assert excinfo.value.max_payload == max_payload
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_publish_accepts_payload_at_max_payload():
+    """Publishing a payload exactly at the server's max_payload succeeds."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_max_payload.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+    try:
+        client = await connect(server.client_url, timeout=1.0)
+        try:
+            assert client.server_info is not None
+            max_payload = client.server_info.max_payload
+            await client.publish(f"test.{uuid.uuid4()}", b"x" * max_payload)
+            await client.flush()
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reject payloads larger than the server-advertised max_payload before writing them to the wire. Without this check, oversized payloads cause a server-side disconnect mid-stream.