### PR TITLE
Release nats-jetstream v0.3.0

### DIFF
--- a/nats-jetstream/CHANGELOG.md
+++ b/nats-jetstream/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.3.0
+
+### Added
+
+- Atomic batch publishing — `allow_atomic`/`allow_batched` on `StreamConfig`, `Nats-Batch-*` header constants, and `batch_id`/`batch_size` on `PublishAck` (ADR-50, #922)
+- Message schedules — `allow_msg_schedules` on `StreamConfig` and `Nats-Schedule-*` header constants (ADR-51, #923)
+- Counter streams — `allow_msg_counter` on `StreamConfig` and `value` on `PublishAck` (ADR-49, #926)
+- Stream sourcing with pre-created push-durable consumers — `StreamConsumerSource` on `StreamSource` (ADR-60, #921)
+- `Stream.reset_consumer()` for the `$JS.API.CONSUMER.RESET` endpoint, plus `ConsumerReset` and `ConsumerInvalidResetError` (#920)
+- `persist_mode` on `StreamConfig` for R1 async persistence (ADR-56, #929)
+- Re-export of `new` from `nats.jetstream` (#880)
+
+### Fixed
+
+- `Stream.get_message()` now raises `MessageNotFoundError` on a 404 from the direct-get path instead of leaking the underlying status error (#881)
+
 # 0.2.0
 
 ### Added

--- a/nats-jetstream/pyproject.toml
+++ b/nats-jetstream/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "nats-jetstream"
-version = "0.2.0"
+version = "0.3.0"
 description = 'Python client for NATS JetStream'
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ dev = [
 
 [[package]]
 name = "nats-jetstream"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "nats-jetstream" }
 dependencies = [
     { name = "nats-core" },


### PR DESCRIPTION
Assumes #926 and #929 land before merge — changelog references them. Hold until they're in.