### PR TITLE
Add force_reconnect for operator-initiated failover

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -196,6 +196,7 @@ class Client(AbstractAsyncContextManager["Client"]):
     _reconnect_attempts: int
     _reconnect_time: float
     _reconnect_lock: asyncio.Lock
+    _reconnect_wake: asyncio.Event
 
     # Subscriptions
     _subscriptions: dict[str, Subscription]
@@ -352,6 +353,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._reconnecting = False
         self._reconnect_time = self._reconnect_time_wait
         self._reconnect_lock = asyncio.Lock()
+        self._reconnect_wake = asyncio.Event()
         self._last_server = None
         self._pending_bytes = 0
         self._pending_messages = []
@@ -746,7 +748,9 @@ class Client(AbstractAsyncContextManager["Client"]):
                         actual_wait = self._reconnect_time * (1 + random.random() * self._reconnect_jitter)
 
                         logger.info("Waiting %.2fs before reconnection attempt", actual_wait)
-                        await asyncio.sleep(actual_wait)
+                        self._reconnect_wake.clear()
+                        with contextlib.suppress(asyncio.TimeoutError):
+                            await asyncio.wait_for(self._reconnect_wake.wait(), timeout=actual_wait)
 
                         servers_to_try = self._server_pool.copy()
                         if not self._no_randomize and len(servers_to_try) > 1:
@@ -1227,6 +1231,35 @@ class Client(AbstractAsyncContextManager["Client"]):
             await self.close()
             msg = f"Drain operation timed out after {timeout} seconds"
             raise TimeoutError(msg)
+
+    async def force_reconnect(self) -> None:
+        """Force a reconnect to the server.
+
+        Non-blocking — returns once the reconnect has been initiated. If the
+        client is currently connected, the existing connection is torn down and
+        the normal reconnect loop picks up from there. If a reconnect is already
+        in progress, the current backoff sleep is skipped so the next attempt
+        fires immediately.
+
+        Raises:
+            ConnectionError: If the connection is closed.
+            RuntimeError: If ``allow_reconnect=False``.
+        """
+        if self._status in (ClientStatus.CLOSING, ClientStatus.CLOSED):
+            msg = "Connection is closed"
+            raise ConnectionError(msg)
+        if not self._allow_reconnect:
+            msg = "Cannot force reconnect: allow_reconnect is disabled"
+            raise RuntimeError(msg)
+
+        # Already reconnecting — kick the backoff sleep so the next attempt
+        # fires immediately without rewinding any state.
+        if self._reconnecting or self._status == ClientStatus.RECONNECTING:
+            self._reconnect_wake.set()
+            return
+
+        # Connected — close and let the normal reconnect flow run.
+        await self._force_disconnect()
 
     async def close(self) -> None:
         """Close the connection."""

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1253,26 +1253,34 @@ class Client(AbstractAsyncContextManager["Client"]):
     async def force_reconnect(self) -> None:
         """Force a reconnect to the server.
 
-        Non-blocking — returns once the reconnect has been initiated. If the
-        client is currently connected, the existing connection is torn down and
-        the normal reconnect loop picks up from there. If a reconnect is already
-        in progress, the current backoff sleep is skipped so the next attempt
-        fires immediately.
+        If a reconnect cycle is already underway (status is ``DISCONNECTED`` or
+        ``RECONNECTING``) the current backoff sleep is woken so the next attempt
+        fires immediately; the call returns without waiting for the cycle to
+        finish. From the ``CONNECTED`` state the existing connection is torn
+        down and the call blocks until the reconnect loop completes — either
+        landing on a server or exhausting attempts.
 
         Raises:
-            ConnectionError: If the connection is closed.
+            ConnectionError: If the client is closed or draining.
             RuntimeError: If ``allow_reconnect=False``.
         """
-        if self._status in (ClientStatus.CLOSING, ClientStatus.CLOSED):
+        if self._status in (
+            ClientStatus.CLOSING,
+            ClientStatus.CLOSED,
+            ClientStatus.DRAINING,
+            ClientStatus.DRAINED,
+        ):
             msg = "Connection is closed"
             raise ConnectionError(msg)
         if not self._allow_reconnect:
             msg = "Cannot force reconnect: allow_reconnect is disabled"
             raise RuntimeError(msg)
 
-        # Already reconnecting — kick the backoff sleep so the next attempt
-        # fires immediately without rewinding any state.
-        if self._reconnecting or self._status == ClientStatus.RECONNECTING:
+        # Reconnect cycle already in flight (including the brief window after
+        # the read loop sets DISCONNECTED but before _force_disconnect sets
+        # _reconnecting) — kick the backoff sleep so the next attempt fires
+        # immediately instead of starting a second cycle.
+        if self._reconnecting or self._status in (ClientStatus.DISCONNECTED, ClientStatus.RECONNECTING):
             self._reconnect_wake.set()
             return
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -2953,3 +2953,78 @@ async def test_lame_duck_mode_callback_exception_is_isolated(client, server):
     server.lame_duck_mode()
     await asyncio.wait_for(second_called.wait(), timeout=5.0)
     assert calls == ["bad", "good"]
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_triggers_reconnect(server, client):
+    """force_reconnect() closes the current connection and completes a reconnect."""
+    reconnected = asyncio.Event()
+    client.add_reconnected_callback(reconnected.set)
+
+    await client.force_reconnect()
+    await asyncio.wait_for(reconnected.wait(), timeout=2.0)
+
+    assert client.status == ClientStatus.CONNECTED
+    # Round-trip verifies the new connection is usable.
+    await client.flush(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_raises_when_closed(server):
+    """force_reconnect() on a closed client raises ConnectionError."""
+    client = await connect(server.client_url, timeout=1.0)
+    await client.close()
+
+    with pytest.raises(ConnectionError):
+        await client.force_reconnect()
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_raises_when_reconnect_disabled(server):
+    """force_reconnect() raises when allow_reconnect=False."""
+    client = await connect(server.client_url, timeout=1.0, allow_reconnect=False)
+    try:
+        with pytest.raises(RuntimeError, match="reconnect"):
+            await client.force_reconnect()
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_skips_backoff_when_already_reconnecting():
+    """force_reconnect() during an ongoing reconnect cycle skips the backoff sleep."""
+    server = await run(port=0, timeout=5.0)
+    server_port = server.port
+
+    try:
+        reconnected = asyncio.Event()
+
+        # Long reconnect wait so we can observe the skip.
+        client = await connect(
+            server.client_url,
+            timeout=1.0,
+            allow_reconnect=True,
+            reconnect_time_wait=5.0,
+            reconnect_jitter=0.0,
+        )
+        client.add_reconnected_callback(reconnected.set)
+
+        await server.shutdown()
+        # Let the read loop notice and start reconnect backoff.
+        await asyncio.sleep(0.2)
+
+        new_server = await run(port=server_port, timeout=5.0)
+        try:
+            # Without skipping, reconnect wouldn't land for ~5s. force_reconnect should
+            # wake the sleep and land well under that budget.
+            await client.force_reconnect()
+            await asyncio.wait_for(reconnected.wait(), timeout=1.5)
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await new_server.shutdown()
+            await client.close()
+    finally:
+        try:
+            await server.shutdown()
+        except Exception:
+            pass

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -3262,3 +3262,13 @@ async def test_force_reconnect_skips_backoff_when_already_reconnecting():
             await server.shutdown()
         except Exception:
             pass
+
+
+@pytest.mark.asyncio
+async def test_force_reconnect_raises_when_drained(server):
+    """force_reconnect() raises ConnectionError after the client has been drained."""
+    client = await connect(server.client_url, timeout=1.0)
+    await client.drain()
+
+    with pytest.raises(ConnectionError):
+        await client.force_reconnect()


### PR DESCRIPTION
Mirrors nats.go's `Conn.ForceReconnect`: closes the current connection, triggers the standard reconnect loop, and kicks the backoff sleep if a reconnect is already in progress. Raises on closed or when `allow_reconnect=False`.