### PR TITLE
Expose min_flush_interval on connect() and Client

### DIFF
--- a/nats-core/src/nats/client/__init__.py
+++ b/nats-core/src/nats/client/__init__.py
@@ -370,6 +370,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         verbose: bool = False,
         pedantic: bool = False,
         skip_subject_validation: bool = False,
+        min_flush_interval: float = _DEFAULT_MIN_FLUSH_INTERVAL,
     ):
         """Initialize the client.
 
@@ -403,6 +404,10 @@ class Client(AbstractAsyncContextManager["Client"]):
             verbose: If True, the server will reply +OK on each protocol message (default: False)
             pedantic: If True, the server enforces strict protocol checks (default: False)
             skip_subject_validation: If True, skip client-side subject and queue validation
+            min_flush_interval: Minimum interval in seconds between socket flushes,
+                coalescing writes from concurrent publishers (default: 0.005).
+                Set to 0 to flush immediately, which favors sequential
+                publish/ack loops over concurrent publishers.
         """
         self._connection = connection
         self._server_info = server_info
@@ -423,6 +428,9 @@ class Client(AbstractAsyncContextManager["Client"]):
             raise ValueError("inbox_prefix cannot contain '*' wildcard")
         if inbox_prefix.endswith("."):
             raise ValueError("inbox_prefix cannot end with '.'")
+
+        if min_flush_interval < 0:
+            raise ValueError("min_flush_interval cannot be negative")
 
         self._inbox_prefix = inbox_prefix
         self._name = name
@@ -458,7 +466,7 @@ class Client(AbstractAsyncContextManager["Client"]):
         self._pending_messages = []
         self._max_pending_bytes = _DEFAULT_PENDING_BYTES_LIMIT
         self._max_pending_messages = _DEFAULT_PENDING_MESSAGES_LIMIT
-        self._min_flush_interval = _DEFAULT_MIN_FLUSH_INTERVAL
+        self._min_flush_interval = min_flush_interval
         loop = asyncio.get_running_loop()
         self._last_flush = loop.time() - self._min_flush_interval
         self._flush_waker = asyncio.Event()
@@ -494,6 +502,11 @@ class Client(AbstractAsyncContextManager["Client"]):
     def last_error(self) -> str | None:
         """Get the last protocol error received from the server."""
         return self._last_error
+
+    @property
+    def min_flush_interval(self) -> float:
+        """Get the minimum interval in seconds between socket flushes."""
+        return self._min_flush_interval
 
     def stats(self) -> ClientStatistics:
         """Return a snapshot of the current connection statistics.
@@ -1764,6 +1777,7 @@ async def connect(
     verbose: bool = False,
     pedantic: bool = False,
     skip_subject_validation: bool = False,
+    min_flush_interval: float = _DEFAULT_MIN_FLUSH_INTERVAL,
 ) -> Client:
     """Connect to a NATS server.
 
@@ -1803,6 +1817,10 @@ async def connect(
             on publish, subscribe, and request. Mirrors nats.go's ``SkipSubjectValidation``.
             WARNING: this disables CRLF-injection protection — only enable for hot-path
             benchmarks where you fully control the subject inputs.
+        min_flush_interval: Minimum interval in seconds between socket flushes,
+            coalescing writes from concurrent publishers (default: 0.005).
+            Set to 0 to flush immediately, which favors sequential
+            publish/ack loops over concurrent publishers.
 
     Returns:
         Client instance
@@ -1977,6 +1995,7 @@ async def connect(
         verbose=verbose,
         pedantic=pedantic,
         skip_subject_validation=skip_subject_validation,
+        min_flush_interval=min_flush_interval,
     )
 
     client._status = ClientStatus.CONNECTED

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -3950,3 +3950,35 @@ async def test_remove_callback_raises_when_not_registered(client):
         client.remove_error_callback(never_registered_error)
     with pytest.raises(ValueError):
         client.remove_lame_duck_mode_callback(never_registered)
+
+
+@pytest.mark.asyncio
+async def test_min_flush_interval_defaults_to_5ms(client):
+    """The write-coalescing flush interval defaults to 5 ms."""
+    assert client.min_flush_interval == 0.005
+
+
+@pytest.mark.asyncio
+async def test_connect_with_custom_min_flush_interval(server):
+    """min_flush_interval can be set at connect time, including 0 to disable coalescing."""
+    client = await connect(server.client_url, min_flush_interval=0.0, timeout=1.0)
+
+    try:
+        assert client.min_flush_interval == 0.0
+
+        # The client must still publish correctly with coalescing disabled.
+        subject = f"test.min_flush.{uuid.uuid4()}"
+        subscription = await client.subscribe(subject)
+        await client.flush()
+        await client.publish(subject, b"hello")
+        message = await subscription.next(timeout=2.0)
+        assert message.data == b"hello"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_connect_with_negative_min_flush_interval_raises(server):
+    """A negative min_flush_interval is rejected."""
+    with pytest.raises(ValueError, match="min_flush_interval"):
+        await connect(server.client_url, min_flush_interval=-0.001, timeout=1.0)


### PR DESCRIPTION
## Motivation

The client's write loop coalesces socket writes by enforcing a minimum interval between flushes, hardcoded to 5 ms (`_DEFAULT_MIN_FLUSH_INTERVAL`). Write-coalescing is the right default when many tasks publish concurrently — one flush amortizes across all their writes.

For sequential publish→await-reply workloads (request/reply, or publish-then-wait-for-ack loops), the interval works against the caller instead: each message pays up to the full 5 ms before its bytes reach the socket, capping a single connection at roughly 200 msgs/s even when the server round trip is well under a millisecond. Today the only way around this is overriding the private `_min_flush_interval` attribute, which isn't safe across releases.

## Changes

- New keyword-only `min_flush_interval: float = 0.005` parameter on `connect()` and `Client.__init__`. The default is unchanged, so existing callers see no behavior difference.
- `0` is valid and means flush immediately (no coalescing); negative values raise `ValueError`, validated alongside the existing `inbox_prefix` checks.
- New read-only `Client.min_flush_interval` property, matching the style of `status` / `last_error`.
- Parameter added at the end of both signatures; docstrings explain the concurrent-vs-sequential trade-off.

## Testing

- Three new tests in `nats-core/tests/test_client.py`: the 5 ms default, connecting with `min_flush_interval=0.0` including a publish/subscribe round trip through the write loop, and rejection of negative values.
- Full `test_client.py` suite passes (178 tests); `ruff check`, `ruff format --check`, and `codespell` are clean