### PR TITLE
Add Client and Orbit section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,76 @@ await nats.connect("tls://connect.ngs.global:4222", user_credentials="/path/to/s
 
 ---
 
+## Client and Orbit
+
+NATS client functionality is split across two layers: the **core client**
+(`nats-py`, this repo) and **[Orbit](https://github.com/synadia-io/orbit.py)**,
+a separate set of packages with higher-level utilities.
+
+The split exists so the core can stay small, stable, and consistent across
+NATS clients in every language, while Orbit can iterate quickly on
+opinionated abstractions without dragging the core API along for the ride.
+
+### Core client (`nats-py`)
+
+- Direct API over Core NATS and JetStream as exposed by `nats-server`.
+- Lightweight, unopinionated, performance-oriented.
+- API surface kept in **parity** with other official NATS clients
+  (Rust, Go, .NET, Java, JS, C). A feature shipped here should look
+  the same shape everywhere.
+- Stable, conservative versioning. Breaking changes are rare and deliberate.
+
+### Orbit (`orbit.py`)
+
+- Higher-level, opinionated abstractions built **on top of** the core client.
+- Per-package versioning, so an experimental utility can iterate
+  without bumping every other piece.
+- Free to be language-specific: a Python-idiomatic API does not need to match
+  the equivalent in other languages.
+- May lag, omit, or extend cross-client parity items.
+
+### What goes where?
+
+| Concern                                            | Core (`nats-py`)    | Orbit |
+|----------------------------------------------------|:-------------------:|:-----:|
+| Connect, publish, subscribe, request/reply         | ✅                  |       |
+| JetStream publish, consumers, streams, KV, OS      | ✅                  |       |
+| Service API (request/reply micro-services)         | ✅                  |       |
+| Wire-protocol coverage, auth, TLS, reconnection    | ✅                  |       |
+| Cross-client parity, conservative semver           | ✅                  |       |
+| Opinionated helpers / sugar over core APIs         |                     | ✅    |
+| New experimental patterns (e.g. partitioned groups)|                     | ✅    |
+| KV codecs, distributed counters, NATS contexts     |                     | ✅    |
+| Python-idiomatic abstractions with no parity mandate|                    | ✅    |
+| Per-utility versioning, faster API churn allowed   |                     | ✅    |
+
+> **Rule of thumb:** if it is a thin mapping of something `nats-server`
+> already speaks and every official client must expose it, it belongs in
+> core. If it is a pattern, helper, or abstraction layered on top, it
+> belongs in Orbit.
+
+### Layering
+
+```text
+   ┌──────────────────────────────────────────────────────┐
+   │  Application code                                    │
+   └──────────────┬───────────────────────────┬───────────┘
+                  │                           │
+                  ▼                           ▼
+        ┌───────────────────┐       ┌───────────────────┐
+        │ Orbit packages    │  uses │ nats-py (core)    │
+        │ (opinionated,     │──────▶│ (parity, stable,  │
+        │  per-pkg semver)  │       │  protocol-level)  │
+        └───────────────────┘       └─────────┬─────────┘
+                                              │
+                                              ▼
+                                       ┌─────────────┐
+                                       │ nats-server │
+                                       └─────────────┘
+```
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.


### PR DESCRIPTION
Explains the split between the core nats-py client and the Orbit utility packages (https://github.com/synadia-io/orbit.py): what each is for, what goes where, and a small layering diagram. Mirrors the section added in nats.rs#1580.

Signed-off-by: Tomasz Pietrek <tomasz@synadia.com>