### PR TITLE
Add limit_marker_ttl support for KV watchers

### DIFF
--- a/nats/src/nats/js/api.py
+++ b/nats/src/nats/js/api.py
@@ -440,9 +440,10 @@ class StreamConfig(Base):
             raise ValueError("nats: invalid store compression type: %s" % self.compression)
         if self.metadata and not isinstance(self.metadata, dict):
             raise ValueError("nats: invalid metadata format")
-        # Omit when unset or zero — unlike max_age, the server does not treat 0 as "disabled"
-        # for this field; omission is the correct signal for "not configured".
-        if self.subject_delete_marker_ttl:
+        # Omit when unset, zero, or negative — unlike max_age, the server does not treat 0
+        # as "disabled" for this field; omission is the correct signal for "not configured".
+        # Negative values are rejected here to avoid an opaque server error.
+        if self.subject_delete_marker_ttl is not None and self.subject_delete_marker_ttl > 0:
             result["subject_delete_marker_ttl"] = self._to_nanoseconds(self.subject_delete_marker_ttl)
         else:
             result.pop("subject_delete_marker_ttl", None)

--- a/nats/src/nats/js/api.py
+++ b/nats/src/nats/js/api.py
@@ -413,6 +413,10 @@ class StreamConfig(Base):
     # Consumer limits for this stream. Introduced in nats-server 2.10.0.
     consumer_limits: Optional[StreamConsumerLimits] = None
 
+    # Enables server-side delete markers for TTL/purge events, observable by watchers.
+    # Introduced in nats-server 2.11.0.
+    subject_delete_marker_ttl: Optional[float] = None  # in seconds
+
     @classmethod
     def from_response(cls, resp: Dict[str, Any]):
         cls._convert_nanoseconds(resp, "max_age")
@@ -423,6 +427,7 @@ class StreamConfig(Base):
         cls._convert(resp, "republish", RePublish)
         cls._convert(resp, "subject_transform", SubjectTransform)
         cls._convert(resp, "consumer_limits", StreamConsumerLimits)
+        cls._convert_nanoseconds(resp, "subject_delete_marker_ttl")
         return super().from_response(resp)
 
     def as_dict(self) -> Dict[str, object]:
@@ -435,6 +440,12 @@ class StreamConfig(Base):
             raise ValueError("nats: invalid store compression type: %s" % self.compression)
         if self.metadata and not isinstance(self.metadata, dict):
             raise ValueError("nats: invalid metadata format")
+        # Omit when unset or zero — unlike max_age, the server does not treat 0 as "disabled"
+        # for this field; omission is the correct signal for "not configured".
+        if self.subject_delete_marker_ttl:
+            result["subject_delete_marker_ttl"] = self._to_nanoseconds(self.subject_delete_marker_ttl)
+        else:
+            result.pop("subject_delete_marker_ttl", None)
         return result
 
 
@@ -742,6 +753,7 @@ class APIStats(Base):
 
     total: int
     errors: int
+    level: Optional[int] = None  # API level; present from NATS server 2.11+
 
 
 @dataclass
@@ -821,10 +833,12 @@ class KeyValueConfig(Base):
     placement: Optional[Placement] = None
     republish: Optional[RePublish] = None
     direct: Optional[bool] = None
+    limit_marker_ttl: Optional[float] = None  # in seconds; client-side only
 
     def as_dict(self) -> Dict[str, object]:
         result = super().as_dict()
         result["ttl"] = self._to_nanoseconds(self.ttl)
+        result.pop("limit_marker_ttl", None)  # client-side only; never sent to server
         return result
 
 

--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -1398,7 +1398,7 @@ class JetStreamContext(JetStreamManager):
             raise nats.js.errors.KeyHistoryTooLargeError
 
         subject_delete_marker_ttl = None
-        if config.limit_marker_ttl is not None:
+        if config.limit_marker_ttl is not None and config.limit_marker_ttl > 0:
             info = await self.account_info()
             if not info.api.level or info.api.level < 1:
                 raise nats.js.errors.KeyValueLimitMarkerTTLNotSupportedError()

--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -1397,6 +1397,13 @@ class JetStreamContext(JetStreamManager):
         if config.history > 64:
             raise nats.js.errors.KeyHistoryTooLargeError
 
+        subject_delete_marker_ttl = None
+        if config.limit_marker_ttl is not None:
+            info = await self.account_info()
+            if not info.api.level or info.api.level < 1:
+                raise nats.js.errors.KeyValueLimitMarkerTTLNotSupportedError()
+            subject_delete_marker_ttl = config.limit_marker_ttl
+
         stream = api.StreamConfig(
             name=KV_STREAM_TEMPLATE.format(bucket=config.bucket),
             description=config.description,
@@ -1416,6 +1423,7 @@ class JetStreamContext(JetStreamManager):
             num_replicas=config.replicas,
             storage=config.storage,
             republish=config.republish,
+            subject_delete_marker_ttl=subject_delete_marker_ttl,
         )
         si = await self.add_stream(stream)
         assert stream.name is not None

--- a/nats/src/nats/js/errors.py
+++ b/nats/src/nats/js/errors.py
@@ -321,3 +321,12 @@ class ObjectAlreadyExists(Error):
     """
 
     pass
+
+
+class KeyValueLimitMarkerTTLNotSupportedError(Error):
+    """
+    Raised when limit_marker_ttl is used but the connected server does not support it (pre-2.11).
+    """
+
+    def __str__(self):
+        return "nats: limit marker TTLs not supported by server"

--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -504,6 +504,14 @@ class KeyValue:
                     op = KV_PURGE
                 elif reason == "Remove":
                     op = KV_DEL
+                else:
+                    # Unknown future reason — skip silently rather than emitting
+                    # an entry with operation=None that callers can't distinguish
+                    # from a regular value update.
+                    if meta.num_pending == 0 and not watcher._init_done:
+                        await watcher._updates.put(None)
+                        watcher._init_done = True
+                    return
 
             # keys() uses this
             if ignore_deletes and op in (KV_PURGE, KV_DEL):

--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -32,6 +32,8 @@ KV_OP = "KV-Operation"
 KV_DEL = "DEL"
 KV_PURGE = "PURGE"
 MSG_ROLLUP_SUBJECT = "sub"
+# Introduced in nats-server 2.11: server-placed markers use this header instead of KV-Operation.
+KV_MARKER_REASON = "Nats-Marker-Reason"
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +126,14 @@ class KeyValue:
             if self.stream_info.config.max_age is None:
                 return None
             return self.stream_info.config.max_age
+
+        @property
+        def marker_ttl(self) -> Optional[float]:
+            """
+            marker_ttl returns the subject delete marker TTL in seconds,
+            or None if not set.
+            """
+            return self.stream_info.config.subject_delete_marker_ttl
 
     def __init__(
         self,
@@ -486,14 +496,21 @@ class KeyValue:
             op = None
             if msg.header and KV_OP in msg.header:
                 op = msg.header.get(KV_OP)
+            elif msg.header and KV_MARKER_REASON in msg.header:
+                # nats-server 2.11+: server-placed TTL/age expiry markers use
+                # Nats-Marker-Reason instead of KV-Operation.
+                reason = msg.header.get(KV_MARKER_REASON)
+                if reason in ("MaxAge", "Purge"):
+                    op = KV_PURGE
+                elif reason == "Remove":
+                    op = KV_DEL
 
-                # keys() uses this
-                if ignore_deletes:
-                    if op == KV_PURGE or op == KV_DEL:
-                        if meta.num_pending == 0 and not watcher._init_done:
-                            await watcher._updates.put(None)
-                            watcher._init_done = True
-                        return
+            # keys() uses this
+            if ignore_deletes and op in (KV_PURGE, KV_DEL):
+                if meta.num_pending == 0 and not watcher._init_done:
+                    await watcher._updates.put(None)
+                    watcher._init_done = True
+                return
 
             entry = KeyValue.Entry(
                 bucket=self._name,

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -4096,6 +4096,11 @@ class KVLimitMarkerTTLTest(SingleJetStreamServerTestCase):
     async def test_kv_limit_marker_ttl_roundtrip(self):
         """limit_marker_ttl is stored as subject_delete_marker_ttl on the stream."""
         nc = await nats.connect()
+
+        server_version = nc.connected_server_version
+        if not (server_version.major > 2 or (server_version.major == 2 and server_version.minor >= 11)):
+            pytest.skip("limit_marker_ttl requires nats-server v2.11.0 or later")
+
         js = nc.jetstream()
 
         kv = await js.create_key_value(bucket="TEST_MARKER_ROUNDTRIP", limit_marker_ttl=60.0)
@@ -4109,6 +4114,11 @@ class KVLimitMarkerTTLTest(SingleJetStreamServerTestCase):
     async def test_kv_limit_marker_ttl_bucket_status(self):
         """BucketStatus.marker_ttl reflects subject_delete_marker_ttl from stream config."""
         nc = await nats.connect()
+
+        server_version = nc.connected_server_version
+        if not (server_version.major > 2 or (server_version.major == 2 and server_version.minor >= 11)):
+            pytest.skip("limit_marker_ttl requires nats-server v2.11.0 or later")
+
         js = nc.jetstream()
 
         kv = await js.create_key_value(bucket="TEST_MARKER_STATUS", limit_marker_ttl=30.0)

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -30,6 +30,73 @@ except ImportError:
     parse_email = None
 
 
+class APIDataClassTest(unittest.TestCase):
+    def test_api_stats_level_present(self):
+        """APIStats parses level field from server response."""
+        resp = {"total": 5, "errors": 1, "level": 1}
+        stats = nats.js.api.APIStats.from_response(resp)
+        assert stats.level == 1
+
+    def test_api_stats_level_absent(self):
+        """APIStats.level is None when server does not send it (pre-2.11)."""
+        resp = {"total": 5, "errors": 1}
+        stats = nats.js.api.APIStats.from_response(resp)
+        assert stats.level is None
+
+    def test_stream_config_subject_delete_marker_ttl_as_dict(self):
+        """subject_delete_marker_ttl is serialized to nanoseconds."""
+        config = nats.js.api.StreamConfig(
+            name="test",
+            subjects=["test.*"],
+            subject_delete_marker_ttl=30.0,
+        )
+        d = config.as_dict()
+        assert d["subject_delete_marker_ttl"] == 30 * 10**9
+
+    def test_stream_config_subject_delete_marker_ttl_omitted_when_none_or_zero(self):
+        """subject_delete_marker_ttl is not sent when None or zero (server ignores 0; omission is correct)."""
+        config = nats.js.api.StreamConfig(name="test", subjects=["test.*"])
+        d = config.as_dict()
+        assert "subject_delete_marker_ttl" not in d
+
+        config_zero = nats.js.api.StreamConfig(name="test", subjects=["test.*"], subject_delete_marker_ttl=0.0)
+        d_zero = config_zero.as_dict()
+        assert "subject_delete_marker_ttl" not in d_zero
+
+    def test_stream_config_subject_delete_marker_ttl_from_response(self):
+        """subject_delete_marker_ttl is deserialized from nanoseconds to seconds."""
+        resp = {
+            "name": "test",
+            "subjects": ["test.*"],
+            "storage": "file",
+            "num_replicas": 1,
+            "subject_delete_marker_ttl": 30 * 10**9,
+        }
+        config = nats.js.api.StreamConfig.from_response(resp)
+        assert config.subject_delete_marker_ttl == 30.0
+
+    def test_stream_config_subject_delete_marker_ttl_fractional(self):
+        """sub-second values are truncated to integer nanoseconds."""
+        config = nats.js.api.StreamConfig(
+            name="test",
+            subjects=["test.*"],
+            subject_delete_marker_ttl=0.5,
+        )
+        d = config.as_dict()
+        assert d["subject_delete_marker_ttl"] == 500_000_000
+
+    def test_key_value_config_limit_marker_ttl(self):
+        """KeyValueConfig accepts limit_marker_ttl field."""
+        cfg = nats.js.api.KeyValueConfig(bucket="TEST", limit_marker_ttl=60.0)
+        assert cfg.limit_marker_ttl == 60.0
+
+    def test_key_value_config_limit_marker_ttl_not_in_as_dict(self):
+        """limit_marker_ttl is client-side only and must not appear in as_dict output."""
+        cfg = nats.js.api.KeyValueConfig(bucket="TEST", limit_marker_ttl=60.0)
+        d = cfg.as_dict()
+        assert "limit_marker_ttl" not in d
+
+
 class PublishTest(SingleJetStreamServerTestCase):
     @async_test
     async def test_publish(self):
@@ -4024,6 +4091,89 @@ class KVTest(SingleJetStreamServerTestCase):
         await nc.close()
 
 
+class KVLimitMarkerTTLTest(SingleJetStreamServerTestCase):
+    @async_test
+    async def test_kv_limit_marker_ttl_roundtrip(self):
+        """limit_marker_ttl is stored as subject_delete_marker_ttl on the stream."""
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        kv = await js.create_key_value(bucket="TEST_MARKER_ROUNDTRIP", limit_marker_ttl=60.0)
+
+        stream_info = await js.stream_info("KV_TEST_MARKER_ROUNDTRIP")
+        assert stream_info.config.subject_delete_marker_ttl == 60.0
+
+        await nc.close()
+
+    @async_test
+    async def test_kv_limit_marker_ttl_bucket_status(self):
+        """BucketStatus.marker_ttl reflects subject_delete_marker_ttl from stream config."""
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        kv = await js.create_key_value(bucket="TEST_MARKER_STATUS", limit_marker_ttl=30.0)
+        status = await kv.status()
+        assert status.marker_ttl == 30.0
+
+        await nc.close()
+
+    @async_test
+    async def test_kv_no_limit_marker_ttl_status_is_none(self):
+        """BucketStatus.marker_ttl is None when limit_marker_ttl was not set."""
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        kv = await js.create_key_value(bucket="TEST_NO_MARKER")
+        status = await kv.status()
+        assert status.marker_ttl is None
+
+        await nc.close()
+
+    @async_test
+    async def test_kv_limit_marker_ttl_watcher_observes_expiry(self):
+        """Watcher receives a DEL/PURGE entry when a key expires via msg_ttl."""
+        nc = await nats.connect()
+
+        server_version = nc.connected_server_version
+        if server_version.major == 2 and server_version.minor < 11:
+            pytest.skip("limit_marker_ttl requires nats-server v2.11.0 or later")
+
+        js = nc.jetstream()
+
+        # Create bucket with 3-second marker lifetime so markers outlive the test
+        kv = await js.create_key_value(bucket="TEST_MARKER_WATCHER", limit_marker_ttl=3.0)
+
+        # Create a key that expires in 1 second
+        await kv.create("age", b"30", msg_ttl=1.0)
+
+        # Attach watcher with history so we see the initial value first
+        watcher = await kv.watch("age", include_history=True)
+
+        # First entry: the current value (not yet expired)
+        entry = await watcher.updates(timeout=3.0)
+        assert entry is not None
+        assert entry.key == "age"
+        assert entry.value == b"30"
+        assert entry.operation is None
+
+        # None marker: initial state is delivered
+        none_entry = await watcher.updates(timeout=3.0)
+        assert none_entry is None
+
+        # Wait for the 1s TTL to expire
+        await asyncio.sleep(1.5)
+
+        # Watcher must receive a purge marker placed by the server.
+        # nats-server 2.11+ uses Nats-Marker-Reason: MaxAge (mapped to PURGE by the client).
+        expiry_entry = await watcher.updates(timeout=5.0)
+        assert expiry_entry is not None
+        assert expiry_entry.key == "age"
+        assert expiry_entry.operation == "PURGE"
+
+        await watcher.stop()
+        await nc.close()
+
+
 class ObjectStoreTest(SingleJetStreamServerTestCase):
     @async_test
     async def test_object_basics(self):
@@ -4602,27 +4752,26 @@ class AccountLimitsTest(SingleJetStreamServerLimitsTestCase):
         for i in range(0, 5):
             await js.publish("limits", b"A")
 
-        expected = nats.js.api.AccountInfo(
-            memory=0,
-            storage=111,
-            streams=1,
-            consumers=0,
-            limits=nats.js.api.AccountLimits(
-                max_memory=67108864,  # 64MB
-                max_storage=33554432,  # 32MB
-                max_streams=10,
-                max_consumers=20,
-                max_ack_pending=100,
-                memory_max_stream_bytes=2048,
-                storage_max_stream_bytes=4096,
-                max_bytes_required=True,
-            ),
-            api=nats.js.api.APIStats(total=4, errors=2),
-            domain="test-domain",
-            tiers=None,
-        )
         info = await js.account_info()
-        assert expected == info
+        assert info.memory == 0
+        assert info.storage == 111
+        assert info.streams == 1
+        assert info.consumers == 0
+        assert info.limits == nats.js.api.AccountLimits(
+            max_memory=67108864,  # 64MB
+            max_storage=33554432,  # 32MB
+            max_streams=10,
+            max_consumers=20,
+            max_ack_pending=100,
+            memory_max_stream_bytes=2048,
+            storage_max_stream_bytes=4096,
+            max_bytes_required=True,
+        )
+        assert info.api.total == 4
+        assert info.api.errors == 2
+        # info.api.level is server-version-dependent; not checked here
+        assert info.domain == "test-domain"
+        assert info.tiers is None
 
         # Messages are limited.
         js = nc.jetstream(domain="test-domain")


### PR DESCRIPTION
Add limit_marker_ttl to KeyValueConfig and subject_delete_marker_ttl to StreamConfig, enabling watchers to observe TTL-driven key expiry events.

When limit_marker_ttl is set on a bucket, the server places a short-lived tombstone whenever a key is removed by TTL, max_age, or purge. Watchers receive this tombstone as a DEL or PURGE operation, closing the gap where expiry events were previously invisible.

Matches the Go client's LimitMarkerTTL / SubjectDeleteMarkerTTL behaviour, including the API-level server version check (requires nats-server 2.11+).

Changes:
- api.py: APIStats.level, StreamConfig.subject_delete_marker_ttl (ns conversion), KeyValueConfig.limit_marker_ttl (client-side only)
- errors.py: KeyValueLimitMarkerTTLNotSupportedError
- client.py: account_info() version guard + wiring in create_key_value
- kv.py: BucketStatus.marker_ttl property; handle Nats-Marker-Reason header in watch_updates for nats-server 2.11+ TTL expiry markers
- tests: APIDataClassTest (unit) + KVLimitMarkerTTLTest (integration)

Closes #909, #725