### PR TITLE
Honor ConsumerConfig.durable_name in pull_subscribe

### DIFF
--- a/nats/src/nats/js/client.py
+++ b/nats/src/nats/js/client.py
@@ -580,6 +580,12 @@ class JetStreamContext(JetStreamManager):
         if stream is None:
             stream = await self._jsm.find_stream_name_by_subject(subject)
 
+        # Honor a durable name supplied through the config when the durable
+        # argument is omitted, so the consumer is created (and looked up) as a
+        # durable rather than a fresh ephemeral each call.
+        if durable is None and config is not None and config.durable_name:
+            durable = config.durable_name
+
         should_create = True
         try:
             if durable:

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -276,6 +276,22 @@ class PublishTest(SingleJetStreamServerTestCase):
 
 class PullSubscribeTest(SingleJetStreamServerTestCase):
     @async_test
+    async def test_pull_subscribe_honors_config_durable_name(self):
+        # Regression for #603: a durable_name supplied via ConsumerConfig must
+        # be honored when the durable argument is omitted, instead of silently
+        # creating a fresh ephemeral consumer.
+        nc = await nats.connect()
+        js = nc.jetstream()
+        await js.add_stream(name="pdur", subjects=["pdur"])
+
+        sub = await js.pull_subscribe("pdur", config=nats.js.api.ConsumerConfig(durable_name="mydurable"))
+        info = await sub.consumer_info()
+        assert info.name == "mydurable"
+        assert info.config.durable_name == "mydurable"
+
+        await nc.close()
+
+    @async_test
     async def test_auto_create_consumer(self):
         nc = NATS()
         await nc.connect()

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -284,10 +284,16 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         js = nc.jetstream()
         await js.add_stream(name="pdur", subjects=["pdur"])
 
-        sub = await js.pull_subscribe("pdur", config=nats.js.api.ConsumerConfig(durable_name="mydurable"))
+        config = nats.js.api.ConsumerConfig(durable_name="mydurable")
+        sub = await js.pull_subscribe("pdur", config=config)
         info = await sub.consumer_info()
         assert info.name == "mydurable"
         assert info.config.durable_name == "mydurable"
+
+        rebound = await js.pull_subscribe("pdur", config=config)
+        rebound_info = await rebound.consumer_info()
+        assert rebound_info.name == info.name
+        assert rebound_info.created == info.created
 
         await nc.close()
 


### PR DESCRIPTION
When the durable was supplied only through the config, `pull_subscribe` generated an ephemeral name while leaving `durable_name` set, so the server rejected the mismatched request. Resolve the durable from `config.durable_name` before the lookup.

Fixes #603.