### PR TITLE
Use inspect.iscoroutinefunction over deprecated asyncio alias

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import inspect
 import ipaddress
 import json
 import logging
@@ -477,7 +478,7 @@ class Client:
             discovered_server_cb,
             lame_duck_mode_cb,
         ]:
-            if cb and not asyncio.iscoroutinefunction(cb):
+            if cb and not inspect.iscoroutinefunction(cb):
                 raise errors.InvalidCallbackTypeError
 
         self._setup_server_pool(servers)

--- a/nats/src/nats/aio/subscription.py
+++ b/nats/src/nats/aio/subscription.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 from typing import (
     TYPE_CHECKING,
     AsyncIterator,
@@ -207,8 +208,8 @@ class Subscription:
         Creates the resources for the subscription to start processing messages.
         """
         if self._cb:
-            if not asyncio.iscoroutinefunction(self._cb) and not (
-                hasattr(self._cb, "func") and asyncio.iscoroutinefunction(self._cb.func)
+            if not inspect.iscoroutinefunction(self._cb) and not (
+                hasattr(self._cb, "func") and inspect.iscoroutinefunction(self._cb.func)
             ):
                 raise errors.Error("nats: must use coroutine for subscriptions")
 


### PR DESCRIPTION
Python 3.14 deprecates `asyncio.iscoroutinefunction` in favor of `inspect.iscoroutinefunction` (https://github.com/python/cpython/issues/122858)