### PR TITLE
fix: validate data type in parser before extending buffer

### DIFF
--- a/nats/src/nats/protocol/parser.py
+++ b/nats/src/nats/protocol/parser.py
@@ -87,6 +87,10 @@ class Parser:
         Parses the wire protocol from NATS for the client
         and dispatches the subscription callbacks.
         """
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise ProtocolError(
+                f"nats: parser expected bytes, got {type(data).__name__}"
+            )
         self.buf.extend(data)
         while self.buf:
             if self.state == AWAITING_CONTROL_LINE:


### PR DESCRIPTION
## Problem

`Parser.parse()` calls `self.buf.extend(data)` without validating the type of `data`. When the transport layer returns an unexpected type (e.g., `int` instead of `bytes`), this raises:

```
TypeError: can't extend bytearray with int
  File "nats/protocol/parser.py", line 90, in parse
    self.buf.extend(data)
```

This `TypeError` is **not** a `ProtocolError`, so it bypasses the `ProtocolError` exception handler in `_read_loop` and falls into the generic `except Exception` branch, which does not trigger reconnection (see #914).

## Fix

Add a type check at the top of `Parser.parse()` that raises a `ProtocolError` when `data` is not `bytes`, `bytearray`, or `memoryview`. This ensures:

1. The error is caught by the existing `except errors.ProtocolError` handler in `_read_loop`
2. `_process_op_err()` is called, triggering the reconnection logic
3. The error message clearly identifies the unexpected type for debugging

## Changes

- `nats/src/nats/protocol/parser.py`: Added type validation in `parse()` before `self.buf.extend(data)`

## Relationship to #914

This PR is complementary to #914. Together they provide defense in depth:
- **#914** fixes the `_read_loop` so that *any* unexpected exception triggers reconnection
- **This PR** converts the specific `TypeError` into a `ProtocolError` at the source, providing a clearer error message and ensuring the correct exception handler is used