### PR TITLE
Resolve WebSocket close task when connect never established

### DIFF
--- a/nats/src/nats/aio/transport.py
+++ b/nats/src/nats/aio/transport.py
@@ -264,6 +264,12 @@ class WebSocketTransport(Transport):
 
     def close(self):
         if not self._ws:
+            # A connect attempt that failed before the websocket was
+            # established leaves _ws unset. Resolve _close_task so a later
+            # wait_closed() does not block forever on the pending future
+            # created in __init__.
+            if not self._close_task.done():
+                self._close_task.set_result(None)
             return
         self._close_task = asyncio.create_task(self._ws.close())
 

--- a/nats/src/nats/aio/transport.py
+++ b/nats/src/nats/aio/transport.py
@@ -257,19 +257,14 @@ class WebSocketTransport(Transport):
             await self._ws.send_bytes(message)
 
     async def wait_closed(self):
-        await self._close_task
+        if self._ws is not None:
+            await self._close_task
         if self._client:
             await self._client.close()
         self._ws = self._client = None
 
     def close(self):
-        if not self._ws:
-            # A connect attempt that failed before the websocket was
-            # established leaves _ws unset. Resolve _close_task so a later
-            # wait_closed() does not block forever on the pending future
-            # created in __init__.
-            if not self._close_task.done():
-                self._close_task.set_result(None)
+        if self._ws is None:
             return
         self._close_task = asyncio.create_task(self._ws.close())
 

--- a/nats/tests/test_client_websocket.py
+++ b/nats/tests/test_client_websocket.py
@@ -37,6 +37,20 @@ class WebSocketTest(SingleWebSocketServerTestCase):
         await nc.close()
 
     @async_test
+    async def test_close_after_failed_connect_does_not_hang(self):
+        # Regression for #969: if a wss connect fails before the websocket is
+        # established, _ws stays None; close()/wait_closed() must not hang on
+        # the unresolved _close_task created in __init__.
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        from nats.aio.transport import WebSocketTransport
+
+        transport = WebSocketTransport()
+        transport.close()
+        await asyncio.wait_for(transport.wait_closed(), timeout=2)
+
+    @async_test
     async def test_request_with_headers(self):
         if not aiohttp_installed:
             pytest.skip("aiohttp not installed")

--- a/nats/tests/test_client_websocket.py
+++ b/nats/tests/test_client_websocket.py
@@ -1,8 +1,11 @@
 import asyncio
 import unittest
+from unittest import mock
 
 import pytest
 from nats.aio.errors import *
+from nats.aio.transport import WebSocketTransport
+from nats.errors import NoServersError
 
 import nats
 from tests.utils import *
@@ -13,6 +16,38 @@ try:
     aiohttp_installed = True
 except ModuleNotFoundError:
     aiohttp_installed = False
+
+
+class WebSocketTransportTest(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+
+    def tearDown(self):
+        self.loop.close()
+
+    @async_test
+    async def test_close_after_failed_connect_does_not_hang(self):
+        """A failed WebSocket connect must not make Client.close hang."""
+        if not aiohttp_installed:
+            pytest.skip("aiohttp not installed")
+
+        async def fail_connect(*args, **kwargs):
+            raise OSError("websocket connect failed")
+
+        async def ignore_error(error):
+            pass
+
+        nc = nats.NATS()
+        with mock.patch.object(WebSocketTransport, "connect", fail_connect):
+            with pytest.raises(NoServersError):
+                await nc.connect(
+                    "ws://localhost:8080",
+                    max_reconnect_attempts=1,
+                    reconnect_time_wait=0,
+                    error_cb=ignore_error,
+                )
+
+        await asyncio.wait_for(nc.close(), timeout=2)
 
 
 class WebSocketTest(SingleWebSocketServerTestCase):
@@ -35,20 +70,6 @@ class WebSocketTest(SingleWebSocketServerTestCase):
         self.assertEqual(msg.headers["hello"], "world-1")
 
         await nc.close()
-
-    @async_test
-    async def test_close_after_failed_connect_does_not_hang(self):
-        # Regression for #969: if a wss connect fails before the websocket is
-        # established, _ws stays None; close()/wait_closed() must not hang on
-        # the unresolved _close_task created in __init__.
-        if not aiohttp_installed:
-            pytest.skip("aiohttp not installed")
-
-        from nats.aio.transport import WebSocketTransport
-
-        transport = WebSocketTransport()
-        transport.close()
-        await asyncio.wait_for(transport.wait_closed(), timeout=2)
 
     @async_test
     async def test_request_with_headers(self):


### PR DESCRIPTION
`WebSocketTransport.close()` early-returned when `_ws` was `None`, leaving the `_close_task` future unresolved, so a wss connect that failed before the socket was established hung `Client.close()` forever. Resolve the task in that case, mirroring the TcpTransport fix.

Fixes #969.