### PR TITLE
Add support for consumer reset

### DIFF
--- a/nats-jetstream/schemas/jetstream/api/v1/consumer_reset_request.json
+++ b/nats-jetstream/schemas/jetstream/api/v1/consumer_reset_request.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nats.io/schemas/jetstream/api/v1/consumer_reset_request.json",
+  "description": "A request to the JetStream $JS.API.CONSUMER.RESET API",
+  "title": "io.nats.jetstream.api.v1.consumer_reset_request",
+  "type": "object",
+  "properties": {
+    "seq": {
+      "description": "The sequence to reset the consumer to",
+      "$ref": "definitions.json#/definitions/golang_uint64"
+    }
+  }
+}

--- a/nats-jetstream/schemas/jetstream/api/v1/consumer_reset_response.json
+++ b/nats-jetstream/schemas/jetstream/api/v1/consumer_reset_response.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://nats.io/schemas/jetstream/api/v1/consumer_reset_response.json",
+  "description": "A response from the JetStream $JS.API.CONSUMER.RESET API",
+  "title": "io.nats.jetstream.api.v1.consumer_reset_response",
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "oneOf": [
+    {
+      "$ref": "definitions.json#/definitions/error_response"
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "definitions.json#/definitions/consumer_info"
+        }
+      ],
+      "required": [
+        "reset_seq"
+      ],
+      "properties": {
+        "reset_seq": {
+          "description": "The sequence that the consumer was reset to",
+          "$ref": "definitions.json#/definitions/golang_uint64"
+        }
+      }
+    }
+  ],
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "io.nats.jetstream.api.v1.consumer_reset_response"
+    }
+  }
+}

--- a/nats-jetstream/src/nats/jetstream/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/__init__.py
@@ -11,9 +11,10 @@ from typing import TYPE_CHECKING, AsyncIterator, overload
 from nats.client.message import Headers
 from nats.client.protocol.message import parse_headers
 from nats.jetstream import api
-from nats.jetstream.consumer import Consumer, ConsumerInfo, OrderedConsumerConfig
+from nats.jetstream.consumer import Consumer, ConsumerInfo, ConsumerReset, OrderedConsumerConfig
 from nats.jetstream.errors import (
     ConsumerDeletedError,
+    ConsumerInvalidResetError,
     ConsumerNotFoundError,
     ErrorCode,
     JetStreamError,
@@ -857,6 +858,7 @@ __all__ = [
     "JetStream",
     "Consumer",
     "ConsumerInfo",
+    "ConsumerReset",
     "Stream",
     "StreamConfig",
     "StreamConsumerLimits",
@@ -882,6 +884,7 @@ __all__ = [
     "ErrorCode",
     "JetStreamError",
     "ConsumerDeletedError",
+    "ConsumerInvalidResetError",
     "ConsumerNotFoundError",
     "JetStreamNotEnabledError",
     "JetStreamNotEnabledForAccountError",

--- a/nats-jetstream/src/nats/jetstream/api/client.py
+++ b/nats-jetstream/src/nats/jetstream/api/client.py
@@ -38,6 +38,8 @@ from .types import (
     ConsumerNamesResponse,
     ConsumerPauseRequest,
     ConsumerPauseResponse,
+    ConsumerResetRequest,
+    ConsumerResetResponse,
     ErrorResponse,
     StreamCreateRequest,
     StreamCreateResponse,
@@ -231,6 +233,37 @@ class Client:
                 f"{self._prefix}.CONSUMER.PAUSE.{stream_name}.{consumer_name}",
                 request if request else None,
                 response_type=ConsumerPauseResponse,
+            )
+        except JetStreamError as e:
+            if e.error_code == ErrorCode.CONSUMER_NOT_FOUND:
+                raise ConsumerNotFoundError(
+                    e.description, code=e.code, error_code=e.error_code, description=e.description
+                ) from e
+            raise
+
+    async def consumer_reset(
+        self, stream_name: str, consumer_name: str, /, **request: Unpack[ConsumerResetRequest]
+    ) -> ConsumerResetResponse:
+        """Reset a consumer's delivery state (ADR-60).
+
+        Args:
+            stream_name: The stream name
+            consumer_name: The consumer name
+            **request: Request body with optional ``seq`` field. Empty payload
+                or ``seq=0`` resumes redelivery from one above the consumer's
+                ack floor; a non-zero ``seq`` sets the ack floor to one below
+                that sequence so the next delivered message has a stream
+                sequence ``>= seq``.
+
+        Returns:
+            ConsumerResetResponse with refreshed consumer state and the
+            stream sequence the consumer was reset to.
+        """
+        try:
+            return await self.request_json(
+                f"{self._prefix}.CONSUMER.RESET.{stream_name}.{consumer_name}",
+                request if request else None,
+                response_type=ConsumerResetResponse,
             )
         except JetStreamError as e:
             if e.error_code == ErrorCode.CONSUMER_NOT_FOUND:

--- a/nats-jetstream/src/nats/jetstream/api/client.py
+++ b/nats-jetstream/src/nats/jetstream/api/client.py
@@ -16,6 +16,7 @@ from typing import (
 from nats.client.errors import NoRespondersError
 
 from ..errors import (
+    ConsumerInvalidResetError,
     ConsumerNotFoundError,
     ErrorCode,
     JetStreamError,
@@ -268,6 +269,10 @@ class Client:
         except JetStreamError as e:
             if e.error_code == ErrorCode.CONSUMER_NOT_FOUND:
                 raise ConsumerNotFoundError(
+                    e.description, code=e.code, error_code=e.error_code, description=e.description
+                ) from e
+            if e.error_code == ErrorCode.CONSUMER_INVALID_RESET:
+                raise ConsumerInvalidResetError(
                     e.description, code=e.code, error_code=e.error_code, description=e.description
                 ) from e
             raise

--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -1307,6 +1307,61 @@ class ConsumerCreateResponse(TypedDict):
     type: Literal["io.nats.jetstream.api.v1.consumer_create_response"]
 
 
+class ConsumerResetResponse(TypedDict):
+    """A response from the JetStream $JS.API.CONSUMER.RESET API"""
+
+    ack_floor: SequenceInfo
+    """The highest contiguous acknowledged message"""
+
+    cluster: NotRequired[ClusterInfo]
+
+    config: ConsumerConfig
+
+    created: str
+    """The time the Consumer was created"""
+
+    delivered: SequenceInfo
+    """The last message delivered from this Consumer"""
+
+    name: str
+    """A unique name for the consumer, either machine generated or the durable name"""
+
+    num_ack_pending: int
+    """The number of messages pending acknowledgement"""
+
+    num_pending: int
+    """The number of messages left unconsumed in this Consumer"""
+
+    num_redelivered: int
+    """The number of redeliveries that have been performed"""
+
+    num_waiting: int
+    """The number of pull consumers waiting for messages"""
+
+    pause_remaining: NotRequired[int]
+    """When paused the time remaining until unpause"""
+
+    paused: NotRequired[bool]
+    """Indicates if the consumer is currently in a paused state"""
+
+    priority_groups: NotRequired[list[PriorityGroupState]]
+    """The state of Priority Groups"""
+
+    push_bound: NotRequired[bool]
+    """Indicates if any client is connected and receiving messages from a push consumer"""
+
+    reset_seq: int
+    """The stream sequence the consumer was reset to. The next delivered message has a stream sequence >= this value."""
+
+    stream_name: str
+    """The Stream the consumer belongs to"""
+
+    ts: NotRequired[str]
+    """The server time the consumer info was created"""
+
+    type: Literal["io.nats.jetstream.api.v1.consumer_reset_response"]
+
+
 class StreamRemovePeerRequest(TypedDict):
     """A request to the JetStream $JS.API.STREAM.PEER.REMOVE API"""
 
@@ -1546,6 +1601,13 @@ class ConsumerPauseRequest(TypedDict):
 
     pause_until: NotRequired[str]
     """Time to pause until, when empty or a time in the past will unpause the consumer"""
+
+
+class ConsumerResetRequest(TypedDict):
+    """A request to the JetStream $JS.API.CONSUMER.RESET API"""
+
+    seq: NotRequired[int]
+    """The stream sequence to reset the consumer to. Empty payload or 0 resets back to the consumer's ack floor without changing it."""
 
 
 class StreamRestoreRequest(TypedDict):

--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -540,6 +540,15 @@ class Consumer(Protocol):
         """Get a message stream for continuous message consumption."""
         ...
 
+    async def reset(self, seq: int | None = None) -> int:
+        """Reset the consumer's delivery state (ADR-60).
+
+        Implementations may not support resetting in all cases (e.g. ordered
+        consumers manage their own delivery sequence and recover via
+        recreation). Such implementations should raise ``NotImplementedError``.
+        """
+        ...
+
     async def close(self) -> None:
         """Close the consumer."""
         ...

--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -394,6 +394,31 @@ class ConsumerInfo:
 
 
 @dataclass
+class ConsumerReset:
+    """Result of a consumer reset operation (ADR-60).
+
+    Carries the refreshed :class:`ConsumerInfo` together with the stream
+    sequence the server actually reset the consumer to.
+    """
+
+    info: ConsumerInfo
+    """Refreshed consumer state after the reset has been applied."""
+
+    reset_seq: int
+    """The stream sequence the next delivered message will be at or above.
+
+    For an explicit ``seq=N`` request this echoes ``N``; for an empty / zero
+    request this is one above the consumer's ack floor.
+    """
+
+    @classmethod
+    def from_response(cls, data: api.ConsumerResetResponse, *, strict: bool = False) -> ConsumerReset:
+        reset_seq = data.pop("reset_seq")
+        info = ConsumerInfo.from_response(data, strict=strict)  # type: ignore[arg-type]
+        return cls(info=info, reset_seq=reset_seq)
+
+
+@dataclass
 class OrderedConsumerConfig:
     """Configuration for an ordered JetStream consumer.
 
@@ -540,8 +565,11 @@ class Consumer(Protocol):
         """Get a message stream for continuous message consumption."""
         ...
 
-    async def reset(self, seq: int | None = None) -> int:
+    async def reset(self, seq: int | None = None) -> ConsumerReset:
         """Reset the consumer's delivery state (ADR-60).
+
+        Returns the refreshed consumer state alongside the stream sequence
+        the server reset the consumer to.
 
         Implementations may not support resetting in all cases (e.g. ordered
         consumers manage their own delivery sequence and recover via

--- a/nats-jetstream/src/nats/jetstream/consumer/ordered.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/ordered.py
@@ -100,6 +100,19 @@ class OrderedConsumer(Consumer):
             raise OrderedConsumerClosedError("Ordered consumer has no active consumer")
         return await self._current_consumer.get_info()
 
+    async def reset(self, seq: int | None = None) -> int:
+        """Not supported on ordered consumers.
+
+        Ordered consumers manage their own delivery sequence and recover
+        from gaps by recreating the underlying consumer. Per ADR-60, an
+        external ``$JS.API.CONSUMER.RESET`` should not be issued against
+        them — instead, let the existing gap-detection path recreate the
+        consumer.
+        """
+        raise NotImplementedError(
+            "reset() is not supported on ordered consumers; recovery happens via consumer recreation"
+        )
+
     async def close(self) -> None:
         """Close the ordered consumer and clean up resources.
 

--- a/nats-jetstream/src/nats/jetstream/consumer/ordered.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/ordered.py
@@ -13,6 +13,7 @@ from nats.jetstream.consumer import (
     Consumer,
     ConsumerConfig,
     ConsumerInfo,
+    ConsumerReset,
     MessageBatch,
     MessageStream,
     OrderedConsumerConfig,
@@ -100,7 +101,7 @@ class OrderedConsumer(Consumer):
             raise OrderedConsumerClosedError("Ordered consumer has no active consumer")
         return await self._current_consumer.get_info()
 
-    async def reset(self, seq: int | None = None) -> int:
+    async def reset(self, seq: int | None = None) -> ConsumerReset:
         """Not supported on ordered consumers.
 
         Ordered consumers manage their own delivery sequence and recover

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -521,6 +521,20 @@ class PullConsumer(Consumer):
         # Refresh info from server
         return self._info
 
+    async def reset(self, seq: int | None = None) -> int:
+        """Reset this consumer's delivery state (ADR-60).
+
+        See :meth:`Stream.reset_consumer` for the full semantics. ``seq=None``
+        (or ``0``) resumes redelivery from one above the consumer's ack
+        floor; a non-zero ``seq`` sets the ack floor to one below it so the
+        next delivered message has a stream sequence ``>= seq``.
+
+        Returns:
+            The stream sequence the next delivered message will be at or
+            above.
+        """
+        return await self._stream.reset_consumer(self._info.name, seq)
+
     async def close(self) -> None:
         """Close the consumer.
 

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -529,11 +529,26 @@ class PullConsumer(Consumer):
         floor; a non-zero ``seq`` sets the ack floor to one below it so the
         next delivered message has a stream sequence ``>= seq``.
 
+        Cached :attr:`info` is refreshed from the server's response.
+
         Returns:
             The stream sequence the next delivered message will be at or
             above.
         """
-        return await self._stream.reset_consumer(self._info.name, seq)
+        api = getattr(self._stream._jetstream, "_api", None)
+        if api is None:
+            raise RuntimeError("JetStream does not have an API client")
+
+        if seq is None:
+            response = await api.consumer_reset(self._stream._name, self._info.name)
+        else:
+            response = await api.consumer_reset(self._stream._name, self._info.name, seq=seq)
+
+        reset_seq = response.pop("reset_seq")
+        # Drop response-envelope discriminator before parsing into ConsumerInfo.
+        response.pop("type", None)
+        self._info = ConsumerInfo.from_response(response, strict=self._stream._jetstream.strict)
+        return reset_seq
 
     async def close(self) -> None:
         """Close the consumer.

--- a/nats-jetstream/src/nats/jetstream/consumer/pull.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/pull.py
@@ -16,6 +16,7 @@ from typing import (
 from nats.jetstream.consumer import (
     Consumer,
     ConsumerInfo,
+    ConsumerReset,
     MessageBatch,
     MessageStream,
 )
@@ -521,7 +522,7 @@ class PullConsumer(Consumer):
         # Refresh info from server
         return self._info
 
-    async def reset(self, seq: int | None = None) -> int:
+    async def reset(self, seq: int | None = None) -> ConsumerReset:
         """Reset this consumer's delivery state (ADR-60).
 
         See :meth:`Stream.reset_consumer` for the full semantics. ``seq=None``
@@ -532,23 +533,13 @@ class PullConsumer(Consumer):
         Cached :attr:`info` is refreshed from the server's response.
 
         Returns:
-            The stream sequence the next delivered message will be at or
-            above.
+            A :class:`ConsumerReset` carrying the refreshed
+            :class:`ConsumerInfo` and the stream sequence the next delivered
+            message will be at or above.
         """
-        api = getattr(self._stream._jetstream, "_api", None)
-        if api is None:
-            raise RuntimeError("JetStream does not have an API client")
-
-        if seq is None:
-            response = await api.consumer_reset(self._stream._name, self._info.name)
-        else:
-            response = await api.consumer_reset(self._stream._name, self._info.name, seq=seq)
-
-        reset_seq = response.pop("reset_seq")
-        # Drop response-envelope discriminator before parsing into ConsumerInfo.
-        response.pop("type", None)
-        self._info = ConsumerInfo.from_response(response, strict=self._stream._jetstream.strict)
-        return reset_seq
+        result = await self._stream.reset_consumer(self._info.name, seq)
+        self._info = result.info
+        return result
 
     async def close(self) -> None:
         """Close the consumer.

--- a/nats-jetstream/src/nats/jetstream/errors.py
+++ b/nats-jetstream/src/nats/jetstream/errors.py
@@ -14,6 +14,7 @@ class ErrorCode:
     STREAM_NAME_IN_USE = 10058
     STREAM_NOT_FOUND = 10059
     JETSTREAM_NOT_ENABLED = 10076
+    CONSUMER_INVALID_RESET = 10204
 
 
 class JetStreamError(Exception):
@@ -93,5 +94,16 @@ class OrderedConsumerClosedError(JetStreamError):
 
 class OrderedConsumerResetError(JetStreamError):
     """Raised when max reset attempts exceeded during ordered consumer recovery."""
+
+    pass
+
+
+class ConsumerInvalidResetError(JetStreamError):
+    """Consumer reset is invalid (error code 10204).
+
+    Raised when a reset request violates the consumer's ``DeliverPolicy``
+    constraints — e.g. a non-zero ``seq`` below ``opt_start_seq`` on a
+    ``by_start_sequence`` consumer.
+    """
 
     pass

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -1516,6 +1516,45 @@ class Stream:
         # RFC3339 format: "1970-01-01T00:00:00Z"
         await api.consumer_pause(self._name, consumer_name)
 
+    async def reset_consumer(self, consumer_name: str, seq: int | None = None) -> int:
+        """Reset a consumer's delivery state (ADR-60).
+
+        Pending and redelivered counts are cleared and the consumer's
+        delivery sequence restarts at 1. If ``seq`` is provided and
+        non-zero, the ack floor stream sequence is set to one below it so
+        the next delivered message has a stream sequence ``>= seq``;
+        otherwise the ack floor stream sequence is left where it was and
+        redelivery resumes from one above it.
+
+        Resetting to a specific sequence is only allowed on consumers with
+        ``DeliverPolicy`` of ``all``, ``by_start_sequence``, or
+        ``by_start_time``; for the bounded policies the server rejects
+        resets below the configured starting sequence/time.
+
+        Args:
+            consumer_name: Name of the consumer to reset.
+            seq: Optional stream sequence the consumer should be reset to.
+
+        Returns:
+            The stream sequence the next delivered message will be at or
+            above. For ``seq=N`` this is ``N``; for ``None``/``0`` this is
+            one above the consumer's ack floor.
+
+        Raises:
+            ConsumerNotFoundError: If the consumer does not exist.
+            JetStreamError: For other JetStream API errors (e.g. reset
+                below ``opt_start_seq``).
+        """
+        api = getattr(self._jetstream, "_api", None)
+        if api is None:
+            raise RuntimeError("JetStream does not have an API client")
+
+        if seq is None:
+            response = await api.consumer_reset(self._name, consumer_name)
+        else:
+            response = await api.consumer_reset(self._name, consumer_name, seq=seq)
+        return response["reset_seq"]
+
     @overload
     async def ordered_consumer(self, config: OrderedConsumerConfig, /) -> Consumer:
         """Create an ordered consumer from an OrderedConsumerConfig object."""

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -19,7 +19,7 @@ from typing import (
 from nats.client.errors import StatusError
 from nats.client.message import Headers
 
-from .consumer import Consumer, ConsumerConfig, ConsumerInfo, OrderedConsumerConfig
+from .consumer import Consumer, ConsumerConfig, ConsumerInfo, ConsumerReset, OrderedConsumerConfig
 from .consumer.ordered import OrderedConsumer
 from .consumer.pull import PullConsumer
 from .errors import MessageNotFoundError
@@ -1516,7 +1516,7 @@ class Stream:
         # RFC3339 format: "1970-01-01T00:00:00Z"
         await api.consumer_pause(self._name, consumer_name)
 
-    async def reset_consumer(self, consumer_name: str, seq: int | None = None) -> int:
+    async def reset_consumer(self, consumer_name: str, seq: int | None = None) -> ConsumerReset:
         """Reset a consumer's delivery state (ADR-60).
 
         Pending and redelivered counts are cleared and the consumer's
@@ -1538,14 +1538,15 @@ class Stream:
                 above the consumer's ack floor.
 
         Returns:
-            The stream sequence the next delivered message will be at or
-            above. For ``seq=N`` (with ``N > 0``) this is ``N``; for
-            ``None``/``0`` this is one above the consumer's ack floor.
+            A :class:`ConsumerReset` carrying the refreshed
+            :class:`ConsumerInfo` and the stream sequence the next delivered
+            message will be at or above.
 
         Raises:
             ConsumerNotFoundError: If the consumer does not exist.
-            JetStreamError: For other JetStream API errors (e.g. reset
-                below ``opt_start_seq``).
+            ConsumerInvalidResetError: If the requested reset violates the
+                consumer's ``DeliverPolicy`` (e.g. ``seq`` below
+                ``opt_start_seq`` on a bounded policy).
         """
         api = getattr(self._jetstream, "_api", None)
         if api is None:
@@ -1555,7 +1556,7 @@ class Stream:
             response = await api.consumer_reset(self._name, consumer_name)
         else:
             response = await api.consumer_reset(self._name, consumer_name, seq=seq)
-        return response["reset_seq"]
+        return ConsumerReset.from_response(response, strict=self._jetstream.strict)
 
     @overload
     async def ordered_consumer(self, config: OrderedConsumerConfig, /) -> Consumer:

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -1534,11 +1534,13 @@ class Stream:
         Args:
             consumer_name: Name of the consumer to reset.
             seq: Optional stream sequence the consumer should be reset to.
+                ``None`` and ``0`` are equivalent: both resume from one
+                above the consumer's ack floor.
 
         Returns:
             The stream sequence the next delivered message will be at or
-            above. For ``seq=N`` this is ``N``; for ``None``/``0`` this is
-            one above the consumer's ack floor.
+            above. For ``seq=N`` (with ``N > 0``) this is ``N``; for
+            ``None``/``0`` this is one above the consumer's ack floor.
 
         Raises:
             ConsumerNotFoundError: If the consumer does not exist.

--- a/nats-jetstream/tests/test_consumer.py
+++ b/nats-jetstream/tests/test_consumer.py
@@ -1082,3 +1082,90 @@ async def test_consumer_info_timestamp(jetstream: JetStream):
     info = await stream.get_consumer_info("ts_consumer")
     assert isinstance(info.timestamp, datetime)
     assert info.timestamp.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_consumer_reset_to_seq(jetstream: JetStream):
+    """Reset a consumer forward to a specific stream sequence (ADR-60)."""
+    stream = await jetstream.create_stream(name="test_reset_seq", subjects=["RSEQ.*"])
+    for i in range(5):
+        await jetstream.publish(f"RSEQ.{i}", f"msg {i}".encode())
+
+    consumer = await stream.create_consumer(
+        name="reset_seq",
+        durable_name="reset_seq",
+        ack_policy="explicit",
+    )
+
+    reset_seq = await consumer.reset(seq=3)
+    assert reset_seq == 3
+
+    msg = await consumer.next(max_wait=1.0)
+    assert msg.metadata.sequence.stream == 3
+    assert msg.data == b"msg 2"
+
+
+@pytest.mark.asyncio
+async def test_consumer_reset_to_ack_floor(jetstream: JetStream):
+    """Reset with no payload resumes from one above the ack floor (ADR-60)."""
+    stream = await jetstream.create_stream(name="test_reset_floor", subjects=["RFLOOR.*"])
+    for i in range(5):
+        await jetstream.publish(f"RFLOOR.{i}", f"msg {i}".encode())
+
+    consumer = await stream.create_consumer(
+        name="reset_floor",
+        durable_name="reset_floor",
+        ack_policy="explicit",
+    )
+
+    # Consume and ack the first two messages so the ack floor advances.
+    batch = await consumer.fetch(max_messages=2, max_wait=1.0)
+    async for msg in batch:
+        await msg.ack()
+
+    info = await stream.get_consumer_info("reset_floor")
+    floor = info.ack_floor["stream_seq"]
+
+    reset_seq = await consumer.reset()
+    assert reset_seq == floor + 1
+
+    msg = await consumer.next(max_wait=1.0)
+    assert msg.metadata.sequence.stream >= reset_seq
+
+
+@pytest.mark.asyncio
+async def test_stream_reset_consumer(jetstream: JetStream):
+    """Stream.reset_consumer is the lower-level form of Consumer.reset."""
+    stream = await jetstream.create_stream(name="test_reset_stream", subjects=["RSTRM.*"])
+    for i in range(5):
+        await jetstream.publish(f"RSTRM.{i}", f"msg {i}".encode())
+
+    await stream.create_consumer(
+        name="reset_stream",
+        durable_name="reset_stream",
+        ack_policy="explicit",
+    )
+
+    reset_seq = await stream.reset_consumer("reset_stream", seq=2)
+    assert reset_seq == 2
+
+
+@pytest.mark.asyncio
+async def test_consumer_reset_below_start_seq_rejected(jetstream: JetStream):
+    """Reset below opt_start_seq is rejected by the server."""
+    from nats.jetstream import JetStreamError
+
+    stream = await jetstream.create_stream(name="test_reset_pinned", subjects=["RPIN.*"])
+    for i in range(5):
+        await jetstream.publish(f"RPIN.{i}", f"msg {i}".encode())
+
+    await stream.create_consumer(
+        name="pinned",
+        durable_name="pinned",
+        ack_policy="explicit",
+        deliver_policy="by_start_sequence",
+        opt_start_seq=3,
+    )
+
+    with pytest.raises(JetStreamError):
+        await stream.reset_consumer("pinned", seq=1)

--- a/nats-jetstream/tests/test_consumer.py
+++ b/nats-jetstream/tests/test_consumer.py
@@ -1100,8 +1100,10 @@ async def test_consumer_reset_to_seq(jetstream: JetStream):
         ack_policy="explicit",
     )
 
-    reset_seq = await consumer.reset(seq=3)
-    assert reset_seq == 3
+    result = await consumer.reset(seq=3)
+    assert result.reset_seq == 3
+    assert result.info.name == "reset_seq"
+    assert result.info.num_ack_pending == 0
 
     msg = await consumer.next(max_wait=1.0)
     assert msg.metadata.sequence.stream == 3
@@ -1132,11 +1134,13 @@ async def test_consumer_reset_to_ack_floor(jetstream: JetStream):
     info = await stream.get_consumer_info("reset_floor")
     floor = info.ack_floor["stream_seq"]
 
-    reset_seq = await consumer.reset()
-    assert reset_seq == floor + 1
+    result = await consumer.reset()
+    assert result.reset_seq == floor + 1
+    # Cached info on the consumer is refreshed from the response.
+    assert consumer.info is result.info
 
     msg = await consumer.next(max_wait=1.0)
-    assert msg.metadata.sequence.stream == reset_seq
+    assert msg.metadata.sequence.stream == result.reset_seq
 
 
 @pytest.mark.asyncio
@@ -1155,8 +1159,9 @@ async def test_stream_reset_consumer(jetstream: JetStream):
         ack_policy="explicit",
     )
 
-    reset_seq = await stream.reset_consumer("reset_stream", seq=2)
-    assert reset_seq == 2
+    result = await stream.reset_consumer("reset_stream", seq=2)
+    assert result.reset_seq == 2
+    assert result.info.name == "reset_stream"
 
     msg = await consumer.next(max_wait=1.0)
     assert msg.metadata.sequence.stream == 2
@@ -1164,11 +1169,11 @@ async def test_stream_reset_consumer(jetstream: JetStream):
 
 @pytest.mark.asyncio
 async def test_consumer_reset_below_start_seq_rejected(jetstream: JetStream):
-    """Reset below opt_start_seq is rejected by the server.
+    """Reset below opt_start_seq raises ConsumerInvalidResetError (10204).
 
     Requires NATS server 2.14+.
     """
-    from nats.jetstream import JetStreamError
+    from nats.jetstream import ConsumerInvalidResetError
 
     stream = await jetstream.create_stream(name="test_reset_pinned", subjects=["RPIN.*"])
     for i in range(5):
@@ -1182,5 +1187,5 @@ async def test_consumer_reset_below_start_seq_rejected(jetstream: JetStream):
         opt_start_seq=3,
     )
 
-    with pytest.raises(JetStreamError):
+    with pytest.raises(ConsumerInvalidResetError):
         await stream.reset_consumer("pinned", seq=1)

--- a/nats-jetstream/tests/test_consumer.py
+++ b/nats-jetstream/tests/test_consumer.py
@@ -1086,7 +1086,10 @@ async def test_consumer_info_timestamp(jetstream: JetStream):
 
 @pytest.mark.asyncio
 async def test_consumer_reset_to_seq(jetstream: JetStream):
-    """Reset a consumer forward to a specific stream sequence (ADR-60)."""
+    """Reset a consumer forward to a specific stream sequence (ADR-60).
+
+    Requires NATS server 2.14+.
+    """
     stream = await jetstream.create_stream(name="test_reset_seq", subjects=["RSEQ.*"])
     for i in range(5):
         await jetstream.publish(f"RSEQ.{i}", f"msg {i}".encode())
@@ -1107,7 +1110,10 @@ async def test_consumer_reset_to_seq(jetstream: JetStream):
 
 @pytest.mark.asyncio
 async def test_consumer_reset_to_ack_floor(jetstream: JetStream):
-    """Reset with no payload resumes from one above the ack floor (ADR-60)."""
+    """Reset with no payload resumes from one above the ack floor (ADR-60).
+
+    Requires NATS server 2.14+.
+    """
     stream = await jetstream.create_stream(name="test_reset_floor", subjects=["RFLOOR.*"])
     for i in range(5):
         await jetstream.publish(f"RFLOOR.{i}", f"msg {i}".encode())
@@ -1130,17 +1136,20 @@ async def test_consumer_reset_to_ack_floor(jetstream: JetStream):
     assert reset_seq == floor + 1
 
     msg = await consumer.next(max_wait=1.0)
-    assert msg.metadata.sequence.stream >= reset_seq
+    assert msg.metadata.sequence.stream == reset_seq
 
 
 @pytest.mark.asyncio
 async def test_stream_reset_consumer(jetstream: JetStream):
-    """Stream.reset_consumer is the lower-level form of Consumer.reset."""
+    """Stream.reset_consumer is the lower-level form of Consumer.reset.
+
+    Requires NATS server 2.14+.
+    """
     stream = await jetstream.create_stream(name="test_reset_stream", subjects=["RSTRM.*"])
     for i in range(5):
         await jetstream.publish(f"RSTRM.{i}", f"msg {i}".encode())
 
-    await stream.create_consumer(
+    consumer = await stream.create_consumer(
         name="reset_stream",
         durable_name="reset_stream",
         ack_policy="explicit",
@@ -1149,10 +1158,16 @@ async def test_stream_reset_consumer(jetstream: JetStream):
     reset_seq = await stream.reset_consumer("reset_stream", seq=2)
     assert reset_seq == 2
 
+    msg = await consumer.next(max_wait=1.0)
+    assert msg.metadata.sequence.stream == 2
+
 
 @pytest.mark.asyncio
 async def test_consumer_reset_below_start_seq_rejected(jetstream: JetStream):
-    """Reset below opt_start_seq is rejected by the server."""
+    """Reset below opt_start_seq is rejected by the server.
+
+    Requires NATS server 2.14+.
+    """
     from nats.jetstream import JetStreamError
 
     stream = await jetstream.create_stream(name="test_reset_pinned", subjects=["RPIN.*"])


### PR DESCRIPTION
Implements ADR-60's `$JS.API.CONSUMER.RESET` endpoint added in nats-server 2.14: `Stream.reset_consumer(name, seq=None)` and `Consumer.reset(seq=None)`. Empty/0 resumes redelivery from one above the ack floor; a non-zero `seq` sets the ack floor below it so the next delivered message has a stream sequence `>= seq`.

Ordered-consumer behavior is unchanged: an external reset surfaces as a delivery-sequence gap, which the existing recovery path already handles by recreating the consumer (per ADR-60 §Consequences).