### PR TITLE
Verify CONNECT acceptance on reconnect

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -838,6 +838,21 @@ class Client(AbstractAsyncContextManager["Client"]):
 
                                 logger.debug("->> CONNECT %s", json.dumps(connect_info))
                                 await connection.write(encode_connect(connect_info))
+                                await connection.write(encode_ping())
+
+                                try:
+                                    response = await asyncio.wait_for(
+                                        parse(connection), timeout=self._reconnect_timeout
+                                    )
+                                except asyncio.TimeoutError:
+                                    await connection.close()
+                                    msg = "Server did not respond to PING"
+                                    raise ConnectionError(msg)
+
+                                if isinstance(response, Err):
+                                    await connection.close()
+                                    msg = f"Connection error: {response.error}"
+                                    raise ConnectionError(msg)
 
                                 self._connection = connection
                                 self._server_info = new_server_info

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -50,7 +50,7 @@ from nats.client.protocol.command import (
     encode_sub,
     encode_unsub,
 )
-from nats.client.protocol.message import Err, Info, ParseError, parse
+from nats.client.protocol.message import Err, Info, ParseError, Pong, parse
 from nats.client.protocol.types import (
     ConnectInfo,
 )
@@ -849,9 +849,19 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     msg = "Server did not respond to PING"
                                     raise ConnectionError(msg)
 
+                                if response is None:
+                                    await connection.close()
+                                    msg = "Connection closed before PONG received"
+                                    raise ConnectionError(msg)
+
                                 if isinstance(response, Err):
                                     await connection.close()
                                     msg = f"Connection error: {response.error}"
+                                    raise ConnectionError(msg)
+
+                                if not isinstance(response, Pong):
+                                    await connection.close()
+                                    msg = f"Unexpected response to PING: {type(response).__name__}"
                                     raise ConnectionError(msg)
 
                                 self._connection = connection

--- a/nats-core/tests/configs/server_auth_token_alt.conf
+++ b/nats-core/tests/configs/server_auth_token_alt.conf
@@ -1,0 +1,4 @@
+# NATS server config for testing token authentication with a different token
+authorization {
+  token: "different_token_456"
+}

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -183,6 +183,57 @@ async def test_reconnect_with_token(token):
             pass
 
 
+@pytest.mark.asyncio
+async def test_reconnect_with_invalid_auth_does_not_silently_succeed():
+    """Server-side CONNECT rejection on reconnect must not flip status to CONNECTED.
+
+    If the reconnect path does not wait for PONG after sending CONNECT, a
+    server -ERR (e.g. auth failure against a rotated token) is never observed
+    and the client would fire reconnected callbacks, resume the subscription
+    list, and swallow subsequent publishes into a dead socket.
+    """
+    config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_token.conf")
+    alt_config_path = os.path.join(os.path.dirname(__file__), "configs", "server_auth_token_alt.conf")
+    server = await run(config_path=config_path, port=0, timeout=5.0)
+
+    try:
+        reconnect_count = 0
+
+        def on_reconnect():
+            nonlocal reconnect_count
+            reconnect_count += 1
+
+        client = await connect(
+            server.client_url,
+            timeout=1.0,
+            token="test_token_123",
+            allow_reconnect=True,
+            reconnect_time_wait=0.1,
+        )
+        client.add_reconnected_callback(on_reconnect)
+
+        server_port = server.port
+        await server.shutdown()
+
+        # Replacement server rejects the original token.
+        alt_server = await run(config_path=alt_config_path, port=server_port, timeout=5.0)
+        try:
+            # Give the client a generous window for reconnect attempts; any
+            # successful handshake (buggy or otherwise) would land in here.
+            await asyncio.sleep(1.0)
+
+            assert reconnect_count == 0, f"reconnected callback fired {reconnect_count} time(s) despite auth rejection"
+            assert client.status != ClientStatus.CONNECTED
+        finally:
+            await alt_server.shutdown()
+            await client.close()
+    finally:
+        try:
+            await server.shutdown()
+        except Exception:
+            pass
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="Windows returns different error message for auth failures")
 @pytest.mark.asyncio
 async def test_connect_to_token_server_with_incorrect_token():

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -218,9 +218,14 @@ async def test_reconnect_with_invalid_auth_does_not_silently_succeed():
         # Replacement server rejects the original token.
         alt_server = await run(config_path=alt_config_path, port=server_port, timeout=5.0)
         try:
-            # Give the client a generous window for reconnect attempts; any
-            # successful handshake (buggy or otherwise) would land in here.
-            await asyncio.sleep(1.0)
+            # Wait until the client has tried (and failed) to reconnect a few
+            # times — proves the reconnect machinery ran, so the assertion
+            # below can't pass vacuously on a slow machine.
+            async def saw_attempts(n: int):
+                while client._reconnect_attempts < n:
+                    await asyncio.sleep(0.01)
+
+            await asyncio.wait_for(saw_attempts(3), timeout=5.0)
 
             assert reconnect_count == 0, f"reconnected callback fired {reconnect_count} time(s) despite auth rejection"
             assert client.status != ClientStatus.CONNECTED


### PR DESCRIPTION
Reconnect wrote CONNECT and flipped to CONNECTED without waiting for PONG, so a server -ERR (e.g. rotated token) was silently ignored and subsequent publishes dropped into a dead socket.