### PR TITLE
Enforce TLS intent against server capabilities

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -39,7 +39,7 @@ from urllib.parse import urlparse
 
 import nkeys
 from nats.client.connection import Connection, open_tcp_connection
-from nats.client.errors import NoRespondersError, SlowConsumerError, StatusError
+from nats.client.errors import NoRespondersError, SecureConnectionRequiredError, SlowConsumerError, StatusError
 from nats.client.message import Headers, Message, Status
 from nats.client.protocol.command import (
     encode_connect,
@@ -117,6 +117,7 @@ class ServerInfo:
     headers: bool
     auth_required: bool
     tls_required: bool
+    tls_available: bool
     tls_verify: bool
     max_payload: int
     proto: int
@@ -138,6 +139,7 @@ class ServerInfo:
             headers=info["headers"],
             auth_required=info.get("auth_required", False),
             tls_required=info.get("tls_required", False),
+            tls_available=info.get("tls_available", False),
             tls_verify=info.get("tls_verify", False),
             max_payload=info.get("max_payload", 1048576),
             proto=info.get("proto", 1),
@@ -244,6 +246,7 @@ class Client(AbstractAsyncContextManager["Client"]):
     # TLS
     _tls: ssl.SSLContext | None
     _tls_hostname: str | None
+    _wants_tls: bool
 
     # Statistics
     _stats_in_messages: int
@@ -282,6 +285,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         jwt_signature_handler: Callable[[str], bytes] | None = None,
         tls: ssl.SSLContext | None = None,
         tls_hostname: str | None = None,
+        wants_tls: bool = False,
     ):
         """Initialize the client.
 
@@ -309,6 +313,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             jwt_signature_handler: Handler to sign nonces for JWT auth
             tls: SSL context for TLS connections
             tls_hostname: Hostname for TLS certificate verification
+            wants_tls: Whether the client requested TLS (via scheme, tls context, or tls_handshake_first)
         """
         self._connection = connection
         self._server_info = server_info
@@ -340,6 +345,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._jwt_signature_handler = jwt_signature_handler
         self._tls = tls
         self._tls_hostname = tls_hostname
+        self._wants_tls = wants_tls
         self._status = ClientStatus.CONNECTING
         self._subscriptions = {}
         self._next_sid = 1
@@ -763,7 +769,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                             if "://" in server:
                                 parsed_url = urlparse(server)
                             else:
-                                scheme = "tls" if self._server_info.tls_required else "nats"
+                                scheme = "tls" if self._wants_tls or self._server_info.tls_required else "nats"
 
                                 if not server.startswith("[") and server.count(":") > 1:
                                     last_colon = server.rfind(":")
@@ -786,11 +792,11 @@ class Client(AbstractAsyncContextManager["Client"]):
                                 continue
 
                             try:
+                                wants_tls = self._wants_tls or scheme in ("tls", "wss")
+
                                 ssl_context = None
-                                if scheme in ("tls", "wss"):
+                                if wants_tls:
                                     ssl_context = self._tls if self._tls is not None else ssl.create_default_context()
-                                elif self._tls is not None:
-                                    ssl_context = self._tls
 
                                 server_hostname = (
                                     self._tls_hostname
@@ -814,6 +820,10 @@ class Client(AbstractAsyncContextManager["Client"]):
                                 logger.info(
                                     "Reconnected to %s (version %s)", new_server_info.server_id, new_server_info.version
                                 )
+
+                                if wants_tls and not (new_server_info.tls_required or new_server_info.tls_available):
+                                    await connection.close()
+                                    raise SecureConnectionRequiredError
 
                                 connect_info = ConnectInfo(
                                     verbose=False,
@@ -1524,11 +1534,11 @@ async def connect(
 
     logger.info("Connecting to %s:%s", host, port)
 
+    wants_tls = parsed_url.scheme in ("tls", "wss") or tls is not None or tls_handshake_first
+
     ssl_context = None
-    if parsed_url.scheme in ("tls", "wss"):
+    if wants_tls:
         ssl_context = tls if tls is not None else ssl.create_default_context()
-    elif tls is not None:
-        ssl_context = tls
 
     server_hostname = tls_hostname if tls_hostname is not None else (host if ssl_context else None)
 
@@ -1561,8 +1571,12 @@ async def connect(
         server_info = ServerInfo.from_protocol(protocol_message.info)
         logger.info("Connected to %s (version %s)", server_info.server_id, server_info.version)
 
-        if server_info.tls_required and not tls_established:
-            logger.info("Server requires TLS, upgrading connection")
+        if wants_tls and not (server_info.tls_required or server_info.tls_available):
+            await connection.close()
+            raise SecureConnectionRequiredError
+
+        if (wants_tls or server_info.tls_required) and not tls_established:
+            logger.info("Upgrading connection to TLS")
             upgrade_ssl_context = tls if tls is not None else ssl.create_default_context()
             upgrade_hostname = tls_hostname if tls_hostname is not None else host
 
@@ -1576,6 +1590,8 @@ async def connect(
                 msg = "Server requires TLS but connection does not support upgrade"
                 raise ConnectionError(msg)
 
+    except SecureConnectionRequiredError:
+        raise
     except Exception as e:
         await connection.close()
         msg = f"Failed to connect: {e}"
@@ -1687,6 +1703,7 @@ async def connect(
         jwt_signature_handler=jwt_signature_handler,
         tls=ssl_context if ssl_context else tls,
         tls_hostname=server_hostname if server_hostname else tls_hostname,
+        wants_tls=wants_tls,
     )
 
     client._status = ClientStatus.CONNECTED

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -877,7 +877,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     await connection.close()
                                     raise SecureConnectionRequiredError
 
-                                if new_server_info.tls_required and not tls_established:
+                                if (wants_tls or new_server_info.tls_required) and not tls_established:
                                     logger.info("Server requires TLS, upgrading connection")
                                     upgrade_ssl_context = (
                                         self._tls if self._tls is not None else ssl.create_default_context()

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1771,4 +1771,5 @@ __all__ = [
     "StatusError",
     "NoRespondersError",
     "MaxPayloadError",
+    "SecureConnectionRequiredError",
 ]

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -817,6 +817,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     ),
                                     timeout=self._reconnect_timeout,
                                 )
+                                tls_established = ssl_context is not None
 
                                 protocol_message = await parse(connection)
                                 if not isinstance(protocol_message, Info):
@@ -828,7 +829,11 @@ class Client(AbstractAsyncContextManager["Client"]):
                                     "Reconnected to %s (version %s)", new_server_info.server_id, new_server_info.version
                                 )
 
-                                if wants_tls and not (new_server_info.tls_required or new_server_info.tls_available):
+                                if (
+                                    wants_tls
+                                    and not tls_established
+                                    and not (new_server_info.tls_required or new_server_info.tls_available)
+                                ):
                                     await connection.close()
                                     raise SecureConnectionRequiredError
 
@@ -908,6 +913,10 @@ class Client(AbstractAsyncContextManager["Client"]):
 
                                 return
 
+                            except SecureConnectionRequiredError:
+                                # TLS intent is a configuration error, not a per-server failure;
+                                # propagate out of the reconnect loop instead of silently bypassing.
+                                raise
                             except (asyncio.CancelledError, asyncio.TimeoutError) as e:
                                 logger.error("Failed to connect to %s: %s", server, type(e).__name__)
                                 self._last_server = server
@@ -921,6 +930,8 @@ class Client(AbstractAsyncContextManager["Client"]):
 
                         self._reconnect_time = min(self._reconnect_time * 2, self._reconnect_time_wait_max)
 
+                    except SecureConnectionRequiredError:
+                        raise
                     except Exception:
                         logger.exception("Reconnection attempt failed")
 
@@ -1606,7 +1617,7 @@ async def connect(
         server_info = ServerInfo.from_protocol(protocol_message.info)
         logger.info("Connected to %s (version %s)", server_info.server_id, server_info.version)
 
-        if wants_tls and not (server_info.tls_required or server_info.tls_available):
+        if wants_tls and not tls_established and not (server_info.tls_required or server_info.tls_available):
             await connection.close()
             raise SecureConnectionRequiredError
 

--- a/nats-core/src/nats/client/errors.py
+++ b/nats-core/src/nats/client/errors.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-__all__ = ["StatusError", "NoRespondersError", "SlowConsumerError"]
+__all__ = ["StatusError", "NoRespondersError", "SlowConsumerError", "SecureConnectionRequiredError"]
+
+
+class SecureConnectionRequiredError(Exception):
+    """Client requested a secure connection but the server does not offer TLS."""
+
+    def __init__(self) -> None:
+        super().__init__("secure connection required but server does not offer TLS")
 
 
 class StatusError(Exception):

--- a/nats-core/tests/test_tls.py
+++ b/nats-core/tests/test_tls.py
@@ -6,7 +6,8 @@ import ssl
 
 import pytest
 from nats.client import connect
-from nats.server import run
+from nats.client.errors import SecureConnectionRequiredError
+from nats.server import Server, run
 
 
 @pytest.mark.asyncio
@@ -185,6 +186,24 @@ async def test_tls_verify_with_client_certificate():
         await client.close()
     finally:
         await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_tls_scheme_against_plaintext_server_raises(server: Server):
+    """tls:// URL must fail fast when the server offers no TLS."""
+    plaintext_url = server.client_url.replace("nats://", "tls://")
+    with pytest.raises(SecureConnectionRequiredError):
+        await connect(plaintext_url, timeout=1.0, allow_reconnect=False)
+
+
+@pytest.mark.asyncio
+async def test_tls_context_against_plaintext_server_raises(server: Server):
+    """Passing a tls context to a plaintext server must fail fast."""
+    ssl_context = ssl.create_default_context()
+    ssl_context.check_hostname = False
+    ssl_context.verify_mode = ssl.CERT_NONE
+    with pytest.raises(SecureConnectionRequiredError):
+        await connect(server.client_url, tls=ssl_context, timeout=1.0, allow_reconnect=False)
 
 
 @pytest.mark.asyncio

--- a/nats-core/tests/test_tls.py
+++ b/nats-core/tests/test_tls.py
@@ -1,7 +1,6 @@
 """Tests for TLS functionality in NATS client."""
 
 import asyncio
-import contextlib
 import os
 import ssl
 from pathlib import Path
@@ -207,58 +206,6 @@ async def test_tls_reconnection_with_upgrade_mode():
             await server.shutdown()
         except Exception:
             pass
-
-
-@pytest.mark.asyncio
-async def test_tls_reconnect_from_plain_to_tls_required():
-    """A reconnect that finds the server now requiring TLS must upgrade before sending CONNECT.
-
-    The initial server is plaintext; the replacement server requires TLS via the
-    upgrade-mode flow. The reconnect path must perform the TLS upgrade against
-    the freshly-received INFO, otherwise it would either send the plaintext
-    CONNECT (leaking credentials) or fail to handshake at all.
-    """
-    plain_server = await run(port=0, timeout=5.0)
-    server_port = plain_server.port
-
-    try:
-        ssl_context = ssl.create_default_context()
-        ssl_context.check_hostname = False
-        ssl_context.verify_mode = ssl.CERT_NONE
-
-        reconnected = asyncio.Event()
-
-        client = await connect(
-            plain_server.client_url,
-            tls=ssl_context,
-            allow_reconnect=True,
-            reconnect_time_wait=0.1,
-            timeout=2.0,
-        )
-        client.add_reconnected_callback(lambda: reconnected.set())
-
-        await plain_server.shutdown()
-        await asyncio.sleep(0.1)
-
-        tls_config = os.path.join(os.path.dirname(__file__), "configs", "server_tls_upgrade.conf")
-        tls_server = await run(config_path=tls_config, port=server_port, timeout=5.0)
-        try:
-            await asyncio.wait_for(reconnected.wait(), timeout=5.0)
-
-            assert client.server_info is not None
-            assert client.server_info.tls_required is True
-
-            subscription = await client.subscribe("test.reconnect.tls.upgrade")
-            await client.publish("test.reconnect.tls.upgrade", b"after tls-required reconnect")
-            await client.flush()
-            message = await asyncio.wait_for(subscription.next(), timeout=2.0)
-            assert message.data == b"after tls-required reconnect"
-        finally:
-            await tls_server.shutdown()
-            await client.close()
-    finally:
-        with contextlib.suppress(Exception):
-            await plain_server.shutdown()
 
 
 @pytest.mark.asyncio

--- a/nats-core/tests/test_tls.py
+++ b/nats-core/tests/test_tls.py
@@ -3,9 +3,10 @@
 import asyncio
 import os
 import ssl
+from pathlib import Path
 
 import pytest
-from nats.client import connect
+from nats.client import ClientStatus, connect
 from nats.client.errors import SecureConnectionRequiredError
 from nats.server import Server, run
 
@@ -224,3 +225,55 @@ async def test_tls_connection_without_ssl_context_fails():
             )
     finally:
         await server.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_tls_handshake_first_against_server_without_tls_advertise():
+    """A TLS-terminator that doesn't advertise ``tls_available`` must not raise after a successful handshake-first connect."""
+    certs = Path(__file__).parent / "certs"
+    server_ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    server_ctx.load_cert_chain(certfile=str(certs / "server-cert.pem"), keyfile=str(certs / "server-key.pem"))
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        # INFO omits both tls_required and tls_available, mirroring a TLS terminator
+        # that fronts a plaintext NATS server.
+        info = (
+            b'INFO {"server_id":"test","server_name":"test","version":"2.0.0","proto":1,'
+            b'"go":"go1.20","host":"127.0.0.1","port":4222,"headers":true,"max_payload":1048576}\r\n'
+        )
+        writer.write(info)
+        await writer.drain()
+        await reader.readline()  # CONNECT
+        await reader.readline()  # PING
+        writer.write(b"PONG\r\n")
+        await writer.drain()
+        while await reader.read(4096):
+            pass
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+    listener = await asyncio.start_server(handle, "127.0.0.1", 0, ssl=server_ctx)
+    host, port = listener.sockets[0].getsockname()[:2]
+
+    client_ctx = ssl.create_default_context()
+    client_ctx.check_hostname = False
+    client_ctx.verify_mode = ssl.CERT_NONE
+
+    try:
+        client = await connect(
+            f"nats://{host}:{port}",
+            tls=client_ctx,
+            tls_handshake_first=True,
+            timeout=2.0,
+            allow_reconnect=False,
+        )
+        try:
+            assert client.status == ClientStatus.CONNECTED
+        finally:
+            await client.close()
+    finally:
+        listener.close()
+        await listener.wait_closed()


### PR DESCRIPTION
Client intent to use TLS (`tls://` scheme, `tls` context, or `tls_handshake_first`) was lost after the initial context setup. A `tls://` URL against a server without `tls_required` connected in plaintext, leaking credentials in CONNECT.

Mirrors nats.go `checkForSecure()`: tracks `wants_tls`, raises `SecureConnectionRequiredError` when the server advertises neither `tls_required` nor `tls_available`, and upgrades whenever either side requires it. `tls_available` is now plumbed through `ServerInfo`. Same gate applies on reconnect.