### PR TITLE
Add counter stream wire support

### DIFF
--- a/nats-jetstream/src/nats/jetstream/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/__init__.py
@@ -208,6 +208,8 @@ class PublishAck:
     sequence: int | None = None
     domain: str | None = None
     duplicate: bool = False
+    value: str | None = None
+    """Current value of the counter on counter-enabled streams (ADR for counter streams)."""
 
     @classmethod
     def from_response(cls, data: api.PublishAck, *, strict: bool = False) -> PublishAck:
@@ -215,6 +217,7 @@ class PublishAck:
         sequence = data.pop("seq", None)
         domain = data.pop("domain", None)
         duplicate = data.pop("duplicate", False)
+        value = data.pop("val", None)
 
         # Check for unconsumed fields
         if strict and data:
@@ -225,6 +228,7 @@ class PublishAck:
             sequence=sequence,
             domain=domain,
             duplicate=duplicate,
+            value=value,
         )
 
 

--- a/nats-jetstream/src/nats/jetstream/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/__init__.py
@@ -211,7 +211,7 @@ class PublishAck:
     domain: str | None = None
     duplicate: bool = False
     value: str | None = None
-    """Current value of the counter on counter-enabled streams (ADR for counter streams)."""
+    """Current value of the counter on counter-enabled streams (ADR-49). String to preserve precision beyond uint64."""
     batch_id: str | None = None
     """Set on the final ack of an atomic batch publish (ADR-50): id of the committed batch."""
     batch_size: int | None = None

--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -603,6 +603,9 @@ class StreamConfig(TypedDict):
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
 
+    allow_msg_counter: NotRequired[bool]
+    """Configures the stream as a counter and rejects all other messages"""
+
     allow_msg_ttl: NotRequired[bool]
     """Enables per-message TTL using headers"""
 
@@ -823,6 +826,9 @@ class StreamCreateRequest(TypedDict):
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
 
+    allow_msg_counter: NotRequired[bool]
+    """Configures the stream as a counter and rejects all other messages"""
+
     allow_msg_ttl: NotRequired[bool]
     """Enables per-message TTL using headers"""
 
@@ -1021,6 +1027,9 @@ class StreamUpdateRequest(TypedDict):
 
     allow_direct: NotRequired[bool]
     """Allow higher performance, direct access to get individual messages"""
+
+    allow_msg_counter: NotRequired[bool]
+    """Configures the stream as a counter and rejects all other messages"""
 
     allow_msg_ttl: NotRequired[bool]
     """Enables per-message TTL using headers"""
@@ -1456,6 +1465,9 @@ class PublishAck(TypedDict):
 
     stream: str
     """The name of the stream that received the message"""
+
+    val: NotRequired[str]
+    """The current value of the counter on counter-enabled streams"""
 
 
 class AccountPurgeResponse(TypedDict):

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -592,7 +592,7 @@ class StreamConfig:
     """Allow higher performance, direct access to get individual messages."""
 
     allow_msg_counter: bool | None = None
-    """Configures the stream as a counter and rejects all other messages. Requires nats-server 2.14+."""
+    """Configures the stream as a counter and rejects all other messages (ADR-49). Requires nats-server 2.12+."""
 
     allow_msg_schedules: bool | None = None
     """Allows the scheduling of messages (ADR-51). Requires nats-server 2.14+."""

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -541,6 +541,9 @@ class StreamConfig:
     allow_direct: bool | None = None
     """Allow higher performance, direct access to get individual messages."""
 
+    allow_msg_counter: bool | None = None
+    """Configures the stream as a counter and rejects all other messages. Requires nats-server 2.14+."""
+
     allow_msg_ttl: bool | None = None
     """Enables per-message TTL using headers."""
 
@@ -683,6 +686,7 @@ class StreamConfig:
         storage = config.pop("storage", "file")
 
         allow_direct = config.pop("allow_direct", None)
+        allow_msg_counter = config.pop("allow_msg_counter", None)
         allow_msg_ttl = config.pop("allow_msg_ttl", None)
         allow_rollup_hdrs = config.pop("allow_rollup_hdrs", None)
         compression = config.pop("compression", None)
@@ -762,6 +766,7 @@ class StreamConfig:
             retention=retention,
             storage=storage,
             allow_direct=allow_direct,
+            allow_msg_counter=allow_msg_counter,
             allow_msg_ttl=allow_msg_ttl,
             allow_rollup_hdrs=allow_rollup_hdrs,
             compression=compression,
@@ -806,6 +811,8 @@ class StreamConfig:
         # Add optional fields only if not None
         if self.allow_direct is not None:
             result["allow_direct"] = self.allow_direct
+        if self.allow_msg_counter is not None:
+            result["allow_msg_counter"] = self.allow_msg_counter
         if self.allow_msg_ttl is not None:
             result["allow_msg_ttl"] = self.allow_msg_ttl
         if self.allow_rollup_hdrs is not None:

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -708,9 +708,9 @@ async def test_stream_state_timestamps(jetstream: JetStream):
 
 @pytest.mark.asyncio
 async def test_stream_allow_msg_counter_round_trip(jetstream: JetStream):
-    """Round-trip allow_msg_counter through stream create/info.
+    """Round-trip allow_msg_counter through stream create/info (ADR-49).
 
-    Requires nats-server 2.14+.
+    Requires nats-server 2.12+.
     """
     stream = await jetstream.create_stream(
         name="COUNTER_RT",
@@ -724,9 +724,9 @@ async def test_stream_allow_msg_counter_round_trip(jetstream: JetStream):
 
 @pytest.mark.asyncio
 async def test_publish_to_counter_stream(jetstream: JetStream):
-    """Counter-enabled stream surfaces the running value on the publish ack.
+    """Counter-enabled stream surfaces the running value on the publish ack (ADR-49).
 
-    Requires nats-server 2.14+.
+    Requires nats-server 2.12+.
     """
     await jetstream.create_stream(
         name="COUNTER",

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -686,3 +686,41 @@ async def test_stream_state_timestamps(jetstream: JetStream):
     assert info.state.first_ts.tzinfo is not None
     assert isinstance(info.state.last_ts, datetime)
     assert info.state.last_ts.tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_stream_allow_msg_counter_round_trip(jetstream: JetStream):
+    """Round-trip allow_msg_counter through stream create/info.
+
+    Requires nats-server 2.14+.
+    """
+    stream = await jetstream.create_stream(
+        name="COUNTER_RT",
+        subjects=["counter.>"],
+        allow_msg_counter=True,
+    )
+
+    info = await stream.get_info()
+    assert info.config.allow_msg_counter is True
+
+
+@pytest.mark.asyncio
+async def test_publish_to_counter_stream(jetstream: JetStream):
+    """Counter-enabled stream surfaces the running value on the publish ack.
+
+    Requires nats-server 2.14+.
+    """
+    await jetstream.create_stream(
+        name="COUNTER",
+        subjects=["counter.>"],
+        allow_msg_counter=True,
+    )
+
+    ack1 = await jetstream.publish("counter.x", b"", headers={"Nats-Incr": "5"})
+    assert ack1.value == "5"
+
+    ack2 = await jetstream.publish("counter.x", b"", headers={"Nats-Incr": "3"})
+    assert ack2.value == "8"
+
+    ack3 = await jetstream.publish("counter.x", b"", headers={"Nats-Incr": "-2"})
+    assert ack3.value == "6"


### PR DESCRIPTION
Exposes nats-server 2.14's counter-stream feature at the wire level:

- `StreamConfig.allow_msg_counter` on the TypedDict and dataclass (and the equivalents on `StreamCreateRequest` / `StreamUpdateRequest`).
- `PublishAck.value` (mapped from the wire `val` field).

End-to-end test publishes three `Nats-Incr`-headered messages to a counter-enabled stream and verifies the running value comes back on each ack (5 → 8 → 6).

Matches the Go client's surface — wire-only, no header constants or helper API.