### PR TITLE
Validate subjects, replies and queue groups client-side

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -171,6 +171,48 @@ class ClientStatistics:
     """Number of successful reconnection attempts."""
 
 
+_SUBJECT_INVALID_CHARS = frozenset(" \t\r\n")
+
+
+def _validate_subject(subject: str, *, allow_wildcards: bool) -> None:
+    """Validate a NATS subject.
+
+    Raises ValueError for empty subjects, whitespace or CRLF, empty tokens,
+    or misplaced wildcards. When allow_wildcards is False, `*` and `>` are
+    rejected outright.
+    """
+    if not subject:
+        raise ValueError("subject cannot be empty")
+    if any(c in _SUBJECT_INVALID_CHARS for c in subject):
+        raise ValueError(f"subject cannot contain whitespace or CRLF: {subject!r}")
+    tokens = subject.split(".")
+    for index, token in enumerate(tokens):
+        if not token:
+            raise ValueError(f"subject cannot contain empty tokens: {subject!r}")
+        if token == ">":
+            if not allow_wildcards:
+                raise ValueError(f"'>' wildcard not allowed in subject: {subject!r}")
+            if index != len(tokens) - 1:
+                raise ValueError(f"'>' wildcard must be the last token: {subject!r}")
+        elif ">" in token:
+            raise ValueError(f"'>' is only valid as a whole token: {subject!r}")
+        elif token == "*":
+            if not allow_wildcards:
+                raise ValueError(f"'*' wildcard not allowed in subject: {subject!r}")
+        elif "*" in token:
+            raise ValueError(f"'*' is only valid as a whole token: {subject!r}")
+
+
+def _validate_queue(queue: str) -> None:
+    """Validate a NATS queue group name. Empty queue is treated as unset."""
+    if not queue:
+        return
+    if any(c in _SUBJECT_INVALID_CHARS for c in queue):
+        raise ValueError(f"queue cannot contain whitespace or CRLF: {queue!r}")
+    if "." in queue or "*" in queue or ">" in queue:
+        raise ValueError(f"queue cannot contain '.', '*', or '>': {queue!r}")
+
+
 class Client(AbstractAsyncContextManager["Client"]):
     """High-level NATS client."""
 
@@ -968,6 +1010,10 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
+        _validate_subject(subject.decode() if isinstance(subject, bytes) else subject, allow_wildcards=False)
+        if reply is not None:
+            _validate_subject(reply.decode() if isinstance(reply, bytes) else reply, allow_wildcards=False)
+
         if isinstance(subject, str):
             subject = subject.encode()
 
@@ -1035,6 +1081,9 @@ class Client(AbstractAsyncContextManager["Client"]):
         # Convert subject and queue to strings for internal storage if they're bytes
         subject_str = subject.decode() if isinstance(subject, bytes) else subject
         queue_str = queue.decode() if isinstance(queue, bytes) else queue
+
+        _validate_subject(subject_str, allow_wildcards=True)
+        _validate_queue(queue_str)
 
         sid = str(self._next_sid)
         self._next_sid += 1
@@ -1127,6 +1176,8 @@ class Client(AbstractAsyncContextManager["Client"]):
         if self._status == ClientStatus.CLOSED:
             msg = "Connection is closed"
             raise RuntimeError(msg)
+
+        _validate_subject(subject, allow_wildcards=False)
 
         if self._request_prefix is None:
             self._request_prefix = f"{self._inbox_prefix}.{uuid.uuid4().hex}."

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -174,24 +174,15 @@ class ClientStatistics:
 _SUBJECT_INVALID_CHARS = frozenset(" \t\r\n")
 
 
-def _decode_or_raise(value: str | bytes, *, name: str) -> str:
-    """Return str unchanged; decode bytes as UTF-8, raising ValueError on bad input."""
-    if isinstance(value, bytes):
-        try:
-            return value.decode("utf-8")
-        except UnicodeDecodeError as e:
-            raise ValueError(f"{name} must be valid UTF-8: {value!r}") from e
-    return value
-
-
 def _validate_subject(subject: str | bytes, *, allow_wildcards: bool) -> str:
     """Validate a NATS subject and return the str form.
 
-    Raises ValueError for empty subjects, non-UTF-8 bytes, whitespace or CRLF,
-    empty tokens, or misplaced wildcards. When allow_wildcards is False, `*`
-    and `>` are rejected outright.
+    Raises ValueError for empty subjects, non-UTF-8 bytes (via UnicodeDecodeError,
+    a ValueError subclass), whitespace or CRLF, empty tokens, or misplaced
+    wildcards. When allow_wildcards is False, `*` and `>` are rejected outright.
     """
-    subject = _decode_or_raise(subject, name="subject")
+    if isinstance(subject, bytes):
+        subject = subject.decode("utf-8")
     if not subject:
         raise ValueError("subject cannot be empty")
     if any(c in _SUBJECT_INVALID_CHARS for c in subject):
@@ -223,7 +214,8 @@ def _validate_queue(queue: str | bytes) -> str:
     a bug shield. Dots are permitted: ``workers.east`` is a common queue
     group naming pattern.
     """
-    queue = _decode_or_raise(queue, name="queue")
+    if isinstance(queue, bytes):
+        queue = queue.decode("utf-8")
     if not queue:
         return queue
     if any(c in _SUBJECT_INVALID_CHARS for c in queue):

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -316,6 +316,9 @@ class Client(AbstractAsyncContextManager["Client"]):
     _tls_handshake_first: bool
     _wants_tls: bool
 
+    # Subject validation
+    _skip_subject_validation: bool
+
     # Statistics
     _stats_in_messages: int
     _stats_out_messages: int
@@ -356,6 +359,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         tls_hostname: str | None = None,
         tls_handshake_first: bool = False,
         wants_tls: bool = False,
+        skip_subject_validation: bool = False,
     ):
         """Initialize the client.
 
@@ -386,6 +390,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             tls_hostname: Hostname for TLS certificate verification
             tls_handshake_first: Perform the TLS handshake before receiving INFO
             wants_tls: Whether the client requested TLS (via scheme, tls context, or tls_handshake_first)
+            skip_subject_validation: If True, skip client-side subject and queue validation
         """
         self._connection = connection
         self._server_info = server_info
@@ -420,6 +425,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._tls_hostname = tls_hostname
         self._tls_handshake_first = tls_handshake_first
         self._wants_tls = wants_tls
+        self._skip_subject_validation = skip_subject_validation
         self._status = ClientStatus.CONNECTING
         self._subscriptions = {}
         self._next_sid = 1
@@ -1153,11 +1159,18 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        subject = _validate_subject(subject).encode()
-        if reply:
-            reply = _validate_subject(reply).encode()
+        if self._skip_subject_validation:
+            subject = subject.encode() if isinstance(subject, str) else subject
+            if reply:
+                reply = reply.encode() if isinstance(reply, str) else reply
+            else:
+                reply = None
         else:
-            reply = None
+            subject = _validate_subject(subject).encode()
+            if reply:
+                reply = _validate_subject(reply).encode()
+            else:
+                reply = None
 
         # HPUB is what the server measures against max_payload, so include the
         # encoded header block in the size check. Encode headers once and reuse.
@@ -1230,8 +1243,12 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        subject_str = _validate_subject(subject, strict=True)
-        queue_str = _validate_queue(queue)
+        if self._skip_subject_validation:
+            subject_str = subject.decode("utf-8") if isinstance(subject, bytes) else subject
+            queue_str = queue.decode("utf-8") if isinstance(queue, bytes) else queue
+        else:
+            subject_str = _validate_subject(subject, strict=True)
+            queue_str = _validate_queue(queue)
 
         sid = str(self._next_sid)
         self._next_sid += 1
@@ -1325,7 +1342,8 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        _validate_subject(subject)
+        if not self._skip_subject_validation:
+            _validate_subject(subject)
 
         if self._request_prefix is None:
             self._request_prefix = f"{self._inbox_prefix}.{uuid.uuid4().hex}."
@@ -1697,6 +1715,7 @@ async def connect(
     password: str | Callable[[], str] | None = None,
     nkey: NkeySeed | NkeyHandlers | None = None,
     jwt: JWTCredentials | JWTHandlers | None = None,
+    skip_subject_validation: bool = False,
 ) -> Client:
     """Connect to a NATS server.
 
@@ -1730,6 +1749,10 @@ async def connect(
             - Path: single .creds file containing both JWT and seed
             - tuple[Path, Path]: (jwt_file, seed_file)
             - tuple[JWTHandler, JWTSignatureHandler]: custom handlers for full control
+        skip_subject_validation: If True, disable client-side subject and queue validation
+            on publish, subscribe, and request. Mirrors nats.go's ``SkipSubjectValidation``.
+            WARNING: this disables CRLF-injection protection — only enable for hot-path
+            benchmarks where you fully control the subject inputs.
 
     Returns:
         Client instance
@@ -1953,6 +1976,7 @@ async def connect(
         tls_hostname=server_hostname if server_hostname else tls_hostname,
         tls_handshake_first=tls_handshake_first,
         wants_tls=wants_tls,
+        skip_subject_validation=skip_subject_validation,
     )
 
     client._status = ClientStatus.CONNECTED

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -174,13 +174,24 @@ class ClientStatistics:
 _SUBJECT_INVALID_CHARS = frozenset(" \t\r\n")
 
 
-def _validate_subject(subject: str, *, allow_wildcards: bool) -> None:
-    """Validate a NATS subject.
+def _decode_or_raise(value: str | bytes, *, name: str) -> str:
+    """Return str unchanged; decode bytes as UTF-8, raising ValueError on bad input."""
+    if isinstance(value, bytes):
+        try:
+            return value.decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(f"{name} must be valid UTF-8: {value!r}") from e
+    return value
 
-    Raises ValueError for empty subjects, whitespace or CRLF, empty tokens,
-    or misplaced wildcards. When allow_wildcards is False, `*` and `>` are
-    rejected outright.
+
+def _validate_subject(subject: str | bytes, *, allow_wildcards: bool) -> str:
+    """Validate a NATS subject and return the str form.
+
+    Raises ValueError for empty subjects, non-UTF-8 bytes, whitespace or CRLF,
+    empty tokens, or misplaced wildcards. When allow_wildcards is False, `*`
+    and `>` are rejected outright.
     """
+    subject = _decode_or_raise(subject, name="subject")
     if not subject:
         raise ValueError("subject cannot be empty")
     if any(c in _SUBJECT_INVALID_CHARS for c in subject):
@@ -201,21 +212,25 @@ def _validate_subject(subject: str, *, allow_wildcards: bool) -> None:
                 raise ValueError(f"'*' wildcard not allowed in subject: {subject!r}")
         elif "*" in token:
             raise ValueError(f"'*' is only valid as a whole token: {subject!r}")
+    return subject
 
 
-def _validate_queue(queue: str) -> None:
-    """Validate a NATS queue group name. Empty queue is treated as unset.
+def _validate_queue(queue: str | bytes) -> str:
+    """Validate a NATS queue group name and return the str form.
 
-    Wildcards are technically allowed on the wire but never meaningful in a
-    queue group, so they are rejected here as a bug shield. Dots are
-    permitted: ``workers.east`` is a common queue group naming pattern.
+    Empty queue is treated as unset. Wildcards are technically allowed on the
+    wire but never meaningful in a queue group, so they are rejected here as
+    a bug shield. Dots are permitted: ``workers.east`` is a common queue
+    group naming pattern.
     """
+    queue = _decode_or_raise(queue, name="queue")
     if not queue:
-        return
+        return queue
     if any(c in _SUBJECT_INVALID_CHARS for c in queue):
         raise ValueError(f"queue cannot contain whitespace or CRLF: {queue!r}")
     if "*" in queue or ">" in queue:
         raise ValueError(f"queue cannot contain '*' or '>': {queue!r}")
+    return queue
 
 
 class Client(AbstractAsyncContextManager["Client"]):
@@ -1015,9 +1030,9 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        _validate_subject(subject.decode() if isinstance(subject, bytes) else subject, allow_wildcards=False)
+        _validate_subject(subject, allow_wildcards=False)
         if reply is not None:
-            _validate_subject(reply.decode() if isinstance(reply, bytes) else reply, allow_wildcards=False)
+            _validate_subject(reply, allow_wildcards=False)
 
         if isinstance(subject, str):
             subject = subject.encode()
@@ -1083,12 +1098,8 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        # Convert subject and queue to strings for internal storage if they're bytes
-        subject_str = subject.decode() if isinstance(subject, bytes) else subject
-        queue_str = queue.decode() if isinstance(queue, bytes) else queue
-
-        _validate_subject(subject_str, allow_wildcards=True)
-        _validate_queue(queue_str)
+        subject_str = _validate_subject(subject, allow_wildcards=True)
+        queue_str = _validate_queue(queue)
 
         sid = str(self._next_sid)
         self._next_sid += 1

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -204,13 +204,18 @@ def _validate_subject(subject: str, *, allow_wildcards: bool) -> None:
 
 
 def _validate_queue(queue: str) -> None:
-    """Validate a NATS queue group name. Empty queue is treated as unset."""
+    """Validate a NATS queue group name. Empty queue is treated as unset.
+
+    Wildcards are technically allowed on the wire but never meaningful in a
+    queue group, so they are rejected here as a bug shield. Dots are
+    permitted: ``workers.east`` is a common queue group naming pattern.
+    """
     if not queue:
         return
     if any(c in _SUBJECT_INVALID_CHARS for c in queue):
         raise ValueError(f"queue cannot contain whitespace or CRLF: {queue!r}")
-    if "." in queue or "*" in queue or ">" in queue:
-        raise ValueError(f"queue cannot contain '.', '*', or '>': {queue!r}")
+    if "*" in queue or ">" in queue:
+        raise ValueError(f"queue cannot contain '*' or '>': {queue!r}")
 
 
 class Client(AbstractAsyncContextManager["Client"]):

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -176,37 +176,40 @@ class ClientStatistics:
     """Number of successful reconnection attempts."""
 
 
-_SUBJECT_INVALID_CHARS = frozenset(" \t\r\n")
+_SUBJECT_INVALID_RE = re.compile(r"[ \t\r\n]")
 
 
-def _validate_subject(subject: str | bytes, *, allow_wildcards: bool) -> str:
+def _validate_subject(subject: str | bytes, *, strict: bool = False) -> str:
     """Validate a NATS subject and return the str form.
 
-    Raises ValueError for empty subjects, non-UTF-8 bytes (via UnicodeDecodeError,
-    a ValueError subclass), whitespace or CRLF, empty tokens, or misplaced
-    wildcards. When allow_wildcards is False, `*` and `>` are rejected outright.
+    Always rejects empty subjects, non-UTF-8 bytes (via UnicodeDecodeError, a
+    ValueError subclass), and whitespace or CRLF. CRLF in particular would
+    allow a caller to inject arbitrary protocol commands.
+
+    With ``strict=True`` (the subscribe path), also rejects empty tokens and
+    misplaced wildcards — `nats.py`-specific structural checks that go
+    beyond what `nats.go`/`nats.rs` enforce client-side. The publish path
+    leaves token shape to the server to stay compatible with the reference
+    clients.
     """
     if isinstance(subject, bytes):
         subject = subject.decode("utf-8")
     if not subject:
         raise ValueError("subject cannot be empty")
-    if any(c in _SUBJECT_INVALID_CHARS for c in subject):
+    if _SUBJECT_INVALID_RE.search(subject):
         raise ValueError(f"subject cannot contain whitespace or CRLF: {subject!r}")
+    if not strict:
+        return subject
     tokens = subject.split(".")
     for index, token in enumerate(tokens):
         if not token:
             raise ValueError(f"subject cannot contain empty tokens: {subject!r}")
         if token == ">":
-            if not allow_wildcards:
-                raise ValueError(f"'>' wildcard not allowed in subject: {subject!r}")
             if index != len(tokens) - 1:
                 raise ValueError(f"'>' wildcard must be the last token: {subject!r}")
         elif ">" in token:
             raise ValueError(f"'>' is only valid as a whole token: {subject!r}")
-        elif token == "*":
-            if not allow_wildcards:
-                raise ValueError(f"'*' wildcard not allowed in subject: {subject!r}")
-        elif "*" in token:
+        elif "*" in token and token != "*":
             raise ValueError(f"'*' is only valid as a whole token: {subject!r}")
     return subject
 
@@ -214,19 +217,16 @@ def _validate_subject(subject: str | bytes, *, allow_wildcards: bool) -> str:
 def _validate_queue(queue: str | bytes) -> str:
     """Validate a NATS queue group name and return the str form.
 
-    Empty queue is treated as unset. Wildcards are technically allowed on the
-    wire but never meaningful in a queue group, so they are rejected here as
-    a bug shield. Dots are permitted: ``workers.east`` is a common queue
-    group naming pattern.
+    Empty queue is treated as unset. Matches `nats.go`'s ``badQueue``: only
+    whitespace and CRLF are rejected. Wildcards and dots are valid tokens
+    on the wire (``workers.east``, ``workers.*``).
     """
     if isinstance(queue, bytes):
         queue = queue.decode("utf-8")
     if not queue:
         return queue
-    if any(c in _SUBJECT_INVALID_CHARS for c in queue):
+    if _SUBJECT_INVALID_RE.search(queue):
         raise ValueError(f"queue cannot contain whitespace or CRLF: {queue!r}")
-    if "*" in queue or ">" in queue:
-        raise ValueError(f"queue cannot contain '*' or '>': {queue!r}")
     return queue
 
 
@@ -1069,15 +1069,11 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        _validate_subject(subject, allow_wildcards=False)
-        if reply is not None:
-            _validate_subject(reply, allow_wildcards=False)
-
-        if isinstance(subject, str):
-            subject = subject.encode()
-
-        if isinstance(reply, str):
-            reply = reply.encode()
+        subject = _validate_subject(subject).encode()
+        if reply:
+            reply = _validate_subject(reply).encode()
+        else:
+            reply = None
 
         # HPUB is what the server measures against max_payload, so include the
         # encoded header block in the size check. Encode headers once and reuse.
@@ -1150,7 +1146,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        subject_str = _validate_subject(subject, allow_wildcards=True)
+        subject_str = _validate_subject(subject, strict=True)
         queue_str = _validate_queue(queue)
 
         sid = str(self._next_sid)
@@ -1245,7 +1241,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             msg = "Connection is closed"
             raise RuntimeError(msg)
 
-        _validate_subject(subject, allow_wildcards=False)
+        _validate_subject(subject)
 
         if self._request_prefix is None:
             self._request_prefix = f"{self._inbox_prefix}.{uuid.uuid4().hex}."

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -783,6 +783,117 @@ async def test_subscribe_with_byte_subject(client):
     assert message.subject == test_subject_str
 
 
+@pytest.mark.parametrize(
+    "subject",
+    [
+        pytest.param("", id="empty"),
+        pytest.param(" ", id="single_space"),
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo\tbar", id="embedded_tab"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+        pytest.param("foo\nbar", id="lf_injection"),
+        pytest.param(".foo", id="leading_dot"),
+        pytest.param("foo.", id="trailing_dot"),
+        pytest.param("foo..bar", id="empty_token"),
+        pytest.param("foo.*", id="star_wildcard"),
+        pytest.param("foo.>", id="greater_than_wildcard"),
+        pytest.param("foo.*.bar", id="star_middle"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_publish_rejects_invalid_subject(client, subject):
+    """Publish rejects malformed or wildcard subjects."""
+    with pytest.raises(ValueError):
+        await client.publish(subject, b"payload")
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+        pytest.param("foo.*", id="star_wildcard"),
+        pytest.param("foo.>", id="greater_than_wildcard"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_publish_rejects_invalid_reply(client, reply):
+    """Publish rejects malformed or wildcard reply subjects."""
+    with pytest.raises(ValueError):
+        await client.publish(f"test.{uuid.uuid4()}", b"payload", reply=reply)
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+        pytest.param(".foo", id="leading_dot"),
+        pytest.param("foo..bar", id="empty_token"),
+        pytest.param("foo.>.bar", id="greater_than_not_last"),
+        pytest.param("foo.**", id="star_combined_with_chars"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_subscribe_rejects_invalid_subject(client, subject):
+    """Subscribe rejects malformed subjects but permits valid wildcards."""
+    with pytest.raises(ValueError):
+        await client.subscribe(subject)
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        pytest.param("foo.*", id="star_wildcard"),
+        pytest.param("foo.*.bar", id="star_middle"),
+        pytest.param("foo.>", id="greater_than_wildcard"),
+        pytest.param("foo.bar.>", id="greater_than_deeper"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_subscribe_accepts_valid_wildcards(client, subject):
+    """Subscribe accepts standard wildcard subjects."""
+    subscription = await client.subscribe(subject)
+    await client.flush()
+    await subscription.unsubscribe()
+
+
+@pytest.mark.parametrize(
+    "queue",
+    [
+        pytest.param("q with space", id="embedded_space"),
+        pytest.param("q\r\n", id="crlf_injection"),
+        pytest.param("q.dotted", id="dot"),
+        pytest.param("q*", id="star"),
+        pytest.param("q>", id="greater_than"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_subscribe_rejects_invalid_queue(client, queue):
+    """Subscribe rejects malformed queue group names."""
+    with pytest.raises(ValueError):
+        await client.subscribe(f"test.{uuid.uuid4()}", queue=queue)
+
+
+@pytest.mark.parametrize(
+    "subject",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+        pytest.param("foo.*", id="star_wildcard"),
+        pytest.param("foo.>", id="greater_than_wildcard"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_request_rejects_invalid_subject(client, subject):
+    """Request rejects malformed or wildcard subjects."""
+    with pytest.raises(ValueError):
+        await client.request(subject, b"payload", timeout=0.5)
+
+
 @pytest.mark.asyncio
 async def test_subscribe_with_byte_queue_group(client):
     """Test that a subscription can be created with a byte queue group."""

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -806,36 +806,50 @@ async def test_subscribe_with_byte_subject(client):
         pytest.param("foo\tbar", id="embedded_tab"),
         pytest.param("foo\r\nbar", id="crlf_injection"),
         pytest.param("foo\nbar", id="lf_injection"),
-        pytest.param(".foo", id="leading_dot"),
-        pytest.param("foo.", id="trailing_dot"),
-        pytest.param("foo..bar", id="empty_token"),
-        pytest.param("foo.*", id="star_wildcard"),
-        pytest.param("foo.>", id="greater_than_wildcard"),
-        pytest.param("foo.*.bar", id="star_middle"),
     ],
 )
 @pytest.mark.asyncio
 async def test_publish_rejects_invalid_subject(client, subject):
-    """Publish rejects malformed or wildcard subjects."""
+    """Publish rejects empty subjects and whitespace/CRLF (matches nats.go/nats.rs)."""
     with pytest.raises(ValueError):
         await client.publish(subject, b"payload")
 
 
 @pytest.mark.parametrize(
-    "reply",
+    "subject",
     [
-        pytest.param("", id="empty"),
-        pytest.param("foo bar", id="embedded_space"),
-        pytest.param("foo\r\nbar", id="crlf_injection"),
         pytest.param("foo.*", id="star_wildcard"),
         pytest.param("foo.>", id="greater_than_wildcard"),
+        pytest.param(".foo", id="leading_dot"),
+        pytest.param("foo..bar", id="empty_token"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_publish_accepts_token_shapes_left_to_server(client, subject):
+    """Publish leaves token shape and wildcards to the server, matching nats.go/nats.rs."""
+    await client.publish(subject, b"payload")
+    await client.flush()
+
+
+@pytest.mark.parametrize(
+    "reply",
+    [
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
     ],
 )
 @pytest.mark.asyncio
 async def test_publish_rejects_invalid_reply(client, reply):
-    """Publish rejects malformed or wildcard reply subjects."""
+    """Publish rejects whitespace/CRLF in the reply subject."""
     with pytest.raises(ValueError):
         await client.publish(f"test.{uuid.uuid4()}", b"payload", reply=reply)
+
+
+@pytest.mark.asyncio
+async def test_publish_treats_empty_reply_as_no_reply(client):
+    """Empty reply is normalized to no-reply, matching nats.go."""
+    await client.publish(f"test.{uuid.uuid4()}", b"payload", reply="")
+    await client.flush()
 
 
 @pytest.mark.asyncio
@@ -893,21 +907,27 @@ async def test_subscribe_accepts_valid_wildcards(client, subject):
     [
         pytest.param("q with space", id="embedded_space"),
         pytest.param("q\r\n", id="crlf_injection"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_subscribe_rejects_invalid_queue(client, queue):
+    """Subscribe rejects whitespace/CRLF in queue names (matches nats.go's badQueue)."""
+    with pytest.raises(ValueError):
+        await client.subscribe(f"test.{uuid.uuid4()}", queue=queue)
+
+
+@pytest.mark.parametrize(
+    "queue",
+    [
+        pytest.param("workers.east", id="dotted"),
         pytest.param("q*", id="star"),
         pytest.param("q>", id="greater_than"),
     ],
 )
 @pytest.mark.asyncio
-async def test_subscribe_rejects_invalid_queue(client, queue):
-    """Subscribe rejects malformed queue group names."""
-    with pytest.raises(ValueError):
-        await client.subscribe(f"test.{uuid.uuid4()}", queue=queue)
-
-
-@pytest.mark.asyncio
-async def test_subscribe_accepts_dotted_queue(client):
-    """Dotted queue groups (e.g. ``workers.east``) are valid."""
-    subscription = await client.subscribe(f"test.{uuid.uuid4()}", queue="workers.east")
+async def test_subscribe_accepts_queue_shapes_left_to_server(client, queue):
+    """Queue shape beyond whitespace/CRLF is left to the server, matching nats.go."""
+    subscription = await client.subscribe(f"test.{uuid.uuid4()}", queue=queue)
     await client.flush()
     await subscription.unsubscribe()
 
@@ -918,13 +938,11 @@ async def test_subscribe_accepts_dotted_queue(client):
         pytest.param("", id="empty"),
         pytest.param("foo bar", id="embedded_space"),
         pytest.param("foo\r\nbar", id="crlf_injection"),
-        pytest.param("foo.*", id="star_wildcard"),
-        pytest.param("foo.>", id="greater_than_wildcard"),
     ],
 )
 @pytest.mark.asyncio
 async def test_request_rejects_invalid_subject(client, subject):
-    """Request rejects malformed or wildcard subjects."""
+    """Request rejects empty subjects and whitespace/CRLF (matches nats.go/nats.rs)."""
     with pytest.raises(ValueError):
         await client.request(subject, b"payload", timeout=0.5)
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -865,7 +865,6 @@ async def test_subscribe_accepts_valid_wildcards(client, subject):
     [
         pytest.param("q with space", id="embedded_space"),
         pytest.param("q\r\n", id="crlf_injection"),
-        pytest.param("q.dotted", id="dot"),
         pytest.param("q*", id="star"),
         pytest.param("q>", id="greater_than"),
     ],
@@ -875,6 +874,14 @@ async def test_subscribe_rejects_invalid_queue(client, queue):
     """Subscribe rejects malformed queue group names."""
     with pytest.raises(ValueError):
         await client.subscribe(f"test.{uuid.uuid4()}", queue=queue)
+
+
+@pytest.mark.asyncio
+async def test_subscribe_accepts_dotted_queue(client):
+    """Dotted queue groups (e.g. ``workers.east``) are valid."""
+    subscription = await client.subscribe(f"test.{uuid.uuid4()}", queue="workers.east")
+    await client.flush()
+    await subscription.unsubscribe()
 
 
 @pytest.mark.parametrize(

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -826,14 +826,14 @@ async def test_publish_rejects_invalid_reply(client, reply):
 
 @pytest.mark.asyncio
 async def test_publish_rejects_non_utf8_bytes_subject(client):
-    """Non-UTF-8 bytes surface as ValueError, not UnicodeDecodeError."""
+    """Non-UTF-8 bytes raise ValueError (via UnicodeDecodeError)."""
     with pytest.raises(ValueError):
         await client.publish(b"\xff\xfe", b"payload")
 
 
 @pytest.mark.asyncio
 async def test_subscribe_rejects_non_utf8_bytes_subject(client):
-    """Non-UTF-8 bytes surface as ValueError, not UnicodeDecodeError."""
+    """Non-UTF-8 bytes raise ValueError (via UnicodeDecodeError)."""
     with pytest.raises(ValueError):
         await client.subscribe(b"\xff\xfe")
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -1004,6 +1004,35 @@ async def test_request_rejects_invalid_subject(client, subject):
 
 
 @pytest.mark.asyncio
+async def test_publish_rejects_crlf_subject_by_default(client):
+    """Default client rejects CRLF subjects on publish."""
+    with pytest.raises(ValueError):
+        await client.publish("foo\r\nbar", b"payload")
+
+
+@pytest.mark.asyncio
+async def test_skip_subject_validation_allows_publish_with_crlf(server):
+    """skip_subject_validation=True bypasses publish-time subject validation."""
+    client = await connect(server.client_url, skip_subject_validation=True)
+    try:
+        # Validation is skipped, so no ValueError is raised before the wire write.
+        await client.publish("foo\r\nbar", b"payload")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_skip_subject_validation_allows_subscribe_with_invalid_queue(server):
+    """skip_subject_validation=True also bypasses queue validation on subscribe."""
+    client = await connect(server.client_url, skip_subject_validation=True)
+    try:
+        subscription = await client.subscribe(f"test.{uuid.uuid4()}", queue="q with space")
+        await subscription.unsubscribe()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_subscribe_with_byte_queue_group(client):
     """Test that a subscription can be created with a byte queue group."""
     test_subject = f"test.byte.queue.{uuid.uuid4()}"

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -824,6 +824,20 @@ async def test_publish_rejects_invalid_reply(client, reply):
         await client.publish(f"test.{uuid.uuid4()}", b"payload", reply=reply)
 
 
+@pytest.mark.asyncio
+async def test_publish_rejects_non_utf8_bytes_subject(client):
+    """Non-UTF-8 bytes surface as ValueError, not UnicodeDecodeError."""
+    with pytest.raises(ValueError):
+        await client.publish(b"\xff\xfe", b"payload")
+
+
+@pytest.mark.asyncio
+async def test_subscribe_rejects_non_utf8_bytes_subject(client):
+    """Non-UTF-8 bytes surface as ValueError, not UnicodeDecodeError."""
+    with pytest.raises(ValueError):
+        await client.subscribe(b"\xff\xfe")
+
+
 @pytest.mark.parametrize(
     "subject",
     [


### PR DESCRIPTION
Reject empty subjects, whitespace/CRLF, empty tokens, and misplaced wildcards before they reach the wire. Without this, callers can inject arbitrary protocol commands via CRLF in a subject.