### PR TITLE
Surface server_name in ServerInfo

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -110,6 +110,7 @@ class ServerInfo:
     """Server information received during connection."""
 
     server_id: str
+    server_name: str
     version: str
     go_version: str
     host: str
@@ -130,6 +131,7 @@ class ServerInfo:
         """Create a ServerInfo instance from protocol info dictionary."""
         return cls(
             server_id=info["server_id"],
+            server_name=info.get("server_name", ""),
             version=info["version"],
             go_version=info["go"],
             host=info["host"],

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -56,6 +56,14 @@ async def test_connect_succeeds_with_valid_url(server):
 
 
 @pytest.mark.asyncio
+async def test_server_info_exposes_server_name(client):
+    """server_info.server_name is populated from the INFO message."""
+    assert client.server_info is not None
+    assert isinstance(client.server_info.server_name, str)
+    assert client.server_info.server_name
+
+
+@pytest.mark.asyncio
 async def test_connect_fails_with_invalid_url():
     """Test that connecting to an invalid server URL fails appropriately."""
     with pytest.raises(Exception):

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -56,11 +56,15 @@ async def test_connect_succeeds_with_valid_url(server):
 
 
 @pytest.mark.asyncio
-async def test_server_info_exposes_server_name(client):
+async def test_server_info_exposes_server_name():
     """server_info.server_name is populated from the INFO message."""
-    assert client.server_info is not None
-    assert isinstance(client.server_info.server_name, str)
-    assert client.server_info.server_name
+    async with await run(port=0, server_name="audit-svr") as server:
+        client = await connect(server.client_url)
+        try:
+            assert client.server_info is not None
+            assert client.server_info.server_name == "audit-svr"
+        finally:
+            await client.close()
 
 
 @pytest.mark.asyncio

--- a/nats-server/src/nats/server/__init__.py
+++ b/nats-server/src/nats/server/__init__.py
@@ -197,7 +197,7 @@ async def _create_server_process(
         cluster: Cluster URL for solicited routes (--cluster).
         cluster_name: Name of the cluster (--cluster_name).
         routes: Routes to solicit and connect (--routes).
-        name: Server name (-n).
+        name: Server name (--server_name).
 
     Returns:
         The created subprocess.
@@ -234,7 +234,7 @@ async def _create_server_process(
         cmd.extend(["--routes", routes])
 
     if name is not None:
-        cmd.extend(["-n", name])
+        cmd.extend(["--server_name", name])
 
     return await asyncio.create_subprocess_exec(
         *cmd,
@@ -313,6 +313,7 @@ async def run(
     jetstream: bool = False,
     store_dir: str | None = None,
     config_path: str | None = None,
+    server_name: str | None = None,
     timeout: float = 10.0,
 ) -> Server:
     """Start a NATS server and wait for it to be ready.
@@ -324,6 +325,7 @@ async def run(
         jetstream: Whether to enable JetStream.
         store_dir: Directory to use for JetStream storage. Only used when jetstream=True.
         config_path: Path to server config file.
+        server_name: Server name (``-n``); surfaced as ``server_name`` in INFO.
         timeout: Maximum time to wait for server to start in seconds.
 
     Returns:
@@ -339,6 +341,7 @@ async def run(
         jetstream=jetstream,
         store_dir=store_dir,
         config_path=config_path,
+        name=server_name,
     )
 
     assigned_host, assigned_port = await _wait_for_server_ready(


### PR DESCRIPTION
ServerInfo.from_protocol() was dropping the server_name field from INFO. Expose it on the public ServerInfo dataclass, defaulting to empty string for minimal servers. Addresses audit finding #9 in `.claude/audit/01-connection-handshake.md`.