### PR TITLE
Avoid hang when KeyWatcher.stop() runs on a full queue

### DIFF
--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -370,7 +370,15 @@ class KeyValue:
             stop will stop this watcher.
             """
             await self._sub.unsubscribe()
-            await self._updates.put(KeyValue.KeyWatcher.STOP_ITER)
+            while True:
+                try:
+                    self._updates.put_nowait(KeyValue.KeyWatcher.STOP_ITER)
+                    return
+                except asyncio.QueueFull:
+                    try:
+                        self._updates.get_nowait()
+                    except asyncio.QueueEmpty:
+                        pass
 
         async def updates(self, timeout=5.0):
             """

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3574,6 +3574,33 @@ class KVTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_kv_watcher_stop_does_not_hang_when_queue_is_full(self):
+        """Regression for #898: KeyWatcher.stop() must not block when its
+        internal queue is full because the consumer is not draining it."""
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        kv = await js.create_key_value(bucket="WATCHSTOP")
+        watcher = await kv.watchall()
+
+        # Fill the watcher's bounded queue (maxsize=256) without consuming.
+        queue_capacity = watcher._updates.maxsize
+        for i in range(queue_capacity + 50):
+            await kv.put(f"k{i}", b"v")
+
+        # Wait for the subscription callback to saturate the queue.
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while watcher._updates.qsize() < queue_capacity:
+            if asyncio.get_event_loop().time() > deadline:
+                break
+            await asyncio.sleep(0.05)
+        assert watcher._updates.qsize() == queue_capacity
+
+        await asyncio.wait_for(watcher.stop(), timeout=2.0)
+
+        await nc.close()
+
+    @async_test
     async def test_kv_history(self):
         errors = []
 

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3591,7 +3591,9 @@ class KVTest(SingleJetStreamServerTestCase):
             if asyncio.get_running_loop().time() > deadline:
                 break
             await asyncio.sleep(0.05)
-        assert watcher._updates.qsize() == queue_capacity
+        assert watcher._updates.qsize() == queue_capacity, (
+            f"queue did not saturate within 5s: {watcher._updates.qsize()}/{queue_capacity}"
+        )
 
         await asyncio.wait_for(watcher.stop(), timeout=2.0)
 

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3589,9 +3589,9 @@ class KVTest(SingleJetStreamServerTestCase):
             await kv.put(f"k{i}", b"v")
 
         # Wait for the subscription callback to saturate the queue.
-        deadline = asyncio.get_event_loop().time() + 5.0
+        deadline = asyncio.get_running_loop().time() + 5.0
         while watcher._updates.qsize() < queue_capacity:
-            if asyncio.get_event_loop().time() > deadline:
+            if asyncio.get_running_loop().time() > deadline:
                 break
             await asyncio.sleep(0.05)
         assert watcher._updates.qsize() == queue_capacity


### PR DESCRIPTION
Fixes #898. KeyWatcher.stop() awaited put on a bounded queue; when the consumer wasn't draining, the put blocked indefinitely. Push the sentinel with put_nowait, evicting one queued update on QueueFull.