### PR TITLE
Honor explicit inactive_threshold of 0 in KV watch

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -429,7 +429,7 @@ class JetStreamContext(JetStreamManager):
             if deliver_policy:
                 # NOTE: deliver_policy is defaulting to ALL so check is different for this one.
                 config.deliver_policy = deliver_policy
-            if inactive_threshold:
+            if inactive_threshold is not None:
                 config.inactive_threshold = inactive_threshold
 
             # Create inbox for push consumer, if deliver_subject is not assigned already.

--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -571,7 +571,8 @@ class KeyValue:
             deliver_policy = api.DeliverPolicy.LAST_PER_SUBJECT
 
         # Cleanup watchers after 5 minutes of inactivity by default. An
-        # explicit 0 disables the inactivity cleanup so the watch runs forever.
+        # explicit 0 is forwarded as-is instead of being replaced by the
+        # default, letting the server decide the behavior for the consumer.
         if inactive_threshold is None:
             inactive_threshold = 5 * 60
 

--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -570,8 +570,9 @@ class KeyValue:
         if not include_history:
             deliver_policy = api.DeliverPolicy.LAST_PER_SUBJECT
 
-        # Cleanup watchers after 5 minutes of inactivity by default.
-        if not inactive_threshold:
+        # Cleanup watchers after 5 minutes of inactivity by default. An
+        # explicit 0 disables the inactivity cleanup so the watch runs forever.
+        if inactive_threshold is None:
             inactive_threshold = 5 * 60
 
         watcher._sub = await self._js.subscribe(

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3173,6 +3173,30 @@ class KVTest(SingleJetStreamServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_kv_watch_inactive_threshold_zero(self):
+        # Regression for #580: an explicit inactive_threshold of 0 must be
+        # honored (watch forever) rather than being treated as falsey and
+        # overridden with the 5 minute default.
+        nc = await nats.connect()
+        js = nc.jetstream()
+        kv = await js.create_key_value(bucket="WATCHFOREVER")
+
+        watcher = await kv.watch("key")
+        info = await watcher._sub.consumer_info()
+        assert info.config.inactive_threshold == 5 * 60
+        await watcher.stop()
+
+        # An explicit 0 is no longer clobbered to the 5 minute default; it is
+        # passed through, so the server (which imposes its own minimum for
+        # ordered consumers) decides rather than the client forcing 300s.
+        watcher = await kv.watch("key", inactive_threshold=0)
+        info = await watcher._sub.consumer_info()
+        assert info.config.inactive_threshold < 5 * 60
+        await watcher.stop()
+
+        await nc.close()
+
+    @async_test
     async def test_not_kv(self):
         errors = []
 

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -3175,8 +3175,12 @@ class KVTest(SingleJetStreamServerTestCase):
     @async_test
     async def test_kv_watch_inactive_threshold_zero(self):
         # Regression for #580: an explicit inactive_threshold of 0 must be
-        # honored (watch forever) rather than being treated as falsey and
-        # overridden with the 5 minute default.
+        # honored rather than being treated as falsey and overridden with the
+        # 5 minute default.
+        from unittest import mock
+
+        from nats.js.manager import JetStreamManager
+
         nc = await nats.connect()
         js = nc.jetstream()
         kv = await js.create_key_value(bucket="WATCHFOREVER")
@@ -3186,12 +3190,20 @@ class KVTest(SingleJetStreamServerTestCase):
         assert info.config.inactive_threshold == 5 * 60
         await watcher.stop()
 
-        # An explicit 0 is no longer clobbered to the 5 minute default; it is
-        # passed through, so the server (which imposes its own minimum for
-        # ordered consumers) decides rather than the client forcing 300s.
-        watcher = await kv.watch("key", inactive_threshold=0)
-        info = await watcher._sub.consumer_info()
-        assert info.config.inactive_threshold < 5 * 60
+        # An explicit 0 is forwarded to the server as-is instead of being
+        # replaced by the default. Assert against the config the client sends
+        # rather than the round-tripped value, since the server rewrites 0 to
+        # its own minimum for ordered consumers.
+        sent = []
+        original = JetStreamManager.add_consumer
+
+        async def capture(self, stream, config=None, **kwargs):
+            sent.append(config)
+            return await original(self, stream, config=config, **kwargs)
+
+        with mock.patch.object(JetStreamManager, "add_consumer", capture):
+            watcher = await kv.watch("key", inactive_threshold=0)
+        assert sent[-1].inactive_threshold == 0
         await watcher.stop()
 
         await nc.close()


### PR DESCRIPTION
`watch()` used a truthiness check on `inactive_threshold`, so an explicit `0` (disable the inactivity cleanup) was indistinguishable from `None` and got overridden with the 5 minute default. Check against `None`.

Fixes #580.