### PR TITLE
Add stream persist mode wire support

### DIFF
--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -694,6 +694,9 @@ class StreamConfig(TypedDict):
     num_replicas: int
     """How many replicas to keep for each message."""
 
+    persist_mode: NotRequired[Literal["default", "async"]]
+    """Persistence mode for R1 streams (ADR-56). Server omits the field for the default mode."""
+
     placement: NotRequired[Placement]
     """Placement directives to consider when placing replicas of this stream, random placement when unset"""
 
@@ -926,6 +929,9 @@ class StreamCreateRequest(TypedDict):
     pedantic: NotRequired[bool]
     """Enables pedantic mode where the server will not apply defaults or change the request"""
 
+    persist_mode: NotRequired[Literal["default", "async"]]
+    """Persistence mode for R1 streams (ADR-56). Server omits the field for the default mode."""
+
     placement: NotRequired[Placement]
     """Placement directives to consider when placing replicas of this stream, random placement when unset"""
 
@@ -1130,6 +1136,9 @@ class StreamUpdateRequest(TypedDict):
 
     num_replicas: int
     """How many replicas to keep for each message."""
+
+    persist_mode: NotRequired[Literal["default", "async"]]
+    """Persistence mode for R1 streams (ADR-56). Server omits the field for the default mode."""
 
     placement: NotRequired[Placement]
     """Placement directives to consider when placing replicas of this stream, random placement when unset"""

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -33,6 +33,7 @@ RetentionPolicy = Literal["limits", "interest", "workqueue"]
 StorageType = Literal["file", "memory"]
 DiscardPolicy = Literal["old", "new"]
 CompressionType = Literal["none", "s2"]
+PersistMode = Literal["default", "async"]
 
 if TYPE_CHECKING:
     from . import JetStream, api
@@ -645,6 +646,9 @@ class StreamConfig:
     no_ack: bool | None = None
     """Disables acknowledging messages that are received by the Stream."""
 
+    persist_mode: PersistMode | None = None
+    """Persistence mode for R1 streams (ADR-56). ``"async"`` allows acknowledging publishes before fsync; ``None`` (or ``"default"``) keeps the synchronous default. Requires nats-server 2.12+ (API Level 2)."""
+
     placement: Placement | None = None
     """Placement directives to consider when placing replicas of this stream, random placement when unset."""
 
@@ -767,6 +771,7 @@ class StreamConfig:
         mirror_direct = config.pop("mirror_direct", None)
         name = config.pop("name", None)
         no_ack = config.pop("no_ack", None)
+        persist_mode = config.pop("persist_mode", None)
         sealed = config.pop("sealed", None)
         subjects = config.pop("subjects", None)
 
@@ -842,6 +847,7 @@ class StreamConfig:
             mirror_direct=mirror_direct,
             name=name,
             no_ack=no_ack,
+            persist_mode=persist_mode,
             placement=placement,
             republish=republish,
             sealed=sealed,
@@ -907,6 +913,8 @@ class StreamConfig:
             result["name"] = self.name
         if self.no_ack is not None:
             result["no_ack"] = self.no_ack
+        if self.persist_mode is not None:
+            result["persist_mode"] = self.persist_mode
         if self.placement is not None:
             result["placement"] = self.placement.to_request()
         if self.republish is not None:

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -707,6 +707,24 @@ async def test_stream_state_timestamps(jetstream: JetStream):
 
 
 @pytest.mark.asyncio
+async def test_stream_persist_mode_round_trip(jetstream: JetStream):
+    """Round-trip persist_mode through stream create/info (ADR-56).
+
+    Requires nats-server 2.12+ (API Level 2). The server omits the field
+    when persist_mode is the default, so we only round-trip ``"async"``.
+    """
+    stream = await jetstream.create_stream(
+        name="ASYNC",
+        subjects=["async.>"],
+        num_replicas=1,
+        persist_mode="async",
+    )
+
+    info = await stream.get_info()
+    assert info.config.persist_mode == "async"
+
+
+@pytest.mark.asyncio
 async def test_stream_allow_msg_schedules_round_trip(jetstream: JetStream):
     """Round-trip allow_msg_schedules through stream create/info (ADR-51).
 


### PR DESCRIPTION
Wire-level support for ADR-56 `persist_mode` on `StreamConfig`. Surfaced as a Literal so callers can opt into `async` persistence without an enum import; the server omits the field for the default mode so the round-trip test only asserts the `async` path.