### PR TITLE
Fix legacy KV, object store, compression tests on nats-server 2.14

### DIFF
--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3111,11 +3111,7 @@ class KVTest(SingleJetStreamServerTestCase):
         assert config.storage == "file"
         assert config.template_owner == None
 
-        version = nc.connected_server_version
-        if version.major == 2 and (version.minor < 9 or version.minor > 12):
-            assert config.allow_direct == None
-        else:
-            assert config.allow_direct == False
+        assert config.allow_direct == False
 
         # Nothing from start
         with pytest.raises(KeyNotFoundError):
@@ -4054,21 +4050,14 @@ class ObjectStoreTest(SingleJetStreamServerTestCase):
         assert sinfo.config.max_msgs == -1
         assert sinfo.config.max_bytes == -1
         assert sinfo.config.discard == "new"
-        version = nc.connected_server_version
-        if version.major == 2 and version.minor > 12:
-            assert sinfo.config.max_age is None
-        else:
-            assert sinfo.config.max_age == 0
+        assert sinfo.config.max_age == 0
         assert sinfo.config.max_msgs_per_subject == -1
         assert sinfo.config.max_msg_size == -1
         assert sinfo.config.storage == "file"
         assert sinfo.config.num_replicas == 1
         assert sinfo.config.allow_rollup_hdrs == True
         assert sinfo.config.allow_direct == True
-        if version.major == 2 and version.minor > 12:
-            assert sinfo.config.mirror_direct is None
-        else:
-            assert sinfo.config.mirror_direct == False
+        assert sinfo.config.mirror_direct == False
 
         bucketname = "".join(random.SystemRandom().choice(string.ascii_letters) for _ in range(10))
         obs = await js.create_object_store(bucket=bucketname)
@@ -5120,11 +5109,7 @@ class V210FeaturesTest(SingleJetStreamServerTestCase):
             compression="none",
         )
         sinfo = await js.stream_info("NONE")
-        version = nc.connected_server_version
-        if version.major == 2 and version.minor > 12:
-            assert sinfo.config.compression is None
-        else:
-            assert sinfo.config.compression == nats.js.api.StoreCompression.NONE
+        assert sinfo.config.compression == nats.js.api.StoreCompression.NONE
 
         # By default it should be using 'none' as the configured compression value.
         js = nc.jetstream()
@@ -5133,10 +5118,7 @@ class V210FeaturesTest(SingleJetStreamServerTestCase):
             subjects=["quux"],
         )
         sinfo = await js.stream_info("NONE2")
-        if version.major == 2 and version.minor > 12:
-            assert sinfo.config.compression is None
-        else:
-            assert sinfo.config.compression == nats.js.api.StoreCompression.NONE
+        assert sinfo.config.compression == nats.js.api.StoreCompression.NONE
         await nc.close()
 
     @async_test


### PR DESCRIPTION
Tests assumed servers >2.12 would omit allow_direct/max_age/mirror_direct/compression from StreamConfig. 2.14.0 ships them with concrete defaults instead, matching 2.9-2.12, so the version-gated branches were dead.