### PR TITLE
Use datetime.UTC alias instead of timezone.utc

### DIFF
--- a/nats-jetstream/src/nats/jetstream/consumer/__init__.py
+++ b/nats-jetstream/src/nats/jetstream/consumer/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterable, AsyncIterator
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import TracebackType
 from typing import (
     TYPE_CHECKING,
@@ -291,9 +291,9 @@ class ConsumerConfig:
         if self.opt_start_seq is not None:
             request["opt_start_seq"] = self.opt_start_seq
         if self.opt_start_time is not None:
-            request["opt_start_time"] = self.opt_start_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+            request["opt_start_time"] = self.opt_start_time.astimezone(UTC).isoformat().replace("+00:00", "Z")
         if self.pause_until is not None:
-            request["pause_until"] = self.pause_until.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+            request["pause_until"] = self.pause_until.astimezone(UTC).isoformat().replace("+00:00", "Z")
         if self.priority_groups is not None:
             request["priority_groups"] = self.priority_groups
         if self.priority_policy is not None:

--- a/nats-jetstream/src/nats/jetstream/message.py
+++ b/nats-jetstream/src/nats/jetstream/message.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from nats.client.message import Headers
@@ -89,7 +89,7 @@ class Metadata:
                     sequence=SequencePair(consumer=int(consumer_seq), stream=int(stream_seq)),
                     num_delivered=int(delivered),
                     num_pending=int(pending),
-                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=timezone.utc),
+                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=UTC),
                     stream=stream,
                     consumer=consumer,
                     domain=domain_value,
@@ -100,7 +100,7 @@ class Metadata:
                     sequence=SequencePair(consumer=int(consumer_seq), stream=int(stream_seq)),
                     num_delivered=int(delivered),
                     num_pending=int(pending),
-                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=timezone.utc),
+                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=UTC),
                     stream=stream,
                     consumer=consumer,
                 )
@@ -110,7 +110,7 @@ class Metadata:
                     sequence=SequencePair(consumer=int(consumer_seq), stream=int(stream_seq)),
                     num_delivered=int(delivered),
                     num_pending=0,
-                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=timezone.utc),
+                    timestamp=datetime.fromtimestamp(int(timestamp) / 1e9, tz=UTC),
                     stream=stream,
                     consumer=consumer,
                 )
@@ -158,7 +158,7 @@ class Message:
             sequence=SequencePair(consumer=0, stream=0),
             num_delivered=0,
             num_pending=0,
-            timestamp=datetime.now(timezone.utc),
+            timestamp=datetime.now(UTC),
             stream="",
             consumer="",
         )

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import json
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1189,7 +1189,7 @@ class Stream:
                     subject=last_by_subject or "",
                     sequence=sequence or 0,
                     data=response.data,
-                    time=datetime.now(timezone.utc),
+                    time=datetime.now(UTC),
                     headers=None,
                 )
 
@@ -1355,7 +1355,7 @@ class Stream:
         if name is None:
             durable_name = config.get("durable_name")
             if durable_name is None:
-                name = f"consumer-{base64.b64encode(str(datetime.now(timezone.utc)).encode()).decode()}"
+                name = f"consumer-{base64.b64encode(str(datetime.now(UTC)).encode()).decode()}"
             else:
                 name = durable_name
 
@@ -1571,15 +1571,13 @@ class Stream:
             ConsumerNotFoundError: If the consumer does not exist
             JetStreamError: For other JetStream API errors
         """
-        from datetime import datetime, timezone
-
         # Get API client from jetstream
         api = getattr(self._jetstream, "_api", None)
         if api is None:
             raise RuntimeError("JetStream does not have an API client")
 
         # Convert Unix timestamp to RFC3339 string (ISO 8601 format with timezone)
-        dt = datetime.fromtimestamp(pause_until, tz=timezone.utc)
+        dt = datetime.fromtimestamp(pause_until, tz=UTC)
         pause_until_str = dt.isoformat().replace("+00:00", "Z")
 
         # Pause consumer via API

--- a/nats-jetstream/tests/test_consumer.py
+++ b/nats-jetstream/tests/test_consumer.py
@@ -1019,11 +1019,11 @@ async def test_messages_with_threshold_bytes(jetstream: JetStream):
 @pytest.mark.asyncio
 async def test_create_consumer_with_opt_start_time(jetstream: JetStream):
     """Test creating a consumer with opt_start_time and reading it back."""
-    from datetime import datetime, timezone
+    from datetime import UTC, datetime
 
     stream = await jetstream.create_stream(name="test_ost", subjects=["OST.*"])
 
-    start_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+    start_time = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
     await stream.create_consumer(
         name="ost_consumer",
         deliver_policy="by_start_time",
@@ -1040,11 +1040,11 @@ async def test_create_consumer_with_opt_start_time(jetstream: JetStream):
 @pytest.mark.asyncio
 async def test_create_consumer_with_pause_until(jetstream: JetStream):
     """Test creating a consumer with pause_until and reading it back."""
-    from datetime import datetime, timedelta, timezone
+    from datetime import UTC, datetime, timedelta
 
     stream = await jetstream.create_stream(name="test_pu", subjects=["PU.*"])
 
-    pause_until = datetime.now(timezone.utc) + timedelta(hours=1)
+    pause_until = datetime.now(UTC) + timedelta(hours=1)
     await stream.create_consumer(
         name="pu_consumer",
         ack_policy="none",

--- a/nats-jetstream/tests/test_message.py
+++ b/nats-jetstream/tests/test_message.py
@@ -1,7 +1,7 @@
 """Tests for the nats.jetstream.message module."""
 
 import asyncio
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from nats.client import Client
@@ -20,7 +20,7 @@ def test_metadata_from_reply_parses_valid_subject():
     assert metadata.num_delivered == 1
     assert metadata.sequence.stream == 100
     assert metadata.sequence.consumer == 50
-    assert metadata.timestamp == datetime.fromtimestamp(1234567890 / 1e9, tz=timezone.utc)
+    assert metadata.timestamp == datetime.fromtimestamp(1234567890 / 1e9, tz=UTC)
     assert metadata.num_pending == 10
 
 
@@ -49,7 +49,7 @@ def test_metadata_from_reply_parses_v2_format_with_domain():
     assert metadata.num_delivered == 1
     assert metadata.sequence.stream == 100
     assert metadata.sequence.consumer == 50
-    assert metadata.timestamp == datetime.fromtimestamp(1234567890 / 1e9, tz=timezone.utc)
+    assert metadata.timestamp == datetime.fromtimestamp(1234567890 / 1e9, tz=UTC)
     assert metadata.num_pending == 10
     assert metadata.domain == "hub"
 
@@ -118,7 +118,7 @@ def test_message_with_explicit_metadata():
         sequence=SequencePair(consumer=10, stream=20),
         num_delivered=3,
         num_pending=5,
-        timestamp=datetime.now(timezone.utc),
+        timestamp=datetime.now(UTC),
         stream="my-stream",
         consumer="my-consumer",
     )


### PR DESCRIPTION
Python 3.11 added `datetime.UTC` as an alias for `timezone.utc`. The package targets 3.11+, so switch the datetime call sites to the shorter spelling.