### PR TITLE
Populate KeyValue Entry.created from message timestamp

### DIFF
--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -193,7 +193,7 @@ class KeyValue:
             value=msg.data,
             revision=msg.seq,
             delta=None,
-            created=None,
+            created=msg.time,
             operation=None,
         )
 

--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -92,7 +92,7 @@ class KeyValue:
         value: Optional[bytes]
         revision: Optional[int]
         delta: Optional[int]
-        created: Optional[int]
+        created: Optional[datetime.datetime]
         operation: Optional[str]
 
     @dataclass(frozen=True)

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3173,6 +3173,24 @@ class KVTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_kv_get_returns_created_time(self):
+        # Regression for #398: KeyValue.get() must populate Entry.created with
+        # the message timestamp, over both the direct-get and API-get paths.
+        nc = await nats.connect()
+        js = nc.jetstream()
+
+        for direct in (True, False):
+            bucket = f"CREATED_{'DIRECT' if direct else 'API'}"
+            kv = await js.create_key_value(bucket=bucket, direct=direct)
+            await kv.put("key", b"value")
+
+            entry = await kv.get("key")
+            assert entry.created is not None, f"created missing (direct={direct})"
+            assert isinstance(entry.created, datetime.datetime)
+
+        await nc.close()
+
+    @async_test
     async def test_not_kv(self):
         errors = []
 


### PR DESCRIPTION
`KeyValue.get()` hardcoded `Entry.created` to `None`, so callers had no creation time for a fetched key. Both the direct-get and API-get paths already carry the timestamp on `RawStreamMsg.time`; use it.

Fixes #398.