### PR TITLE
Bind Object Store reads to the backing stream by name for mirrored buckets

### DIFF
--- a/nats/src/nats/js/object_store.py
+++ b/nats/src/nats/js/object_store.py
@@ -200,7 +200,14 @@ class ObjectStore:
             return result
 
         chunk_subj = OBJ_CHUNKS_PRE_TEMPLATE.format(bucket=self._name, obj=info.nuid)
-        sub = await self._js.subscribe(subject=chunk_subj, ordered_consumer=True)
+        # Bind to the backing stream by name: a mirrored bucket's stream binds
+        # no subjects, so looking the stream up by subject would fail with
+        # NotFoundError (see #505).
+        sub = await self._js.subscribe(
+            subject=chunk_subj,
+            stream=self._stream,
+            ordered_consumer=True,
+        )
 
         h = sha256()
 
@@ -500,6 +507,7 @@ class ObjectStore:
 
         watcher._sub = await self._js.subscribe(
             all_meta,
+            stream=self._stream,
             cb=watch_updates,
             ordered_consumer=True,
             deliver_policy=deliver_policy,

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -5978,3 +5978,116 @@ class BadStreamNamesTest(SingleJetStreamServerTestCase):
         assert e.description == "changed"
 
         await nc.close()
+
+
+class MirroredDomainBucketsTest(HubLeafJetStreamServerTestCase):
+    """
+    KV and Object Store reads against buckets mirrored across JetStream
+    domains (GH-505).  The mirror stream binds no subjects, so any code
+    path that locates the backing stream by subject raises NotFoundError;
+    reads must bind by stream name, matching the Go client.
+    """
+
+    async def wait_for_mirror(self, js, stream, messages, timeout=10):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                info = await js.stream_info(stream)
+                if info.state.messages >= messages:
+                    return info
+            except NotFoundError:
+                pass
+            await asyncio.sleep(0.1)
+        raise AssertionError(f"mirror stream {stream} did not catch up")
+
+    @async_long_test
+    async def test_object_store_get_from_cross_domain_mirror(self):
+        errors = []
+
+        async def error_handler(e):
+            print("Error:", e, type(e))
+            errors.append(e)
+
+        nc_hub = await nats.connect(f"nats://127.0.0.1:{self.hub_port}", error_cb=error_handler)
+        nc_leaf = await nats.connect(f"nats://127.0.0.1:{self.leaf_port}", error_cb=error_handler)
+        js_hub = nc_hub.jetstream()
+        js_leaf = nc_leaf.jetstream()
+
+        obs_hub = await js_hub.create_object_store(bucket="MIRRORED")
+        # Multiple chunks (default chunk size is 128k) plus a second object
+        # so list() has more than one entry to report.
+        blob = os.urandom(256 * 1024 + 17)
+        await obs_hub.put("blob", blob)
+        await obs_hub.put("small", b"tiny")
+        origin = await js_hub.stream_info("OBJ_MIRRORED")
+
+        # Mirror of the bucket's backing stream in the leaf domain: binds
+        # no subjects, reachable only by stream name.
+        await js_leaf.add_stream(
+            name="OBJ_MIRRORED",
+            mirror=nats.js.api.StreamSource(
+                name="OBJ_MIRRORED",
+                external=nats.js.api.ExternalStream(api=f"$JS.{self.hub_domain}.API"),
+            ),
+        )
+        await self.wait_for_mirror(js_leaf, "OBJ_MIRRORED", origin.state.messages)
+
+        obs_leaf = await js_leaf.object_store("MIRRORED")
+
+        # get() reads chunks through an ordered consumer on the mirror.
+        result = await obs_leaf.get("blob")
+        assert result.data == blob
+        assert result.info.name == "blob"
+
+        # list() goes through watch(), the other subject-bound code path.
+        entries = await obs_leaf.list()
+        assert sorted(e.name for e in entries) == ["blob", "small"]
+
+        assert len(errors) == 0
+        await nc_hub.close()
+        await nc_leaf.close()
+
+    @async_long_test
+    async def test_kv_get_and_keys_from_cross_domain_mirror(self):
+        errors = []
+
+        async def error_handler(e):
+            print("Error:", e, type(e))
+            errors.append(e)
+
+        nc_hub = await nats.connect(f"nats://127.0.0.1:{self.hub_port}", error_cb=error_handler)
+        nc_leaf = await nats.connect(f"nats://127.0.0.1:{self.leaf_port}", error_cb=error_handler)
+        js_hub = nc_hub.jetstream()
+        js_leaf = nc_leaf.jetstream()
+
+        kv_hub = await js_hub.create_key_value(bucket="MIRRORED_KV")
+        await kv_hub.put("one", b"1")
+        await kv_hub.put("two", b"2")
+        origin = await js_hub.stream_info("KV_MIRRORED_KV")
+
+        # A KV mirror must keep the KV stream shape (the bucket accessor
+        # validates max_msgs_per_subject), mirroring what `nats kv add
+        # --mirror` does.
+        await js_leaf.add_stream(
+            name="KV_MIRRORED_KV",
+            mirror=nats.js.api.StreamSource(
+                name="KV_MIRRORED_KV",
+                external=nats.js.api.ExternalStream(api=f"$JS.{self.hub_domain}.API"),
+            ),
+            max_msgs_per_subject=origin.config.max_msgs_per_subject,
+        )
+        await self.wait_for_mirror(js_leaf, "KV_MIRRORED_KV", origin.state.messages)
+
+        kv_leaf = await js_leaf.key_value("MIRRORED_KV")
+
+        # get() resolves messages on the mirror by stream name.
+        entry = await kv_leaf.get("one")
+        assert entry.value == b"1"
+
+        # keys() consumes through watch(), which must bind by stream name.
+        keys = await kv_leaf.keys()
+        assert sorted(keys) == ["one", "two"]
+
+        assert len(errors) == 0
+        await nc_hub.close()
+        await nc_leaf.close()

--- a/nats/tests/utils.py
+++ b/nats/tests/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import http.client
+import json
 import os
 import shutil
 import signal
@@ -427,6 +428,81 @@ class SingleJetStreamServerTestCase(unittest.TestCase):
         for natsd in self.server_pool:
             natsd.stop()
             shutil.rmtree(natsd.store_dir)
+        self.loop.close()
+
+
+class HubLeafJetStreamServerTestCase(unittest.TestCase):
+    """
+    A hub server and a leaf server, each with its own JetStream domain,
+    connected over a leafnode link.  Cross-domain mirrors created on the
+    leaf reach the hub through ``$JS.<hub domain>.API``.  A mirror binds
+    no subjects, which is what exercises stream-name binding in KV and
+    Object Store (see GH-505).
+    """
+
+    hub_port = 4228
+    hub_http_port = 8228
+    hub_leafnode_port = 7430
+    leaf_port = 4229
+    leaf_http_port = 8229
+    hub_domain = "hub"
+    leaf_domain = "leaf"
+
+    def setUp(self):
+        self.server_pool = []
+        self.tmp_dirs = []
+        self.loop = asyncio.new_event_loop()
+
+        hub_dir = tempfile.mkdtemp()
+        leaf_dir = tempfile.mkdtemp()
+        self.tmp_dirs.extend([hub_dir, leaf_dir])
+
+        hub_conf = os.path.join(hub_dir, "hub.conf")
+        with open(hub_conf, "w") as f:
+            f.write(
+                f"""
+                jetstream {{ domain: {self.hub_domain}, store_dir: "{hub_dir}" }}
+                leafnodes {{ port: {self.hub_leafnode_port} }}
+                """
+            )
+
+        leaf_conf = os.path.join(leaf_dir, "leaf.conf")
+        with open(leaf_conf, "w") as f:
+            f.write(
+                f"""
+                jetstream {{ domain: {self.leaf_domain}, store_dir: "{leaf_dir}" }}
+                leafnodes {{ remotes = [ {{ url: "nats://127.0.0.1:{self.hub_leafnode_port}" }} ] }}
+                """
+            )
+
+        hub = NATSD(port=self.hub_port, http_port=self.hub_http_port, config_file=hub_conf)
+        leaf = NATSD(port=self.leaf_port, http_port=self.leaf_http_port, config_file=leaf_conf)
+        self.server_pool.extend([hub, leaf])
+        for natsd in self.server_pool:
+            start_natsd(natsd)
+        self.wait_for_leafnode()
+
+    def wait_for_leafnode(self, timeout=10):
+        # Cross-domain JS API calls travel over the leafnode link, so wait
+        # until the hub reports the leaf connection before running tests.
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                httpclient = http.client.HTTPConnection(f"127.0.0.1:{self.hub_http_port}", timeout=5)
+                httpclient.request("GET", "/leafz")
+                response = httpclient.getresponse()
+                if response.status == 200 and json.loads(response.read())["leafnodes"] > 0:
+                    return
+            except OSError:
+                pass
+            time.sleep(0.1)
+        raise RuntimeError("test nats-server leafnode connection was not established")
+
+    def tearDown(self):
+        for natsd in self.server_pool:
+            natsd.stop()
+        for tmp_dir in self.tmp_dirs:
+            shutil.rmtree(tmp_dir)
         self.loop.close()
 
 


### PR DESCRIPTION
# Bind Object Store reads to the backing stream by name for mirrored buckets

Fixes #505

## Problem

`ObjectStore.get()` and `ObjectStore.watch()` (and therefore `list()`, which
consumes `watch()`) located the backing stream by **subject lookup**
(`JetStreamManager.find_stream_name_by_subject`). A mirrored bucket's stream
binds **no subjects**, so both paths raised `NotFoundError` when reading a
bucket whose backing stream is a mirror - e.g. an Object Store mirrored from
another JetStream domain over a leafnode link, the topology #505 describes.

The bucket name already determines the stream name (`OBJ_<bucket>`), and the
`ObjectStore` object already carries it (`self._stream`) - the lookup was not
just fragile against mirrors, it was unnecessary.

The Key-Value half of #505 was fixed by #807 (included since v2.15.0); the
regression tests added here cover both KV and Object Store so the whole issue
stays fixed.

## Fix

Pass `stream=self._stream` to the two subscriptions that previously resolved
by subject:

- `ObjectStore.get()` - the chunk-read ordered consumer
- `ObjectStore.watch()` - the meta watcher (also serves `list()`)

This matches the Go reference client, which binds with
`nats.OrderedConsumer(), nats.BindStream(streamName)` in both places
(`jetstream/object.go` - `Get` and `Watch`; same pattern in the legacy
`object.go`). Behavior is specified by ADR-20 (JetStream-based Object Stores);
the KV sibling is ADR-8.

Credit: #808 (@JoaoLockem) proposed the same two-site fix; this PR adds the
regression coverage the fix needs to land safely.

## Tests

`MirroredDomainBucketsTest`, on a new `HubLeafJetStreamServerTestCase`
fixture: a hub server and a leaf server with distinct JetStream domains
connected over a leafnode link, mirrors created with
`external: { api: "$JS.hub.API" }`.

The cross-domain topology is load-bearing for the repro: a **same-server**
mirror would let the subject lookup resolve the *origin* stream and silently
mask the defect. (A same-server origin-deleted variant can also reproduce it,
but the cross-domain shape is the one users actually run and the one #505
reports.)

- `test_object_store_get_from_cross_domain_mirror` - multi-chunk `get()`
  (256 KiB + 17 B across 128 KiB chunks) plus `list()` against the mirror.
  **Fails with `NotFoundError` (raised from
  `manager.find_stream_name_by_subject`) without the fix; passes with it.**
- `test_kv_get_and_keys_from_cross_domain_mirror` - KV `get()` and `keys()`
  (watch path) against a KV-shaped mirror (`max_msgs_per_subject` inherited
  from the origin, as `nats kv add --mirror` does). Passes before and after
  (regression guard for #807).

## Conformance against the Go client

Same topology, same mirrored buckets on the leaf node, read with the patched
Python client and natscli 0.4.0 (nats.go):

| Read path | Go client | Patched nats-py | Result |
|---|---|---|---|
| `object get artifacts tiny` (mirror) | 307,200 bytes | 307,200 bytes | **SHA-256 identical** (`c5ec6f90…`) |
| `object ls artifacts` (mirror) | `tiny` | `['tiny']` | match |
| `kv get cfg alpha` (mirror) | `value-alpha` | `value-alpha` | match |
| `kv ls cfg` (mirror) | `alpha`, `beta` | `['alpha', 'beta']` | match |

Unpatched nats-py 2.15.0 fails the first two with `NotFoundError` where the
Go client succeeds.

## Validation

- `uv run pytest nats/tests/test_js.py::MirroredDomainBucketsTest` — 2 passed
- Full `nats/tests` suite — green (nats-server v2.14.2, CPython 3.13)
- `uv run ruff check` / `uv run ruff format --check` — clean

---

*Note to maintainers:* #808 proposed the same two-line fix - happy to rebase this PR to tests-only if you'd prefer to land #808 for the fix itself; the goal is just that #505 ends up fixed **with** regression coverage either way.
