### PR TITLE
fix: trigger reconnect on unexpected errors in _read_loop

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -2296,9 +2296,8 @@ class Client:
                 break
             except Exception as ex:
                 _logger.error("nats: encountered error", exc_info=ex)
+                await self._process_op_err(ex)
                 break
-            # except asyncio.InvalidStateError:
-            #     pass
 
     async def __aenter__(self) -> "Client":
         """For when NATS client is used in a context manager"""


### PR DESCRIPTION
## Problem

The catch-all `except Exception` branch in `_read_loop` (client.py) only logs the error and breaks out of the loop **without calling `_process_op_err()`**. This means unexpected exceptions — such as a `TypeError` raised when `transport.read()` returns a non-bytes value — silently kill the read loop while the client still believes it is connected.

The client enters a zombie state: `is_connected` remains `True`, but no data is being read, and the reconnection logic is never triggered.

### Reproduction

When the transport layer returns corrupted data (e.g., an `int` instead of `bytes`), the parser raises:

```
TypeError: can't extend bytearray with int
  File "nats/protocol/parser.py", line 90, in parse
    self.buf.extend(data)
```

This `TypeError` falls through to the generic `except Exception` handler, which only logs and breaks — no reconnection attempt is made.

### Comparison with other exception handlers

| Exception type | Calls `_process_op_err`? | Triggers reconnect? |
|---|---|---|
| `ProtocolError` | Yes | Yes |
| `OSError` | Yes | Yes |
| `Exception` (catch-all) | **No** | **No** |

## Fix

Call `await self._process_op_err(ex)` in the `except Exception` branch before breaking, so the client follows the same reconnection path used by `ProtocolError` and `OSError`.

## Changes

- `nats/src/nats/aio/client.py`: Added `_process_op_err` call in the catch-all exception handler of `_read_loop`
- Removed stale commented-out `asyncio.InvalidStateError` handler