### PR TITLE
Mirror initial-connect TLS flow on reconnect

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -241,6 +241,7 @@ class Client(AbstractAsyncContextManager["Client"]):
     # TLS
     _tls: ssl.SSLContext | None
     _tls_hostname: str | None
+    _tls_handshake_first: bool
 
     # Statistics
     _stats_in_messages: int
@@ -279,6 +280,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         jwt_signature_handler: Callable[[str], bytes] | None = None,
         tls: ssl.SSLContext | None = None,
         tls_hostname: str | None = None,
+        tls_handshake_first: bool = False,
     ):
         """Initialize the client.
 
@@ -306,6 +308,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             jwt_signature_handler: Handler to sign nonces for JWT auth
             tls: SSL context for TLS connections
             tls_hostname: Hostname for TLS certificate verification
+            tls_handshake_first: Perform the TLS handshake before receiving INFO
         """
         self._connection = connection
         self._server_info = server_info
@@ -337,6 +340,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._jwt_signature_handler = jwt_signature_handler
         self._tls = tls
         self._tls_hostname = tls_hostname
+        self._tls_handshake_first = tls_handshake_first
         self._status = ClientStatus.CONNECTING
         self._subscriptions = {}
         self._next_sid = 1
@@ -785,12 +789,23 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     else (host if ssl_context else None)
                                 )
 
-                                connection = await asyncio.wait_for(
-                                    open_tcp_connection(
-                                        host, port, ssl_context=ssl_context, server_hostname=server_hostname
-                                    ),
-                                    timeout=self._reconnect_timeout,
-                                )
+                                tls_established = False
+                                if self._tls_handshake_first and ssl_context is not None:
+                                    connection = await asyncio.wait_for(
+                                        open_tcp_connection(
+                                            host,
+                                            port,
+                                            ssl_context=ssl_context,
+                                            server_hostname=server_hostname,
+                                        ),
+                                        timeout=self._reconnect_timeout,
+                                    )
+                                    tls_established = True
+                                else:
+                                    connection = await asyncio.wait_for(
+                                        open_tcp_connection(host, port),
+                                        timeout=self._reconnect_timeout,
+                                    )
 
                                 protocol_message = await parse(connection)
                                 if not isinstance(protocol_message, Info):
@@ -802,10 +817,24 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     "Reconnected to %s (version %s)", new_server_info.server_id, new_server_info.version
                                 )
 
+                                if new_server_info.tls_required and not tls_established:
+                                    logger.info("Server requires TLS, upgrading connection")
+                                    upgrade_ssl_context = (
+                                        self._tls if self._tls is not None else ssl.create_default_context()
+                                    )
+                                    upgrade_hostname = self._tls_hostname if self._tls_hostname is not None else host
+                                    if hasattr(connection, "upgrade_to_tls"):
+                                        await connection.upgrade_to_tls(upgrade_ssl_context, upgrade_hostname)
+                                        tls_established = True
+                                    else:
+                                        await connection.close()
+                                        msg = "Server requires TLS but connection does not support upgrade"
+                                        raise ConnectionError(msg)
+
                                 connect_info = ConnectInfo(
                                     verbose=False,
                                     pedantic=False,
-                                    tls_required=False,
+                                    tls_required=tls_established,
                                     lang="python",
                                     version=__version__,
                                     protocol=1,
@@ -1655,6 +1684,7 @@ async def connect(
         jwt_signature_handler=jwt_signature_handler,
         tls=ssl_context if ssl_context else tls,
         tls_hostname=server_hostname if server_hostname else tls_hostname,
+        tls_handshake_first=tls_handshake_first,
     )
 
     client._status = ClientStatus.CONNECTED

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -863,7 +863,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                                         self._tls if self._tls is not None else ssl.create_default_context()
                                     )
                                     upgrade_hostname = self._tls_hostname if self._tls_hostname is not None else host
-                                    if hasattr(connection, "upgrade_to_tls"):
+                                    if isinstance(connection, TcpConnection):
                                         try:
                                             await connection.upgrade_to_tls(upgrade_ssl_context, upgrade_hostname)
                                         except Exception:

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -838,7 +838,11 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     )
                                     upgrade_hostname = self._tls_hostname if self._tls_hostname is not None else host
                                     if hasattr(connection, "upgrade_to_tls"):
-                                        await connection.upgrade_to_tls(upgrade_ssl_context, upgrade_hostname)
+                                        try:
+                                            await connection.upgrade_to_tls(upgrade_ssl_context, upgrade_hostname)
+                                        except Exception:
+                                            await connection.close()
+                                            raise
                                         tls_established = True
                                     else:
                                         await connection.close()

--- a/nats-core/tests/test_tls.py
+++ b/nats-core/tests/test_tls.py
@@ -153,6 +153,60 @@ async def test_tls_reconnection_preserves_settings():
 
 
 @pytest.mark.asyncio
+async def test_tls_reconnection_with_upgrade_mode():
+    """Reconnect must preserve TLS upgrade-mode handshake (no handshake_first).
+
+    With ``tls_handshake_first=False`` the initial connect reads a plaintext
+    INFO, then upgrades to TLS when ``tls_required`` is set. The reconnect
+    path must follow the same sequence; otherwise it either bypasses the
+    upgrade (plaintext CONNECT with credentials) or tries a TLS-first
+    handshake against an upgrade-mode server.
+    """
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_tls_upgrade.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+    server_port = server.port
+
+    try:
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+        reconnected = asyncio.Event()
+
+        client = await connect(
+            server.client_url,
+            tls=ssl_context,
+            tls_handshake_first=False,
+            allow_reconnect=True,
+            reconnect_time_wait=0.1,
+            timeout=2.0,
+        )
+        client.add_reconnected_callback(lambda: reconnected.set())
+
+        await server.shutdown()
+        await asyncio.sleep(0.1)
+
+        new_server = await run(config_path=config_path, port=server_port, timeout=5.0)
+        try:
+            await asyncio.wait_for(reconnected.wait(), timeout=5.0)
+
+            # Verify the reconnected connection is usable end-to-end.
+            subscription = await client.subscribe("test.reconnect.upgrade")
+            await client.publish("test.reconnect.upgrade", b"after upgrade-mode reconnect")
+            await client.flush()
+            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+            assert message.data == b"after upgrade-mode reconnect"
+        finally:
+            await new_server.shutdown()
+            await client.close()
+    finally:
+        try:
+            await server.shutdown()
+        except Exception:
+            pass
+
+
+@pytest.mark.asyncio
 async def test_tls_verify_with_client_certificate():
     """Test TLS connection with client certificate verification."""
     config_path = os.path.join(os.path.dirname(__file__), "configs", "server_tls_verify.conf")

--- a/nats-core/tests/test_tls.py
+++ b/nats-core/tests/test_tls.py
@@ -1,6 +1,7 @@
 """Tests for TLS functionality in NATS client."""
 
 import asyncio
+import contextlib
 import os
 import ssl
 
@@ -204,6 +205,58 @@ async def test_tls_reconnection_with_upgrade_mode():
             await server.shutdown()
         except Exception:
             pass
+
+
+@pytest.mark.asyncio
+async def test_tls_reconnect_from_plain_to_tls_required():
+    """A reconnect that finds the server now requiring TLS must upgrade before sending CONNECT.
+
+    The initial server is plaintext; the replacement server requires TLS via the
+    upgrade-mode flow. The reconnect path must perform the TLS upgrade against
+    the freshly-received INFO, otherwise it would either send the plaintext
+    CONNECT (leaking credentials) or fail to handshake at all.
+    """
+    plain_server = await run(port=0, timeout=5.0)
+    server_port = plain_server.port
+
+    try:
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
+        reconnected = asyncio.Event()
+
+        client = await connect(
+            plain_server.client_url,
+            tls=ssl_context,
+            allow_reconnect=True,
+            reconnect_time_wait=0.1,
+            timeout=2.0,
+        )
+        client.add_reconnected_callback(lambda: reconnected.set())
+
+        await plain_server.shutdown()
+        await asyncio.sleep(0.1)
+
+        tls_config = os.path.join(os.path.dirname(__file__), "configs", "server_tls_upgrade.conf")
+        tls_server = await run(config_path=tls_config, port=server_port, timeout=5.0)
+        try:
+            await asyncio.wait_for(reconnected.wait(), timeout=5.0)
+
+            assert client.server_info is not None
+            assert client.server_info.tls_required is True
+
+            subscription = await client.subscribe("test.reconnect.tls.upgrade")
+            await client.publish("test.reconnect.tls.upgrade", b"after tls-required reconnect")
+            await client.flush()
+            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
+            assert message.data == b"after tls-required reconnect"
+        finally:
+            await tls_server.shutdown()
+            await client.close()
+    finally:
+        with contextlib.suppress(Exception):
+            await plain_server.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The reconnect path forced TLS-first regardless of `tls_handshake_first` and ignored `tls_required` from INFO, so upgrade-mode servers failed the handshake and credentials could leak in plaintext if a server started requiring TLS mid-session. Covers audit finding 07-tls.md #2.