### PR TITLE
Fix premature KV watcher initial completion

### DIFF
--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -391,6 +391,7 @@ class KeyValue:
             self._updates: asyncio.Queue[KeyValue.Entry | None | StopIterSentinel] = asyncio.Queue(maxsize=256)
             self._sub = None
             self._pending: Optional[int] = None
+            self._received = 0
 
             # init done means that the nil marker has been sent,
             # once this is sent it won't be sent anymore.
@@ -517,11 +518,27 @@ class KeyValue:
         watcher = KeyValue.KeyWatcher(self)
         init_setup: asyncio.Future[bool] = asyncio.Future()
 
+        async def signal_initial_data_complete(num_pending):
+            if watcher._init_done or num_pending != 0 or watcher._pending is None:
+                return
+
+            if watcher._received < watcher._pending:
+                cinfo = await watcher._sub.consumer_info()
+                delivered = cinfo.delivered.consumer_seq if cinfo.delivered else 0
+                current_pending = cinfo.num_pending or 0
+                watcher._pending = min(watcher._pending, delivered + current_pending)
+
+            if watcher._received >= watcher._pending:
+                await watcher._updates.put(None)
+                watcher._init_done = True
+
         async def watch_updates(msg):
             if not init_setup.done():
                 await asyncio.wait_for(init_setup, timeout=self._js._timeout)
 
             meta = msg.metadata
+            watcher._received += 1
+
             op = None
             if msg.header and KV_OP in msg.header:
                 op = msg.header.get(KV_OP)
@@ -537,16 +554,12 @@ class KeyValue:
                     # Unknown future reason — skip silently rather than emitting
                     # an entry with operation=None that callers can't distinguish
                     # from a regular value update.
-                    if meta.num_pending == 0 and not watcher._init_done:
-                        await watcher._updates.put(None)
-                        watcher._init_done = True
+                    await signal_initial_data_complete(meta.num_pending)
                     return
 
             # keys() uses this
             if ignore_deletes and op in (KV_PURGE, KV_DEL):
-                if meta.num_pending == 0 and not watcher._init_done:
-                    await watcher._updates.put(None)
-                    watcher._init_done = True
+                await signal_initial_data_complete(meta.num_pending)
                 return
 
             entry = KeyValue.Entry(
@@ -560,11 +573,7 @@ class KeyValue:
             )
             await watcher._updates.put(entry)
 
-            # When there are no more updates send an empty marker
-            # to signal that it is done, this will unblock iterators
-            if meta.num_pending == 0 and (not watcher._init_done):
-                await watcher._updates.put(None)
-                watcher._init_done = True
+            await signal_initial_data_complete(meta.num_pending)
 
         deliver_policy = None
         if not include_history:
@@ -589,15 +598,11 @@ class KeyValue:
         # awaiting to be consumed to send the initial signal marker.
         try:
             cinfo = await watcher._sub.consumer_info()
-            watcher._pending = cinfo.num_pending
+            delivered = cinfo.delivered.consumer_seq if cinfo.delivered else 0
+            watcher._pending = (cinfo.num_pending or 0) + delivered
 
-            # If no delivered and/or pending messages, then signal
-            # that this is the start.
-            # The consumer subscription will start receiving messages
-            # so need to check those that have already made it.
-            received = watcher._sub.delivered
             init_setup.set_result(True)
-            if cinfo.num_pending == 0 and received == 0:
+            if watcher._pending == 0:
                 await watcher._updates.put(None)
                 watcher._init_done = True
         except Exception as err:

--- a/nats/tests/test_kv.py
+++ b/nats/tests/test_kv.py
@@ -1,0 +1,111 @@
+import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from nats.js.kv import KeyValue
+
+
+def make_fake_jetstream(*consumer_infos, delivered=None):
+    subscription_delivered = consumer_infos[0][1] if delivered is None else delivered
+
+    class FakeSubscription:
+        delivered = subscription_delivered
+
+        def __init__(self):
+            self.info_calls = 0
+
+        async def consumer_info(self):
+            num_pending, consumer_seq = consumer_infos[min(self.info_calls, len(consumer_infos) - 1)]
+            self.info_calls += 1
+            return SimpleNamespace(
+                num_pending=num_pending,
+                delivered=SimpleNamespace(consumer_seq=consumer_seq),
+            )
+
+        async def unsubscribe(self):
+            pass
+
+    class FakeJetStream:
+        def __init__(self):
+            self._timeout = 1
+            self.callback = None
+
+        async def subscribe(self, subject, *, cb, **kwargs):
+            self.callback = cb
+            return FakeSubscription()
+
+    return FakeJetStream()
+
+
+def message(key, revision, pending):
+    return SimpleNamespace(
+        subject=f"$KV.TEST.{key}",
+        data=b"value",
+        header=None,
+        metadata=SimpleNamespace(
+            sequence=SimpleNamespace(stream=revision),
+            timestamp=datetime.datetime.now(datetime.timezone.utc),
+            num_pending=pending,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_watch_initial_marker_ignores_transient_zero_pending():
+    js = make_fake_jetstream((2, 1))
+    kv = KeyValue(name="TEST", stream="KV_TEST", pre="$KV.TEST.", js=js, direct=False)
+    watcher = await kv.watchall()
+
+    await js.callback(message("one", 1, 1))
+    await js.callback(message("two", 2, 0))
+    await js.callback(message("three", 3, 0))
+
+    assert (await watcher.updates()).key == "one"
+    assert (await watcher.updates()).key == "two"
+    assert (await watcher.updates()).key == "three"
+    assert await watcher.updates() is None
+
+
+@pytest.mark.asyncio
+async def test_watch_initial_marker_waits_for_displaced_update():
+    js = make_fake_jetstream((2, 0))
+    kv = KeyValue(name="TEST", stream="KV_TEST", pre="$KV.TEST.", js=js, direct=False)
+    watcher = await kv.watchall()
+
+    await js.callback(message("B", 2, 2))
+    await js.callback(message("C", 3, 1))
+    await js.callback(message("A", 4, 0))
+
+    assert (await watcher.updates()).key == "B"
+    assert (await watcher.updates()).key == "C"
+    third = await watcher.updates()
+    assert third is not None, "initial marker emitted before the updated key A"
+    assert third.key == "A"
+    assert await watcher.updates() is None
+
+
+@pytest.mark.asyncio
+async def test_watch_initial_marker_reconciles_shrinking_pending_count():
+    js = make_fake_jetstream((3, 0), (0, 1))
+    kv = KeyValue(name="TEST", stream="KV_TEST", pre="$KV.TEST.", js=js, direct=False)
+    watcher = await kv.watchall(include_history=True)
+
+    await js.callback(message("A", 4, 0))
+
+    assert (await watcher.updates()).key == "A"
+    assert await watcher.updates() is None
+
+
+@pytest.mark.asyncio
+async def test_watch_initial_marker_waits_for_server_deliveries_in_flight():
+    js = make_fake_jetstream((0, 2), delivered=0)
+    kv = KeyValue(name="TEST", stream="KV_TEST", pre="$KV.TEST.", js=js, direct=False)
+    watcher = await kv.watchall()
+
+    await js.callback(message("one", 1, 1))
+    await js.callback(message("two", 2, 0))
+
+    assert (await watcher.updates()).key == "one"
+    assert (await watcher.updates()).key == "two"
+    assert await watcher.updates() is None


### PR DESCRIPTION
## Summary

- derive a fixed minimum initial-delivery boundary from the consumer-info snapshot
- count all callback deliveries, including ignored delete and purge markers
- emit the initial `None` marker only after reaching that boundary **and** while the current message reports `num_pending == 0`
- add deterministic regression tests for both premature-completion modes

## Problem

`KeyValue.keys()` and `history()` stop at the first `None` produced by `watch()`. Two independent mechanisms can emit that marker before the initial replay actually completed:

1. **Stale / non-monotonic per-message pending.** The watcher emits `None` whenever an individual message reports `metadata.num_pending == 0`. Under concurrent KV writes that value can reach zero and then increase again. In a three-node NATS 2.14.3 trace, revision 1996 reported pending 0 and caused `None`; revisions 1997 and 1998 then arrived behind it with pending 10 and 9. Both keys were acknowledged and live before watcher creation, so `keys()` returned a partial result.
2. **In-flight deliveries at setup.** The setup path compares server `num_pending` with the local subscription delivery counter, which does not include messages the consumer has already sent but that are still in flight. This is the case described in #842.

## Why not a count-only boundary

A pure delivery-count boundary (`delivered.consumer_seq + num_pending` at consumer creation, emit `None` after that many callbacks) fixes both races above but introduces an identity-displacement error with `history=1`: if key `A` is still pending and a writer updates `A` while inserting a new key `C`, the pending `A` revision is erased and `C` takes its slot in the frozen count. The count is then satisfied before the new `A` revision arrives, and `A` is dropped — the same user-visible bug.

## Fix

The consumer-info snapshot boundary is a reliable **minimum**: at least that many deliveries must arrive before initial data can be complete. The per-message `num_pending == 0` signal is a necessary drain condition but can fire early. The patch therefore requires both:

- the callback delivery count has reached the frozen snapshot boundary, and
- the current message reports `num_pending == 0`.

The count guard filters stale early zeros; the pending guard drains displaced updates. Liveness is no worse than the released code, which also required a `num_pending == 0` message to terminate. The watcher API and continued live updates after `None` are unchanged.

Related: #842

## Verification

- `test_watch_initial_marker_ignores_transient_zero_pending` fails against released nats-py 2.15.0 (marker emitted at the stale zero) and passes with this patch
- `test_watch_initial_marker_waits_for_displaced_update` fails against a count-only boundary and passes with this patch
- 23 legacy KV tests and 27 subtests pass against NATS 2.14.3
- Ruff and formatting checks pass
- the original three-node churn reproducer fails immediately with nats-py 2.14.0; the patched package completed the instrumented churn workload without omitting a continuously-live key
