### PR TITLE
Add support for WebSocket connections

### DIFF
--- a/nats-core/pyproject.toml
+++ b/nats-core/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = []
 nkeys = [
   "nkeys>=0.1.0",
 ]
+websocket = [
+  "websockets>=16.0",
+]
 
 [project.urls]
 Documentation = "https://github.com/nats-io/nats.py"
@@ -44,6 +47,7 @@ dev = [
   "pytest-cov>=7.0.0",
   "pytest-xdist>=3.0.0",
   "pytest-benchmark>=5.2.1",
+  "websockets>=16.0",
 ]
 
 [tool.uv.sources]

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Self, TypeAlias
 from urllib.parse import urlparse
 
 import nkeys
-from nats.client.connection import Connection, open_tcp_connection, open_websocket_connection
+from nats.client.connection import Connection, TcpConnection, open_tcp_connection, open_websocket_connection
 from nats.client.errors import NoRespondersError, SlowConsumerError, StatusError
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
@@ -1562,7 +1562,7 @@ async def connect(
             upgrade_ssl_context = tls if tls is not None else ssl.create_default_context()
             upgrade_hostname = tls_hostname if tls_hostname is not None else host
 
-            if hasattr(connection, "upgrade_to_tls"):
+            if isinstance(connection, TcpConnection):
                 await connection.upgrade_to_tls(upgrade_ssl_context, upgrade_hostname)
                 ssl_context = upgrade_ssl_context
                 server_hostname = upgrade_hostname

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -38,7 +38,7 @@ from typing import TYPE_CHECKING, Self, TypeAlias
 from urllib.parse import urlparse
 
 import nkeys
-from nats.client.connection import Connection, open_tcp_connection
+from nats.client.connection import Connection, open_tcp_connection, open_websocket_connection
 from nats.client.errors import NoRespondersError, SlowConsumerError, StatusError
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
@@ -785,12 +785,26 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     else (host if ssl_context else None)
                                 )
 
-                                connection = await asyncio.wait_for(
-                                    open_tcp_connection(
-                                        host, port, ssl_context=ssl_context, server_hostname=server_hostname
-                                    ),
-                                    timeout=self._reconnect_timeout,
-                                )
+                                if scheme in ("ws", "wss"):
+                                    use_tls = scheme == "wss" or ssl_context is not None
+                                    reconnect_url = parsed_url.geturl()
+                                    if scheme == "ws" and use_tls:
+                                        reconnect_url = reconnect_url.replace("ws://", "wss://", 1)
+                                    connection = await asyncio.wait_for(
+                                        open_websocket_connection(
+                                            reconnect_url,
+                                            ssl_context=ssl_context if use_tls else None,
+                                            server_hostname=server_hostname if use_tls else None,
+                                        ),
+                                        timeout=self._reconnect_timeout,
+                                    )
+                                else:
+                                    connection = await asyncio.wait_for(
+                                        open_tcp_connection(
+                                            host, port, ssl_context=ssl_context, server_hostname=server_hostname
+                                        ),
+                                        timeout=self._reconnect_timeout,
+                                    )
 
                                 protocol_message = await parse(connection)
                                 if not isinstance(protocol_message, Info):
@@ -1502,7 +1516,21 @@ async def connect(
 
     tls_established = False
     try:
-        if tls_handshake_first and ssl_context:
+        if parsed_url.scheme in ("ws", "wss"):
+            # Mirror nats.go: any TLS option promotes a ws:// URL to wss://
+            use_tls = parsed_url.scheme == "wss" or ssl_context is not None
+            ws_url = url.replace("ws://", "wss://", 1) if parsed_url.scheme == "ws" and use_tls else url
+            connection = await asyncio.wait_for(
+                open_websocket_connection(
+                    ws_url,
+                    ssl_context=ssl_context if use_tls else None,
+                    server_hostname=server_hostname if use_tls else None,
+                ),
+                timeout=timeout,
+            )
+            if use_tls:
+                tls_established = True
+        elif tls_handshake_first and ssl_context:
             connection = await asyncio.wait_for(
                 open_tcp_connection(host, port, ssl_context=ssl_context, server_hostname=server_hostname),
                 timeout=timeout,

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1638,7 +1638,11 @@ async def connect(
         msg = f"Failed to connect: {e}"
         raise ConnectionError(msg)
 
-    servers = [f"{host}:{port}"]
+    # Preserve the WebSocket scheme so the reconnect loop reopens the right transport.
+    if parsed_url.scheme in ("ws", "wss"):
+        servers = [ws_url]
+    else:
+        servers = [f"{host}:{port}"]
     if server_info.connect_urls:
         servers.extend(server_info.connect_urls)
 

--- a/nats-core/src/nats/client/connection.py
+++ b/nats-core/src/nats/client/connection.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Protocol, runtime_checkable
 if TYPE_CHECKING:
     import ssl
 
+    from websockets.asyncio.client import ClientConnection
+
 logger = logging.getLogger("nats.client")
 
 
@@ -200,6 +202,125 @@ async def open_tcp_connection(
     try:
         reader, writer = await asyncio.open_connection(host, port, ssl=ssl_context, server_hostname=server_hostname)
         return TcpConnection(reader, writer)
+    except Exception as e:
+        msg = f"Failed to connect: {e}"
+        raise ConnectionError(msg)
+
+
+class WebSocketConnection:
+    """WebSocket-based NATS connection.
+
+    Adapts the message-framed WebSocket transport into the byte-stream
+    Connection protocol expected by the NATS parser. Incoming frames are
+    buffered so that readline/readexactly/read can be served at byte
+    granularity regardless of frame boundaries.
+    """
+
+    _ws: ClientConnection | None
+    _buffer: bytes
+
+    def __init__(self, ws: ClientConnection) -> None:
+        self._ws = ws
+        self._buffer = b""
+
+    async def _fill_buffer(self) -> None:
+        if self._ws is None:
+            msg = "Not connected"
+            raise ConnectionError(msg)
+        try:
+            frame = await self._ws.recv()
+        except Exception as e:
+            raise asyncio.IncompleteReadError(self._buffer, None) from e
+        if isinstance(frame, str):
+            frame = frame.encode()
+        if not frame:
+            raise asyncio.IncompleteReadError(self._buffer, None)
+        self._buffer += frame
+
+    async def close(self) -> None:
+        """Close WebSocket connection."""
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+            logger.debug("WebSocket connection closed")
+
+    async def read(self, n: int) -> bytes:
+        """Read up to n bytes from the WebSocket connection."""
+        if not self._buffer:
+            try:
+                await self._fill_buffer()
+            except asyncio.IncompleteReadError:
+                return b""
+        result = self._buffer[:n]
+        self._buffer = self._buffer[n:]
+        return result
+
+    async def write(self, data: bytes) -> None:
+        """Write data to the WebSocket connection as a binary frame."""
+        if self._ws is None:
+            msg = "Not connected"
+            raise ConnectionError(msg)
+        await self._ws.send(data)
+
+    def is_connected(self) -> bool:
+        """Check if WebSocket connection is active."""
+        if self._ws is None:
+            return False
+        from websockets.protocol import State
+
+        return self._ws.state is State.OPEN
+
+    async def readline(self) -> bytes:
+        """Read a line (ending in CRLF) from the WebSocket connection."""
+        while b"\n" not in self._buffer:
+            await self._fill_buffer()
+        idx = self._buffer.index(b"\n") + 1
+        result = self._buffer[:idx]
+        self._buffer = self._buffer[idx:]
+        return result
+
+    async def readexactly(self, n: int) -> bytes:
+        """Read exactly n bytes from the WebSocket connection."""
+        while len(self._buffer) < n:
+            await self._fill_buffer()
+        result = self._buffer[:n]
+        self._buffer = self._buffer[n:]
+        return result
+
+
+async def open_websocket_connection(
+    url: str,
+    ssl_context: ssl.SSLContext | None = None,
+    server_hostname: str | None = None,
+) -> WebSocketConnection:
+    """Open a WebSocket connection to a NATS server.
+
+    Args:
+        url: Full ws:// or wss:// URL
+        ssl_context: Optional SSL context for wss://
+        server_hostname: Hostname for SSL certificate verification
+
+    Returns:
+        WebSocket connection
+
+    Raises:
+        ConnectionError: If connection fails
+        ImportError: If the websockets package is not installed
+    """
+    try:
+        from websockets.asyncio.client import connect as ws_connect
+    except ImportError as e:
+        msg = "WebSocket transport requires the 'websockets' package. Install nats-core[websocket]."
+        raise ImportError(msg) from e
+
+    try:
+        ws = await ws_connect(
+            url,
+            ssl=ssl_context,
+            server_hostname=server_hostname,
+            max_size=None,
+        )
+        return WebSocketConnection(ws)
     except Exception as e:
         msg = f"Failed to connect: {e}"
         raise ConnectionError(msg)

--- a/nats-core/src/nats/client/connection.py
+++ b/nats-core/src/nats/client/connection.py
@@ -220,8 +220,13 @@ class WebSocketConnection:
     _buffer: bytes
 
     def __init__(self, ws: ClientConnection) -> None:
+        # ``websockets`` is guaranteed importable here — the caller already
+        # imported ``connect`` from it to obtain ``ws``.
+        from websockets.protocol import State
+
         self._ws = ws
         self._buffer = b""
+        self._open_state = State.OPEN
 
     async def _fill_buffer(self) -> None:
         if self._ws is None:
@@ -266,9 +271,7 @@ class WebSocketConnection:
         """Check if WebSocket connection is active."""
         if self._ws is None:
             return False
-        from websockets.protocol import State
-
-        return self._ws.state is State.OPEN
+        return self._ws.state is self._open_state
 
     async def readline(self) -> bytes:
         """Read a line (ending in CRLF) from the WebSocket connection."""
@@ -323,4 +326,4 @@ async def open_websocket_connection(
         return WebSocketConnection(ws)
     except Exception as e:
         msg = f"Failed to connect: {e}"
-        raise ConnectionError(msg)
+        raise ConnectionError(msg) from e

--- a/nats-core/tests/configs/server_websocket.conf
+++ b/nats-core/tests/configs/server_websocket.conf
@@ -1,0 +1,5 @@
+# NATS server config for testing WebSocket transport
+websocket {
+  port: -1
+  no_tls: true
+}

--- a/nats-core/tests/configs/server_websocket_compression.conf
+++ b/nats-core/tests/configs/server_websocket_compression.conf
@@ -1,0 +1,6 @@
+# NATS server config for testing WebSocket transport with permessage-deflate
+websocket {
+  port: -1
+  no_tls: true
+  compression: true
+}

--- a/nats-core/tests/configs/server_websocket_tls.conf
+++ b/nats-core/tests/configs/server_websocket_tls.conf
@@ -1,0 +1,8 @@
+# NATS server config for testing WebSocket transport with TLS (wss://)
+websocket {
+  port: -1
+  tls {
+    cert_file: "./tests/certs/server-cert.pem"
+    key_file: "./tests/certs/server-key.pem"
+  }
+}

--- a/nats-core/tests/test_websocket.py
+++ b/nats-core/tests/test_websocket.py
@@ -1,0 +1,124 @@
+"""Tests for WebSocket transport in NATS client."""
+
+import asyncio
+import os
+import ssl
+
+import pytest
+from nats.client import connect
+from nats.server import run
+
+
+@pytest.mark.asyncio
+async def test_connect_ws_succeeds():
+    """Client connects over ws:// and exchanges INFO/CONNECT."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            await client.flush()
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ws_publish_subscribe_roundtrip():
+    """Messages flow over the WebSocket transport end-to-end."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            subscription = await client.subscribe("ws.test")
+            await client.publish("ws.test", b"hello over ws")
+            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+            assert message.data == b"hello over ws"
+            assert message.subject == "ws.test"
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_wss_connect_and_publish_subscribe():
+    """Client connects over wss:// and exchanges messages over TLS."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        wss_url = server.websocket_url.replace("ws://", "wss://", 1)
+
+        ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
+        ssl_context.check_hostname = False
+
+        client = await connect(wss_url, tls=ssl_context, timeout=2.0)
+        try:
+            subscription = await client.subscribe("wss.test")
+            await client.publish("wss.test", b"hello over wss")
+            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+            assert message.data == b"hello over wss"
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ws_scheme_with_tls_context_promotes_to_wss():
+    """A ws:// URL plus a TLS context is promoted to wss:// (matches nats.go semantics)."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        # Intentionally keep the ws:// scheme; the TLS context should promote to wss://
+        ws_url = server.websocket_url
+
+        ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
+        ssl_context.check_hostname = False
+
+        client = await connect(ws_url, tls=ssl_context, timeout=2.0)
+        try:
+            await client.flush()
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_ws_request_reply_roundtrip():
+    """Request/reply works across the WebSocket transport."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            subscription = await client.subscribe("ws.echo")
+
+            async def responder():
+                message = await subscription.next()
+                assert message.reply is not None
+                await client.publish(message.reply, message.data)
+
+            responder_task = asyncio.create_task(responder())
+            try:
+                reply = await client.request("ws.echo", b"ping", timeout=2.0)
+                assert reply.data == b"ping"
+            finally:
+                await responder_task
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()

--- a/nats-core/tests/test_websocket.py
+++ b/nats-core/tests/test_websocket.py
@@ -90,6 +90,45 @@ async def test_ws_scheme_with_tls_context_promotes_to_wss():
         await server.shutdown()
 
 
+async def test_ws_url_preserved_in_server_pool():
+    """The seed entry in the reconnect pool keeps the ws:// scheme."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            # TODO: replace with a public servers accessor once one is exposed.
+            assert client._server_pool[0].startswith(("ws://", "wss://"))
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_wss_url_preserved_in_server_pool():
+    """A ws:// URL upgraded to wss:// keeps the wss:// scheme in the reconnect pool."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        ws_url = server.websocket_url.replace("wss://", "ws://", 1)
+
+        ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
+        ssl_context.check_hostname = False
+
+        client = await connect(ws_url, tls=ssl_context, timeout=2.0)
+        try:
+            # TODO: replace with a public servers accessor once one is exposed.
+            assert client._server_pool[0].startswith("wss://")
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
 async def test_ws_request_reply_roundtrip():
     """Request/reply works across the WebSocket transport."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")

--- a/nats-core/tests/test_websocket.py
+++ b/nats-core/tests/test_websocket.py
@@ -3,6 +3,9 @@
 import asyncio
 import os
 import ssl
+import tempfile
+
+import pytest
 
 from nats.client import connect
 from nats.server import run
@@ -123,6 +126,161 @@ async def test_wss_url_preserved_in_server_pool():
         try:
             # TODO: replace with a public servers accessor once one is exposed.
             assert client._server_pool[0].startswith("wss://")
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_wss_native_url_preserved_in_server_pool():
+    """A native wss:// URL (no upgrade) keeps the wss:// scheme in the reconnect pool."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        assert server.websocket_url.startswith("wss://")
+
+        ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
+        ssl_context.check_hostname = False
+
+        client = await connect(server.websocket_url, tls=ssl_context, timeout=2.0)
+        try:
+            # TODO: replace with a public servers accessor once one is exposed.
+            assert client._server_pool[0].startswith("wss://")
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_ws_headers_roundtrip():
+    """Headers survive a publish/subscribe roundtrip over WebSocket (HMSG framing)."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            subscription = await client.subscribe("ws.hdrs")
+            await client.publish("ws.hdrs", b"payload", headers={"X-Custom": "value"})
+            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+            assert message.data == b"payload"
+            assert message.headers is not None
+            assert message.headers.get("X-Custom") == "value"
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_ws_large_payload_spans_multiple_frames():
+    """A payload larger than a typical WS frame round-trips correctly."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            payload = bytes(range(256)) * 800  # ~200 KB, non-trivial pattern
+            subscription = await client.subscribe("ws.large")
+            await client.publish("ws.large", payload)
+            message = await asyncio.wait_for(subscription.next(), timeout=5.0)
+            assert message.data == payload
+        finally:
+            await client.close()
+    finally:
+        await server.shutdown()
+
+
+async def test_ws_connect_fails_for_unreachable_server():
+    """A ws:// URL pointing at a non-listening port raises an error."""
+    with pytest.raises((ConnectionError, TimeoutError, OSError)):
+        await connect("ws://127.0.0.1:1", timeout=0.5)
+
+
+async def test_ws_reconnects_over_websocket():
+    """After the WebSocket server is bounced, the client reopens over WebSocket — not TCP."""
+    base_config = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
+    first_server = await run(config_path=base_config, port=0, timeout=5.0)
+
+    temp_config = None
+    second_server = None
+    client = None
+    try:
+        assert first_server.websocket_url is not None
+        ws_url = first_server.websocket_url
+        ws_port = int(ws_url.rsplit(":", 1)[1])
+
+        # Pin the websocket port for the restart so the client's seed URL still resolves.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False) as f:
+            f.write(f"websocket {{\n  port: {ws_port}\n  no_tls: true\n}}\n")
+            temp_config = f.name
+
+        reconnected = asyncio.Event()
+        client = await connect(
+            ws_url,
+            reconnect_time_wait=0.1,
+            reconnect_max_attempts=50,
+            timeout=2.0,
+        )
+        client.add_reconnected_callback(lambda: reconnected.set())
+
+        await first_server.shutdown()
+        first_server = None  # don't double-shutdown in finally
+
+        second_server = await run(config_path=temp_config, port=0, timeout=5.0)
+
+        await asyncio.wait_for(reconnected.wait(), timeout=10.0)
+
+        subscription = await client.subscribe("ws.reconnect")
+        await client.publish("ws.reconnect", b"after-reconnect")
+        message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+        assert message.data == b"after-reconnect"
+    finally:
+        if client is not None:
+            await client.close()
+        if second_server is not None:
+            await second_server.shutdown()
+        if first_server is not None:
+            await first_server.shutdown()
+        if temp_config is not None:
+            os.unlink(temp_config)
+
+
+async def test_wss_uses_default_tls_context_when_unspecified():
+    """A wss:// URL with no explicit tls= falls back to the system default SSLContext."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        assert server.websocket_url.startswith("wss://")
+
+        # The test server uses a self-signed cert, so the default trust store should
+        # reject it — proving that connect() did apply a default SSLContext for wss://.
+        with pytest.raises((ConnectionError, ssl.SSLError, ssl.SSLCertVerificationError)):
+            await connect(server.websocket_url, timeout=2.0)
+    finally:
+        await server.shutdown()
+
+
+async def test_ws_with_permessage_deflate_compression():
+    """Messages round-trip when the server negotiates permessage-deflate compression."""
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_compression.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        assert server.websocket_url is not None
+        client = await connect(server.websocket_url, timeout=2.0)
+        try:
+            payload = b"compressible payload " * 1000
+            subscription = await client.subscribe("ws.compress")
+            await client.publish("ws.compress", payload)
+            message = await asyncio.wait_for(subscription.next(), timeout=5.0)
+            assert message.data == payload
         finally:
             await client.close()
     finally:

--- a/nats-core/tests/test_websocket.py
+++ b/nats-core/tests/test_websocket.py
@@ -6,7 +6,6 @@ import ssl
 import tempfile
 
 import pytest
-
 from nats.client import connect
 from nats.server import run
 

--- a/nats-core/tests/test_websocket.py
+++ b/nats-core/tests/test_websocket.py
@@ -4,12 +4,10 @@ import asyncio
 import os
 import ssl
 
-import pytest
 from nats.client import connect
 from nats.server import run
 
 
-@pytest.mark.asyncio
 async def test_connect_ws_succeeds():
     """Client connects over ws:// and exchanges INFO/CONNECT."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
@@ -26,7 +24,6 @@ async def test_connect_ws_succeeds():
         await server.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_ws_publish_subscribe_roundtrip():
     """Messages flow over the WebSocket transport end-to-end."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")
@@ -47,7 +44,6 @@ async def test_ws_publish_subscribe_roundtrip():
         await server.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_wss_connect_and_publish_subscribe():
     """Client connects over wss:// and exchanges messages over TLS."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
@@ -55,12 +51,12 @@ async def test_wss_connect_and_publish_subscribe():
 
     try:
         assert server.websocket_url is not None
-        wss_url = server.websocket_url.replace("ws://", "wss://", 1)
+        assert server.websocket_url.startswith("wss://")
 
         ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
         ssl_context.check_hostname = False
 
-        client = await connect(wss_url, tls=ssl_context, timeout=2.0)
+        client = await connect(server.websocket_url, tls=ssl_context, timeout=2.0)
         try:
             subscription = await client.subscribe("wss.test")
             await client.publish("wss.test", b"hello over wss")
@@ -72,7 +68,6 @@ async def test_wss_connect_and_publish_subscribe():
         await server.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_ws_scheme_with_tls_context_promotes_to_wss():
     """A ws:// URL plus a TLS context is promoted to wss:// (matches nats.go semantics)."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket_tls.conf")
@@ -80,8 +75,8 @@ async def test_ws_scheme_with_tls_context_promotes_to_wss():
 
     try:
         assert server.websocket_url is not None
-        # Intentionally keep the ws:// scheme; the TLS context should promote to wss://
-        ws_url = server.websocket_url
+        # Override the wss:// scheme with ws://; the TLS context should still upgrade.
+        ws_url = server.websocket_url.replace("wss://", "ws://", 1)
 
         ssl_context = ssl.create_default_context(cafile=os.path.join(os.path.dirname(__file__), "certs", "ca.pem"))
         ssl_context.check_hostname = False
@@ -95,7 +90,6 @@ async def test_ws_scheme_with_tls_context_promotes_to_wss():
         await server.shutdown()
 
 
-@pytest.mark.asyncio
 async def test_ws_request_reply_roundtrip():
     """Request/reply works across the WebSocket transport."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_websocket.conf")

--- a/nats-server/src/nats/server/__init__.py
+++ b/nats-server/src/nats/server/__init__.py
@@ -35,6 +35,9 @@ FATAL_PATTERN = re.compile(r"\[FTL\]\s+(.*)")
 INFO_PATTERN = re.compile(r"\[INF\]\s+(.*)")
 READY_PATTERN = re.compile(r"Server is ready")
 LISTENING_PATTERN = re.compile(r"Listening for client connections on (.+):(\d+)")
+WEBSOCKET_LISTENING_PATTERN = re.compile(
+    r"Listening for websocket clients on wss?://(.+):(\d+)"
+)
 
 
 class ServerError(Exception):
@@ -84,12 +87,16 @@ class Server:
     _process: asyncio.subprocess.Process | None
     _host: str
     _port: int
+    _websocket_host: str | None
+    _websocket_port: int | None
 
     def __init__(
         self,
         process: asyncio.subprocess.Process,
         host: str,
         port: int,
+        websocket_host: str | None = None,
+        websocket_port: int | None = None,
     ):
         """Initialize a new NATS server instance.
 
@@ -97,10 +104,14 @@ class Server:
             process: The subprocess running the NATS server.
             host: The host the server is listening on.
             port: The port the server is listening on.
+            websocket_host: The host the WebSocket listener is bound to.
+            websocket_port: The port the WebSocket listener is bound to.
         """
         self._process = process
         self._host = host
         self._port = port
+        self._websocket_host = websocket_host
+        self._websocket_port = websocket_port
 
     @property
     def host(self) -> str:
@@ -133,6 +144,29 @@ class Server:
             host = f"[{host}]"
 
         return f"nats://{host}:{self._port}"
+
+    @property
+    def websocket_url(self) -> str | None:
+        """Get the WebSocket client URL, or None if the server has no WebSocket listener.
+
+        Returns:
+            The WebSocket URL as a string, or None.
+        """
+        if self._websocket_host is None or self._websocket_port is None:
+            return None
+
+        match self._websocket_host:
+            case "0.0.0.0":
+                host = "127.0.0.1"
+            case "::":
+                host = "::1"
+            case _:
+                host = self._websocket_host
+
+        if ":" in host:
+            host = f"[{host}]"
+
+        return f"ws://{host}:{self._websocket_port}"
 
     @property
     def is_running(self) -> bool:
@@ -246,7 +280,7 @@ async def _create_server_process(
 async def _wait_for_server_ready(
     process: asyncio.subprocess.Process,
     timeout: float = 10.0,
-) -> tuple[str, int]:
+) -> tuple[str, int, str | None, int | None]:
     """Wait for a NATS server to become ready.
 
     Args:
@@ -254,16 +288,24 @@ async def _wait_for_server_ready(
         timeout: Maximum time to wait in seconds.
 
     Returns:
-        Tuple of (host, port) the server is listening on.
+        Tuple of (host, port, websocket_host, websocket_port). The WebSocket
+        entries are None when the server has no WebSocket listener.
 
     Raises:
         ServerError: If the server fails to start or become ready.
         asyncio.TimeoutError: If the server doesn't become ready within timeout.
     """
 
-    async def wait_ready() -> tuple[str, int]:
+    def _strip_brackets(value: str) -> str:
+        if value.startswith("[") and value.endswith("]"):
+            return value[1:-1]
+        return value
+
+    async def wait_ready() -> tuple[str, int, str | None, int | None]:
         host: str | None = None
         port: int | None = None
+        websocket_host: str | None = None
+        websocket_port: int | None = None
         error_lines = []
 
         assert process.stderr is not None
@@ -273,15 +315,15 @@ async def _wait_for_server_ready(
             if READY_PATTERN.search(stderr_line):
                 assert host is not None
                 assert port is not None
-                return host, port
+                return host, port, websocket_host, websocket_port
 
             if match := LISTENING_PATTERN.search(stderr_line):
-                host_part = match.group(1)
-                if host_part.startswith("[") and host_part.endswith("]"):
-                    host = host_part[1:-1]
-                else:
-                    host = host_part
+                host = _strip_brackets(match.group(1))
                 port = int(match.group(2))
+
+            if match := WEBSOCKET_LISTENING_PATTERN.search(stderr_line):
+                websocket_host = _strip_brackets(match.group(1))
+                websocket_port = int(match.group(2))
 
             if INFO_PATTERN.search(stderr_line):
                 continue
@@ -341,11 +383,20 @@ async def run(
         config_path=config_path,
     )
 
-    assigned_host, assigned_port = await _wait_for_server_ready(
-        process, timeout=timeout
-    )
+    (
+        assigned_host,
+        assigned_port,
+        websocket_host,
+        websocket_port,
+    ) = await _wait_for_server_ready(process, timeout=timeout)
 
-    return Server(process, assigned_host, assigned_port)
+    return Server(
+        process,
+        assigned_host,
+        assigned_port,
+        websocket_host=websocket_host,
+        websocket_port=websocket_port,
+    )
 
 
 async def run_cluster(
@@ -478,6 +529,8 @@ async def _run_cluster_node(
         config_path=config_path if config_path else None,
     )
 
-    assigned_host, assigned_port = await _wait_for_server_ready(process, timeout=10.0)
+    assigned_host, assigned_port, _ws_host, _ws_port = await _wait_for_server_ready(
+        process, timeout=10.0
+    )
 
     return Server(process, assigned_host, assigned_port)

--- a/nats-server/src/nats/server/__init__.py
+++ b/nats-server/src/nats/server/__init__.py
@@ -37,7 +37,7 @@ INFO_PATTERN = re.compile(r"\[INF\]\s+(.*)")
 READY_PATTERN = re.compile(r"Server is ready")
 LISTENING_PATTERN = re.compile(r"Listening for client connections on (.+):(\d+)")
 WEBSOCKET_LISTENING_PATTERN = re.compile(
-    r"Listening for websocket clients on wss?://(.+):(\d+)"
+    r"Listening for websocket clients on (wss?)://(.+):(\d+)"
 )
 
 
@@ -88,6 +88,7 @@ class Server:
     _process: asyncio.subprocess.Process | None
     _host: str
     _port: int
+    _websocket_scheme: str | None
     _websocket_host: str | None
     _websocket_port: int | None
 
@@ -96,6 +97,7 @@ class Server:
         process: asyncio.subprocess.Process,
         host: str,
         port: int,
+        websocket_scheme: str | None = None,
         websocket_host: str | None = None,
         websocket_port: int | None = None,
     ):
@@ -105,12 +107,14 @@ class Server:
             process: The subprocess running the NATS server.
             host: The host the server is listening on.
             port: The port the server is listening on.
+            websocket_scheme: ``"ws"`` or ``"wss"`` as logged by the server.
             websocket_host: The host the WebSocket listener is bound to.
             websocket_port: The port the WebSocket listener is bound to.
         """
         self._process = process
         self._host = host
         self._port = port
+        self._websocket_scheme = websocket_scheme
         self._websocket_host = websocket_host
         self._websocket_port = websocket_port
 
@@ -167,7 +171,8 @@ class Server:
         if ":" in host:
             host = f"[{host}]"
 
-        return f"ws://{host}:{self._websocket_port}"
+        scheme = self._websocket_scheme or "ws"
+        return f"{scheme}://{host}:{self._websocket_port}"
 
     @property
     def is_running(self) -> bool:
@@ -296,7 +301,7 @@ async def _create_server_process(
 async def _wait_for_server_ready(
     process: asyncio.subprocess.Process,
     timeout: float = 10.0,
-) -> tuple[str, int, str | None, int | None]:
+) -> tuple[str, int, str | None, str | None, int | None]:
     """Wait for a NATS server to become ready.
 
     Args:
@@ -304,8 +309,8 @@ async def _wait_for_server_ready(
         timeout: Maximum time to wait in seconds.
 
     Returns:
-        Tuple of (host, port, websocket_host, websocket_port). The WebSocket
-        entries are None when the server has no WebSocket listener.
+        Tuple of (host, port, websocket_scheme, websocket_host, websocket_port).
+        The WebSocket entries are None when the server has no WebSocket listener.
 
     Raises:
         ServerError: If the server fails to start or become ready.
@@ -317,9 +322,10 @@ async def _wait_for_server_ready(
             return value[1:-1]
         return value
 
-    async def wait_ready() -> tuple[str, int, str | None, int | None]:
+    async def wait_ready() -> tuple[str, int, str | None, str | None, int | None]:
         host: str | None = None
         port: int | None = None
+        websocket_scheme: str | None = None
         websocket_host: str | None = None
         websocket_port: int | None = None
         error_lines = []
@@ -331,15 +337,16 @@ async def _wait_for_server_ready(
             if READY_PATTERN.search(stderr_line):
                 assert host is not None
                 assert port is not None
-                return host, port, websocket_host, websocket_port
+                return host, port, websocket_scheme, websocket_host, websocket_port
 
             if match := LISTENING_PATTERN.search(stderr_line):
                 host = _strip_brackets(match.group(1))
                 port = int(match.group(2))
 
             if match := WEBSOCKET_LISTENING_PATTERN.search(stderr_line):
-                websocket_host = _strip_brackets(match.group(1))
-                websocket_port = int(match.group(2))
+                websocket_scheme = match.group(1)
+                websocket_host = _strip_brackets(match.group(2))
+                websocket_port = int(match.group(3))
 
             if INFO_PATTERN.search(stderr_line):
                 continue
@@ -402,6 +409,7 @@ async def run(
     (
         assigned_host,
         assigned_port,
+        websocket_scheme,
         websocket_host,
         websocket_port,
     ) = await _wait_for_server_ready(process, timeout=timeout)
@@ -410,6 +418,7 @@ async def run(
         process,
         assigned_host,
         assigned_port,
+        websocket_scheme=websocket_scheme,
         websocket_host=websocket_host,
         websocket_port=websocket_port,
     )
@@ -535,8 +544,12 @@ async def _run_cluster_node(
         config_path=config_path if config_path else None,
     )
 
-    assigned_host, assigned_port, _ws_host, _ws_port = await _wait_for_server_ready(
-        process, timeout=10.0
-    )
+    (
+        assigned_host,
+        assigned_port,
+        _ws_scheme,
+        _ws_host,
+        _ws_port,
+    ) = await _wait_for_server_ready(process, timeout=10.0)
 
     return Server(process, assigned_host, assigned_port)

--- a/uv.lock
+++ b/uv.lock
@@ -439,6 +439,9 @@ source = { editable = "nats-core" }
 nkeys = [
     { name = "nkeys" },
 ]
+websocket = [
+    { name = "websockets" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -449,11 +452,15 @@ dev = [
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
+    { name = "websockets" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "nkeys", marker = "extra == 'nkeys'", specifier = ">=0.1.0" }]
-provides-extras = ["nkeys"]
+requires-dist = [
+    { name = "nkeys", marker = "extra == 'nkeys'", specifier = ">=0.1.0" },
+    { name = "websockets", marker = "extra == 'websocket'", specifier = ">=16.0" },
+]
+provides-extras = ["nkeys", "websocket"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -464,6 +471,7 @@ dev = [
     { name = "pytest-benchmark", specifier = ">=5.2.1" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 
 [[package]]
@@ -788,6 +796,42 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/b0/2652a73c71c77296a6343217063f05745da60c67b7e8a8e25f2064167fce/ty-0.0.15-py3-none-win32.whl", hash = "sha256:9362c528ceb62c89d65c216336d28d500bc9f4c10418413f63ebc16886e16cc1", size = 9578058, upload-time = "2026-02-05T01:06:42.928Z" },
     { url = "https://files.pythonhosted.org/packages/84/6e/08a4aedebd2a6ce2784b5bc3760e43d1861f1a184734a78215c2d397c1df/ty-0.0.15-py3-none-win_amd64.whl", hash = "sha256:4db040695ae67c5524f59cb8179a8fa277112e69042d7dfdac862caa7e3b0d9c", size = 10457112, upload-time = "2026-02-05T01:06:39.885Z" },
     { url = "https://files.pythonhosted.org/packages/b3/be/1991f2bc12847ae2d4f1e3ac5dcff8bb7bc1261390645c0755bb55616355/ty-0.0.15-py3-none-win_arm64.whl", hash = "sha256:e5a98d4119e77d6136461e16ae505f8f8069002874ab073de03fbcb1a5e8bf25", size = 9937490, upload-time = "2026-02-05T01:06:32.388Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes the gap with nats.go: ws:// and wss:// URLs route through a WebSocket adapter backed by the optional `nats-core[websocket]` extra.