### PR TITLE
Defer optional nkeys import into auth setup

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -37,7 +37,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Final, Self, TypeAlias
 from urllib.parse import urlparse
 
-import nkeys
 from nats.client.connection import Connection, establish_connection
 from nats.client.errors import (
     MaxPayloadError,
@@ -1609,6 +1608,16 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._lame_duck_mode_callbacks.remove(callback)
 
 
+def _import_nkeys():
+    """Import the optional ``nkeys`` dependency, raising a clear error if missing."""
+    try:
+        import nkeys
+    except ImportError as e:
+        msg = "Nkey and JWT authentication require the 'nkeys' package. Install nats-core[nkeys]."
+        raise ImportError(msg) from e
+    return nkeys
+
+
 def _setup_nkey_auth(
     nkey: str | Path | tuple[Callable[[], str], Callable[[str], bytes]],
 ) -> tuple[Callable[[], str], Callable[[str], bytes]]:
@@ -1623,6 +1632,8 @@ def _setup_nkey_auth(
     if isinstance(nkey, tuple):
         # Already handlers, return as-is
         return nkey
+
+    nkeys = _import_nkeys()
 
     # Load seed from string or file
     if isinstance(nkey, Path):
@@ -1707,6 +1718,8 @@ def _setup_jwt_auth(
     else:
         msg = f"Invalid jwt argument: {jwt!r}"
         raise TypeError(msg)
+
+    nkeys = _import_nkeys()
 
     # Create handlers
     def jwt_handler() -> bytes:

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -1670,6 +1670,8 @@ def _setup_jwt_auth(
         # Already handlers, return as-is
         return jwt  # type: ignore[return-value]
 
+    nkeys = _import_nkeys()
+
     # Parse JWT and seed
     jwt_content: bytes
     seed_bytes: bytes
@@ -1718,8 +1720,6 @@ def _setup_jwt_auth(
     else:
         msg = f"Invalid jwt argument: {jwt!r}"
         raise TypeError(msg)
-
-    nkeys = _import_nkeys()
 
     # Create handlers
     def jwt_handler() -> bytes:


### PR DESCRIPTION
A top-level `import nkeys` broke `import nats.client` on a plain `pip install nats-core`: nkeys ships only as the `[nkeys]` extra, so the unconditional import raised `ImportError` for everyone not using nkey/JWT auth.

The import now lives in the two auth-setup helpers (its only consumers), after their early returns. The base package loads without the extra, pre-built handler tuples and JWT parsing stay nkeys-free, and deriving a signer from a seed raises a clear `Install nats-core[nkeys].` hint — mirroring how the websocket extra is guarded in `connection.py`.
