### PR TITLE
Pass placement from KeyValueConfig into StreamConfig in create_key_value

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -1449,6 +1449,7 @@ class JetStreamContext(JetStreamManager):
             deny_delete=True,
             discard=api.DiscardPolicy.NEW,
             duplicate_window=duplicate_window,
+            placement=config.placement,
             max_age=config.ttl,
             max_bytes=config.max_bytes,
             max_consumers=-1,


### PR DESCRIPTION
Fixes #538. Value of `placement` in given `KeyValueConfig` was not being used in created `StreamConfig`. KV placement can now be controlled when using `create_key_value`.