### PR TITLE
Preserve user-supplied ConsumerConfig.filter_subject on subscribe

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -437,8 +437,9 @@ class JetStreamContext(JetStreamManager):
                 deliver = self._nc.new_inbox()
                 config.deliver_subject = deliver
 
-            # Auto created consumers use the filter subject, unless filter_subjects is set.
-            if not config.filter_subjects:
+            # Auto created consumers use the filter subject, unless the user
+            # already supplied a filter (singular or plural) on the config.
+            if not config.filter_subjects and not config.filter_subject:
                 config.filter_subject = subject
 
             # Heartbeats / FlowControl

--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -595,8 +595,9 @@ class JetStreamContext(JetStreamManager):
             if config is None:
                 config = api.ConsumerConfig()
 
-            # Auto created consumers use the filter subject, unless filter_subjects is set.
-            if not config.filter_subjects:
+            # Auto created consumers use the filter subject, unless the user
+            # already supplied a filter (singular or plural) on the config.
+            if not config.filter_subjects and not config.filter_subject:
                 config.filter_subject = subject
 
             if durable:

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -2064,6 +2064,22 @@ class SubscribeTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_pull_subscribe_preserves_config_filter_subject(self):
+        # Regression for #501: a user-supplied ConsumerConfig.filter_subject
+        # must not be overwritten with the subscribe subject.
+        nc = await nats.connect()
+        js = nc.jetstream()
+        await js.add_stream(name="orders", subjects=["ORDERS.*"])
+
+        sub = await js.pull_subscribe(
+            "ORDERS.*", durable="dur", config=nats.js.api.ConsumerConfig(filter_subject="ORDERS.new")
+        )
+        info = await sub.consumer_info()
+        assert info.config.filter_subject == "ORDERS.new"
+
+        await nc.close()
+
+    @async_test
     async def test_queue_subscribe_deliver_group(self):
         nc = await nats.connect()
         js = nc.jetstream()

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -2050,6 +2050,20 @@ class ConsumerPauseResumeTest(SingleJetStreamServerTestCase):
 
 class SubscribeTest(SingleJetStreamServerTestCase):
     @async_test
+    async def test_subscribe_preserves_config_filter_subject(self):
+        # Regression for #501: a user-supplied ConsumerConfig.filter_subject
+        # must not be overwritten with the subscribe subject.
+        nc = await nats.connect()
+        js = nc.jetstream()
+        await js.add_stream(name="orders", subjects=["ORDERS.*"])
+
+        sub = await js.subscribe("ORDERS.*", config=nats.js.api.ConsumerConfig(filter_subject="ORDERS.new"))
+        info = await sub.consumer_info()
+        assert info.config.filter_subject == "ORDERS.new"
+
+        await nc.close()
+
+    @async_test
     async def test_queue_subscribe_deliver_group(self):
         nc = await nats.connect()
         js = nc.jetstream()


### PR DESCRIPTION
The auto-create path guarded on `filter_subjects` (plural) but assigned `filter_subject` (singular), so a config that set only the singular field had it silently overwritten with the subscribe subject.

Fixes #501.