### PR TITLE
Send client name in CONNECT

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -229,6 +229,9 @@ class Client(AbstractAsyncContextManager["Client"]):
     # Inbox
     _inbox_prefix: str
 
+    # Connection label
+    _name: str | None
+
     # Authentication
     _token: str | Callable[[], str] | None
     _user: str | Callable[[], str] | None
@@ -270,6 +273,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         inbox_prefix: str = "_INBOX",
         ping_interval: float = 120.0,
         max_outstanding_pings: int = 2,
+        name: str | None = None,
         token: str | Callable[[], str] | None = None,
         user: str | Callable[[], str] | None = None,
         password: str | Callable[[], str] | None = None,
@@ -297,6 +301,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             inbox_prefix: Prefix for inbox subjects (default: "_INBOX")
             ping_interval: Interval between PINGs in seconds (default: 120.0)
             max_outstanding_pings: Maximum number of outstanding PINGs before disconnecting (default: 2)
+            name: Optional client label sent as the ``name`` field in CONNECT
             token: Authentication token for the server
             user: Username for authentication
             password: Password for authentication
@@ -328,6 +333,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             raise ValueError("inbox_prefix cannot end with '.'")
 
         self._inbox_prefix = inbox_prefix
+        self._name = name
         self._token = token
         self._user = user
         self._password = password
@@ -813,6 +819,9 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     no_responders=True,
                                     echo=not self._no_echo,
                                 )
+
+                                if self._name is not None:
+                                    connect_info["name"] = self._name
 
                                 if self._token:
                                     connect_info["auth_token"] = self._token() if callable(self._token) else self._token
@@ -1436,6 +1445,7 @@ async def connect(
     inbox_prefix: str = "_INBOX",
     ping_interval: float = 120.0,
     max_outstanding_pings: int = 2,
+    name: str | None = None,
     token: str | Callable[[], str] | None = None,
     user: str | Callable[[], str] | None = None,
     password: str | Callable[[], str] | None = None,
@@ -1461,6 +1471,7 @@ async def connect(
         inbox_prefix: Prefix for inbox subjects (default: "_INBOX")
         ping_interval: Interval between PINGs in seconds (default: 120.0)
         max_outstanding_pings: Maximum number of outstanding PINGs before disconnecting (default: 2)
+        name: Optional client label sent as the ``name`` field in CONNECT
         token: Authentication token for the server
         user: Username for authentication
         password: Password for authentication
@@ -1577,6 +1588,9 @@ async def connect(
     if jwt is not None:
         jwt_handler, jwt_signature_handler = _setup_jwt_auth(jwt)
 
+    if name is not None:
+        connect_info["name"] = name
+
     # Resolve callables for token/user/password
     resolved_token = token() if callable(token) else token
     resolved_user = user() if callable(user) else user
@@ -1644,6 +1658,7 @@ async def connect(
         no_randomize=no_randomize,
         no_echo=no_echo,
         inbox_prefix=inbox_prefix,
+        name=name,
         ping_interval=ping_interval,
         max_outstanding_pings=max_outstanding_pings,
         token=token,

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 import os
 import sys
 import uuid
@@ -1380,6 +1381,102 @@ async def test_custom_inbox_prefix(server):
 
     finally:
         await client.close()
+
+
+async def _start_capture_server(captured: list[dict], *, drop_first: bool = False):
+    """Start a fake NATS listener that records each CONNECT message it sees.
+
+    With ``drop_first=True`` the first accepted connection is closed right after
+    PONG, prompting the client to reconnect so the second CONNECT is captured.
+    """
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        info = (
+            b'INFO {"server_id":"test","server_name":"test","version":"2.0.0","proto":1,'
+            b'"go":"go1.20","host":"127.0.0.1","port":4222,"headers":true,"max_payload":1048576}\r\n'
+        )
+        writer.write(info)
+        await writer.drain()
+
+        connect_line = await reader.readline()
+        if connect_line.startswith(b"CONNECT "):
+            captured.append(json.loads(connect_line[len(b"CONNECT ") :].rstrip(b"\r\n")))
+
+        await reader.readline()  # consume PING
+        writer.write(b"PONG\r\n")
+        await writer.drain()
+
+        if drop_first and len(captured) == 1:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+            return
+
+        while await reader.read(4096):
+            pass
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    return server, f"nats://{host}:{port}"
+
+
+@pytest.mark.parametrize(
+    "name_kwarg, expected_name",
+    [({"name": "my-app"}, "my-app"), ({}, None)],
+    ids=["with-name", "without-name"],
+)
+@pytest.mark.asyncio
+async def test_connect_writes_name_in_connect_message(name_kwarg, expected_name):
+    """``connect(name=...)`` puts the value in CONNECT; omitting it leaves the field out."""
+    captured: list[dict] = []
+    server, url = await _start_capture_server(captured)
+    try:
+        client = await connect(url, timeout=1.0, allow_reconnect=False, **name_kwarg)
+        await client.close()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert len(captured) == 1
+    if expected_name is None:
+        assert "name" not in captured[0]
+    else:
+        assert captured[0]["name"] == expected_name
+
+
+@pytest.mark.asyncio
+async def test_reconnect_resends_name_in_connect_message():
+    """The ``name`` field is re-sent in the CONNECT issued on reconnect."""
+    captured: list[dict] = []
+    server, url = await _start_capture_server(captured, drop_first=True)
+    try:
+        client = await connect(
+            url,
+            timeout=1.0,
+            name="my-app",
+            allow_reconnect=True,
+            reconnect_time_wait=0.05,
+            reconnect_max_attempts=5,
+        )
+        try:
+            for _ in range(50):
+                if len(captured) >= 2:
+                    break
+                await asyncio.sleep(0.05)
+            assert len(captured) >= 2
+            assert captured[1]["name"] == "my-app"
+        finally:
+            await client.close()
+    finally:
+        server.close()
+        await server.wait_closed()
 
 
 @pytest.mark.asyncio

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -1384,12 +1384,19 @@ async def test_custom_inbox_prefix(server):
         await client.close()
 
 
-async def _start_capture_server(captured: list[dict], *, drop_first: bool = False):
-    """Start a fake NATS listener that records each CONNECT message it sees.
-
-    With ``drop_first=True`` the first accepted connection is closed right after
-    PONG, prompting the client to reconnect so the second CONNECT is captured.
-    """
+@pytest.mark.parametrize(
+    "name_kwarg, drop_first, expected_captures, expected_name",
+    [
+        ({"name": "my-app"}, False, 1, "my-app"),
+        ({}, False, 1, None),
+        ({"name": "my-app"}, True, 2, "my-app"),
+    ],
+    ids=["with-name", "without-name", "reconnect"],
+)
+@pytest.mark.asyncio
+async def test_connect_writes_name_in_connect_message(name_kwarg, drop_first, expected_captures, expected_name):
+    """``name`` is written into CONNECT on initial connect and re-sent on reconnect."""
+    captured: list[dict] = []
 
     async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         info = (
@@ -1425,54 +1432,27 @@ async def _start_capture_server(captured: list[dict], *, drop_first: bool = Fals
 
     server = await asyncio.start_server(handle, "127.0.0.1", 0)
     host, port = server.sockets[0].getsockname()[:2]
-    return server, f"nats://{host}:{port}"
+    url = f"nats://{host}:{port}"
 
-
-@pytest.mark.parametrize(
-    "name_kwarg, expected_name",
-    [({"name": "my-app"}, "my-app"), ({}, None)],
-    ids=["with-name", "without-name"],
-)
-@pytest.mark.asyncio
-async def test_connect_writes_name_in_connect_message(name_kwarg, expected_name):
-    """``connect(name=...)`` puts the value in CONNECT; omitting it leaves the field out."""
-    captured: list[dict] = []
-    server, url = await _start_capture_server(captured)
-    try:
-        client = await connect(url, timeout=1.0, allow_reconnect=False, **name_kwarg)
-        await client.close()
-    finally:
-        server.close()
-        await server.wait_closed()
-
-    assert len(captured) == 1
-    if expected_name is None:
-        assert "name" not in captured[0]
-    else:
-        assert captured[0]["name"] == expected_name
-
-
-@pytest.mark.asyncio
-async def test_reconnect_resends_name_in_connect_message():
-    """The ``name`` field is re-sent in the CONNECT issued on reconnect."""
-    captured: list[dict] = []
-    server, url = await _start_capture_server(captured, drop_first=True)
     try:
         client = await connect(
             url,
             timeout=1.0,
-            name="my-app",
-            allow_reconnect=True,
+            allow_reconnect=drop_first,
             reconnect_time_wait=0.05,
             reconnect_max_attempts=5,
+            **name_kwarg,
         )
         try:
             for _ in range(50):
-                if len(captured) >= 2:
+                if len(captured) >= expected_captures:
                     break
                 await asyncio.sleep(0.05)
-            assert len(captured) >= 2
-            assert captured[1]["name"] == "my-app"
+            assert len(captured) == expected_captures
+            if expected_name is None:
+                assert "name" not in captured[-1]
+            else:
+                assert captured[-1]["name"] == expected_name
         finally:
             await client.close()
     finally:


### PR DESCRIPTION
Expose a `name` kwarg on `connect()` and `Client` that becomes the `name` field in the CONNECT message, matching nats.go and nats.aio. Addresses audit finding #1 in `.claude/audit/01-connection-handshake.md`.