### PR TITLE
Use get_running_loop in the client

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -449,12 +449,12 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._max_pending_bytes = _DEFAULT_PENDING_BYTES_LIMIT
         self._max_pending_messages = _DEFAULT_PENDING_MESSAGES_LIMIT
         self._min_flush_interval = _DEFAULT_MIN_FLUSH_INTERVAL
-        self._last_flush = asyncio.get_event_loop().time() - self._min_flush_interval
+        self._last_flush = asyncio.get_running_loop().time() - self._min_flush_interval
         self._flush_waker = asyncio.Event()
         self._ping_interval = ping_interval
         self._max_outstanding_pings = max_outstanding_pings
         self._pings_outstanding = 0
-        self._last_pong_received = asyncio.get_event_loop().time()
+        self._last_pong_received = asyncio.get_running_loop().time()
         self._last_ping_sent = self._last_pong_received
         self._pong_waker = asyncio.Event()
         self._disconnected_callbacks = []
@@ -557,7 +557,7 @@ class Client(AbstractAsyncContextManager["Client"]):
 
     async def _handle_pong(self) -> None:
         """Handle PONG from server."""
-        self._last_pong_received = asyncio.get_event_loop().time()
+        self._last_pong_received = asyncio.get_running_loop().time()
         self._pings_outstanding = 0
         self._pong_waker.set()
 
@@ -573,7 +573,7 @@ class Client(AbstractAsyncContextManager["Client"]):
             return False
 
         self._pings_outstanding += 1
-        self._last_ping_sent = asyncio.get_event_loop().time()
+        self._last_ping_sent = asyncio.get_running_loop().time()
         await self._connection.write(encode_ping())
         return True
 
@@ -586,7 +586,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                         await asyncio.wait_for(self._flush_waker.wait(), timeout=self._ping_interval)
                         self._flush_waker.clear()
 
-                        current_time = asyncio.get_event_loop().time()
+                        current_time = asyncio.get_running_loop().time()
                         since_last_flush = current_time - self._last_flush
                         if since_last_flush < self._min_flush_interval:
                             await asyncio.sleep(self._min_flush_interval - since_last_flush)
@@ -596,7 +596,7 @@ class Client(AbstractAsyncContextManager["Client"]):
                             self._last_flush = current_time
 
                     except TimeoutError:
-                        current_time = asyncio.get_event_loop().time()
+                        current_time = asyncio.get_running_loop().time()
 
                         if current_time - self._last_ping_sent >= self._ping_interval:
                             if self._pings_outstanding >= self._max_outstanding_pings:

--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -449,12 +449,13 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._max_pending_bytes = _DEFAULT_PENDING_BYTES_LIMIT
         self._max_pending_messages = _DEFAULT_PENDING_MESSAGES_LIMIT
         self._min_flush_interval = _DEFAULT_MIN_FLUSH_INTERVAL
-        self._last_flush = asyncio.get_running_loop().time() - self._min_flush_interval
+        loop = asyncio.get_running_loop()
+        self._last_flush = loop.time() - self._min_flush_interval
         self._flush_waker = asyncio.Event()
         self._ping_interval = ping_interval
         self._max_outstanding_pings = max_outstanding_pings
         self._pings_outstanding = 0
-        self._last_pong_received = asyncio.get_running_loop().time()
+        self._last_pong_received = loop.time()
         self._last_ping_sent = self._last_pong_received
         self._pong_waker = asyncio.Event()
         self._disconnected_callbacks = []


### PR DESCRIPTION
`asyncio.get_event_loop()` is soft-deprecated (and slower). Every `.time()` call site here runs inside a running loop — the client is only constructed from `async connect()`, the rest are in coroutines — so `get_running_loop()` is the correct modern form.
