### PR TITLE
Add atomic batch publish wire support

### DIFF
--- a/nats-jetstream/src/nats/jetstream/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/__init__.py
@@ -208,6 +208,10 @@ class PublishAck:
     sequence: int | None = None
     domain: str | None = None
     duplicate: bool = False
+    batch_id: str | None = None
+    """Set on the final ack of an atomic batch publish (ADR-50): id of the committed batch."""
+    batch_size: int | None = None
+    """Set on the final ack of an atomic batch publish (ADR-50): number of messages persisted in the committed batch."""
 
     @classmethod
     def from_response(cls, data: api.PublishAck, *, strict: bool = False) -> PublishAck:
@@ -215,6 +219,8 @@ class PublishAck:
         sequence = data.pop("seq", None)
         domain = data.pop("domain", None)
         duplicate = data.pop("duplicate", False)
+        batch_id = data.pop("batch", None)
+        batch_size = data.pop("count", None)
 
         # Check for unconsumed fields
         if strict and data:
@@ -225,6 +231,8 @@ class PublishAck:
             sequence=sequence,
             domain=domain,
             duplicate=duplicate,
+            batch_id=batch_id,
+            batch_size=batch_size,
         )
 
 

--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -600,6 +600,12 @@ class StreamState(TypedDict):
 
 
 class StreamConfig(TypedDict):
+    allow_atomic: NotRequired[bool]
+    """Allow atomic batched publishes (ADR-50)"""
+
+    allow_batched: NotRequired[bool]
+    """Allows fast batch publishing into the Stream (ADR-50)"""
+
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
 
@@ -820,6 +826,12 @@ class ConsumerGetnextRequest(TypedDict):
 class StreamCreateRequest(TypedDict):
     """A request to the JetStream $JS.API.STREAM.CREATE API"""
 
+    allow_atomic: NotRequired[bool]
+    """Allow atomic batched publishes (ADR-50)"""
+
+    allow_batched: NotRequired[bool]
+    """Allows fast batch publishing into the Stream (ADR-50)"""
+
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
 
@@ -1018,6 +1030,12 @@ class StreamPurgeRequest(TypedDict):
 
 class StreamUpdateRequest(TypedDict):
     """A request to the JetStream $JS.API.STREAM.UPDATE API"""
+
+    allow_atomic: NotRequired[bool]
+    """Allow atomic batched publishes (ADR-50)"""
+
+    allow_batched: NotRequired[bool]
+    """Allows fast batch publishing into the Stream (ADR-50)"""
 
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
@@ -1442,6 +1460,12 @@ class AccountInfoResponse(TypedDict):
 
 class PublishAck(TypedDict):
     """A response received when publishing a message"""
+
+    batch: NotRequired[str]
+    """When doing Atomic Batch Publishes this will be the Batch ID being committed"""
+
+    count: NotRequired[int]
+    """When doing Atomic Batch Publishes how many messages was in the batch"""
 
     domain: NotRequired[str]
     """If the Stream accepting the message is in a JetStream server configured for a domain this would be that domain"""

--- a/nats-jetstream/src/nats/jetstream/headers.py
+++ b/nats-jetstream/src/nats/jetstream/headers.py
@@ -2,26 +2,37 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 # Atomic Batch Publishing (ADR-50)
-NATS_BATCH_ID = "Nats-Batch-Id"
+NATS_BATCH_ID: Final[str] = "Nats-Batch-Id"
 """Atomic batch publish: batch id (max 64 chars)."""
 
-NATS_BATCH_SEQUENCE = "Nats-Batch-Sequence"
+NATS_BATCH_SEQUENCE: Final[str] = "Nats-Batch-Sequence"
 """Atomic batch publish: per-message sequence within the batch."""
 
-NATS_BATCH_COMMIT = "Nats-Batch-Commit"
+NATS_BATCH_COMMIT: Final[str] = "Nats-Batch-Commit"
 """Atomic batch publish: commit marker. ``"1"`` to commit and store the
 final message; ``"eob"`` to commit without storing it (end-of-batch)."""
 
-NATS_BATCH_COMMIT_FINAL = "1"
+NATS_BATCH_COMMIT_FINAL: Final[str] = "1"
 """Value for :data:`NATS_BATCH_COMMIT`: commit and store the final message."""
 
-NATS_BATCH_COMMIT_EOB = "eob"
+NATS_BATCH_COMMIT_EOB: Final[str] = "eob"
 """Value for :data:`NATS_BATCH_COMMIT`: commit without storing the final
 message (end-of-batch). Server is case-sensitive on this string."""
 
 # API-level guards
-NATS_REQUIRED_API_LEVEL = "Nats-Required-Api-Level"
+NATS_REQUIRED_API_LEVEL: Final[str] = "Nats-Required-Api-Level"
 """Minimum JetStream API level the publishing client requires; the server
 rejects the message (and the enclosing batch, if any) when its own level is
 below the value set here."""
+
+__all__ = [
+    "NATS_BATCH_ID",
+    "NATS_BATCH_SEQUENCE",
+    "NATS_BATCH_COMMIT",
+    "NATS_BATCH_COMMIT_FINAL",
+    "NATS_BATCH_COMMIT_EOB",
+    "NATS_REQUIRED_API_LEVEL",
+]

--- a/nats-jetstream/src/nats/jetstream/headers.py
+++ b/nats-jetstream/src/nats/jetstream/headers.py
@@ -1,0 +1,27 @@
+"""JetStream protocol header names and value constants."""
+
+from __future__ import annotations
+
+# Atomic Batch Publishing (ADR-50)
+NATS_BATCH_ID = "Nats-Batch-Id"
+"""Atomic batch publish: batch id (max 64 chars)."""
+
+NATS_BATCH_SEQUENCE = "Nats-Batch-Sequence"
+"""Atomic batch publish: per-message sequence within the batch."""
+
+NATS_BATCH_COMMIT = "Nats-Batch-Commit"
+"""Atomic batch publish: commit marker. ``"1"`` to commit and store the
+final message; ``"eob"`` to commit without storing it (end-of-batch)."""
+
+NATS_BATCH_COMMIT_FINAL = "1"
+"""Value for :data:`NATS_BATCH_COMMIT`: commit and store the final message."""
+
+NATS_BATCH_COMMIT_EOB = "eob"
+"""Value for :data:`NATS_BATCH_COMMIT`: commit without storing the final
+message (end-of-batch). Server is case-sensitive on this string."""
+
+# API-level guards
+NATS_REQUIRED_API_LEVEL = "Nats-Required-Api-Level"
+"""Minimum JetStream API level the publishing client requires; the server
+rejects the message (and the enclosing batch, if any) when its own level is
+below the value set here."""

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -538,6 +538,12 @@ class StreamConfig:
     max_msgs: int | None = None
     """How many messages may be in a Stream, oldest messages will be removed if the Stream exceeds this size. None for unlimited."""
 
+    allow_atomic: bool | None = None
+    """Allow atomic batched publishes (ADR-50). Requires nats-server 2.14+."""
+
+    allow_batched: bool | None = None
+    """Allows fast batch publishing into the Stream (ADR-50). Requires nats-server 2.14+."""
+
     allow_direct: bool | None = None
     """Allow higher performance, direct access to get individual messages."""
 
@@ -682,6 +688,8 @@ class StreamConfig:
         retention = config.pop("retention", "limits")
         storage = config.pop("storage", "file")
 
+        allow_atomic = config.pop("allow_atomic", None)
+        allow_batched = config.pop("allow_batched", None)
         allow_direct = config.pop("allow_direct", None)
         allow_msg_ttl = config.pop("allow_msg_ttl", None)
         allow_rollup_hdrs = config.pop("allow_rollup_hdrs", None)
@@ -761,6 +769,8 @@ class StreamConfig:
             num_replicas=num_replicas,
             retention=retention,
             storage=storage,
+            allow_atomic=allow_atomic,
+            allow_batched=allow_batched,
             allow_direct=allow_direct,
             allow_msg_ttl=allow_msg_ttl,
             allow_rollup_hdrs=allow_rollup_hdrs,
@@ -804,6 +814,10 @@ class StreamConfig:
         }
 
         # Add optional fields only if not None
+        if self.allow_atomic is not None:
+            result["allow_atomic"] = self.allow_atomic
+        if self.allow_batched is not None:
+            result["allow_batched"] = self.allow_batched
         if self.allow_direct is not None:
             result["allow_direct"] = self.allow_direct
         if self.allow_msg_ttl is not None:

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -686,3 +686,76 @@ async def test_stream_state_timestamps(jetstream: JetStream):
     assert info.state.first_ts.tzinfo is not None
     assert isinstance(info.state.last_ts, datetime)
     assert info.state.last_ts.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_stream_allow_batch_publish_round_trip(jetstream: JetStream):
+    """Round-trip allow_atomic / allow_batched flags through stream create/info (ADR-50).
+
+    Requires nats-server 2.14+.
+    """
+    stream = await jetstream.create_stream(
+        name="BATCH",
+        subjects=["batch.>"],
+        allow_atomic=True,
+        allow_batched=True,
+    )
+
+    info = await stream.get_info()
+    assert info.config.allow_atomic is True
+    assert info.config.allow_batched is True
+
+
+@pytest.mark.asyncio
+async def test_atomic_batch_publish(jetstream: JetStream):
+    """Atomic batch publish (ADR-50) returns batch_id/batch_size on the commit ack.
+
+    Requires nats-server 2.14+.
+    """
+    from nats.jetstream.headers import (
+        NATS_BATCH_COMMIT,
+        NATS_BATCH_COMMIT_FINAL,
+        NATS_BATCH_ID,
+        NATS_BATCH_SEQUENCE,
+    )
+
+    stream = await jetstream.create_stream(
+        name="BATCH_PUB",
+        subjects=["bp.>"],
+        allow_atomic=True,
+    )
+
+    batch_id = "batch-1"
+
+    # Pre-commit messages are fire-and-forget: the server stores them but
+    # holds the ack until the commit message arrives. Use the underlying
+    # NATS publish (no request/reply) for these.
+    await jetstream._client.publish(
+        "bp.a",
+        b"one",
+        headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "1"},
+    )
+    await jetstream._client.publish(
+        "bp.b",
+        b"two",
+        headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "2"},
+    )
+
+    # The commit message gets a regular ack populated with batch/count.
+    ack = await jetstream.publish(
+        "bp.c",
+        b"three",
+        headers={
+            NATS_BATCH_ID: batch_id,
+            NATS_BATCH_SEQUENCE: "3",
+            NATS_BATCH_COMMIT: NATS_BATCH_COMMIT_FINAL,
+        },
+        timeout=2.0,
+    )
+
+    assert ack.batch_id == batch_id
+    assert ack.batch_size == 3
+
+    # All three messages should be persisted on the stream.
+    info = await stream.get_info()
+    assert info.state.messages == 3

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -4,6 +4,13 @@ import asyncio
 
 import pytest
 from nats.jetstream import JetStream, MessageNotFoundError, StreamInfo, StreamMessage
+from nats.jetstream.headers import (
+    NATS_BATCH_COMMIT,
+    NATS_BATCH_COMMIT_EOB,
+    NATS_BATCH_COMMIT_FINAL,
+    NATS_BATCH_ID,
+    NATS_BATCH_SEQUENCE,
+)
 
 
 async def collect_async_iter(async_iter):
@@ -712,13 +719,6 @@ async def test_atomic_batch_publish(jetstream: JetStream):
 
     Requires nats-server 2.14+.
     """
-    from nats.jetstream.headers import (
-        NATS_BATCH_COMMIT,
-        NATS_BATCH_COMMIT_FINAL,
-        NATS_BATCH_ID,
-        NATS_BATCH_SEQUENCE,
-    )
-
     stream = await jetstream.create_stream(
         name="BATCH_PUB",
         subjects=["bp.>"],
@@ -727,15 +727,18 @@ async def test_atomic_batch_publish(jetstream: JetStream):
 
     batch_id = "batch-1"
 
-    # Pre-commit messages are fire-and-forget: the server stores them but
-    # holds the ack until the commit message arrives. Use the underlying
-    # NATS publish (no request/reply) for these.
-    await jetstream._client.publish(
+    # ADR-50: the first batch message is sent as a request so the client can
+    # detect feature support; the server replies with an empty body on success
+    # (or an error). Subsequent pre-commit messages are fire-and-forget.
+    handshake = await jetstream.client.request(
         "bp.a",
         b"one",
         headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "1"},
+        timeout=2.0,
     )
-    await jetstream._client.publish(
+    assert handshake.data == b""
+
+    await jetstream.client.publish(
         "bp.b",
         b"two",
         headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "2"},
@@ -759,3 +762,51 @@ async def test_atomic_batch_publish(jetstream: JetStream):
     # All three messages should be persisted on the stream.
     info = await stream.get_info()
     assert info.state.messages == 3
+
+
+@pytest.mark.asyncio
+async def test_atomic_batch_publish_eob_commit(jetstream: JetStream):
+    """``Nats-Batch-Commit: eob`` commits without storing the final message (ADR-50).
+
+    Requires nats-server 2.14+.
+    """
+    stream = await jetstream.create_stream(
+        name="BATCH_EOB",
+        subjects=["eb.>"],
+        allow_atomic=True,
+    )
+
+    batch_id = "batch-eob"
+
+    handshake = await jetstream.client.request(
+        "eb.a",
+        b"one",
+        headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "1"},
+        timeout=2.0,
+    )
+    assert handshake.data == b""
+
+    await jetstream.client.publish(
+        "eb.b",
+        b"two",
+        headers={NATS_BATCH_ID: batch_id, NATS_BATCH_SEQUENCE: "2"},
+    )
+
+    # The EOB commit message itself is not persisted, only used to commit
+    # the preceding messages in the batch.
+    ack = await jetstream.publish(
+        "eb.commit",
+        b"",
+        headers={
+            NATS_BATCH_ID: batch_id,
+            NATS_BATCH_SEQUENCE: "3",
+            NATS_BATCH_COMMIT: NATS_BATCH_COMMIT_EOB,
+        },
+        timeout=2.0,
+    )
+
+    assert ack.batch_id == batch_id
+    assert ack.batch_size == 2
+
+    info = await stream.get_info()
+    assert info.state.messages == 2


### PR DESCRIPTION
Implements ADR-50's atomic batch publish wire surface for nats-server 2.14:

- `StreamConfig.allow_atomic` and `allow_batched` (and the equivalents on `StreamCreateRequest` / `StreamUpdateRequest`).
- `PublishAck.batch_id` / `batch_size`, populated on the commit ack of an atomic batch.
- `nats/jetstream/headers.py` exposes `Nats-Batch-Id`, `-Sequence`, `-Commit` plus value constants `"1"` / `"eob"`, and `Nats-Required-Api-Level`.

End-to-end test: stream with `allow_atomic=True`, publish three messages with `Nats-Batch-Id` (the first two via raw `client.publish`, the third via `jetstream.publish` with `Nats-Batch-Commit: 1`), then assert the commit ack carries the batch id and a batch size of 3 and the stream ends up with three persisted messages.

No high-level batch publish API in this PR — only the wire-level building blocks (matches the Rust client's PR 1581 scope). A future PR can wrap these in an ergonomic batch publisher.