### PR TITLE
Add docs.nats.io examples to main

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,0 +1,62 @@
+# NATS Documentation Examples
+
+These are the Python equivalents of the docs examples published in the NATS
+documentation. They mirror the [Rust](../../../nats.rs/async-nats/examples)
+and [Java](../../../nats.java/examples/src/main/java/io/nats/examples/natsIoDoc)
+versions of the same examples.
+
+The examples use the modern [`nats-core`](../../nats-core) client (and
+[`nats-jetstream`](../../nats-jetstream) for the JetStream example).
+They require **Python 3.13+**.
+
+## Running
+
+From the workspace root:
+
+```bash
+uv sync
+uv run python examples/docs/basics_publish.py
+```
+
+Most examples connect to the public `demo.nats.io` server. The JetStream
+example (`jetstream_basic.py`) needs a local server with JetStream enabled
+on `127.0.0.1:4222` — for example:
+
+```bash
+nats-server -js
+```
+
+Examples that mix a publisher and subscriber include both in the same file
+for convenience.
+
+## Examples
+
+### Basics
+- `basics_publish.py` — publish a message to a subject
+- `basics_subscribe.py` — subscribe to a subject
+
+### Getting Started
+- `getting_started_publish.py` — minimal publisher
+- `getting_started_subscribe.py` — minimal subscriber (async + sync)
+
+### Subjects
+- `subjects_single_wildcard.py` — `*` token wildcard subscriptions
+- `subjects_multi_wildcard.py` — `>` tail wildcard subscriptions
+- `subjects_monitoring.py` — wire-tap subscription with `>`
+
+### Queue Groups
+- `queue_groups_basic.py` — three workers in a queue group
+- `queue_groups_dynamic_scaling.py` — add/remove workers at runtime
+- `queue_groups_mixed_subscribers.py` — mix of plain subs and queue subs
+- `queue_groups_request_reply.py` — load-balanced request/reply
+
+### Request / Reply
+- `request_reply_basic.py` — basic request/reply
+- `request_reply_calculator.py` — small calculator service
+- `request_reply_headers.py` — request/reply with message headers
+- `request_reply_multiple_responders.py` — multiple responders, first wins
+- `request_reply_no_responders.py` — handling no-responders
+- `request_reply_timeout.py` — request with a custom timeout
+
+### JetStream
+- `jetstream_basic.py` — create a stream, publish, durable pull consumer

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,8 +1,9 @@
 # NATS Documentation Examples
 
 These are the Python equivalents of the docs examples published in the NATS
-documentation. They mirror the [Rust](../../../nats.rs/async-nats/examples)
-and [Java](../../../nats.java/examples/src/main/java/io/nats/examples/natsIoDoc)
+documentation. They mirror the
+[Rust](https://github.com/nats-io/nats.rs/tree/main/async-nats/examples)
+and [Java](https://github.com/nats-io/nats.java/tree/main/examples/src/main/java/io/nats/examples/natsIoDoc)
 versions of the same examples.
 
 The examples use the modern [`nats-core`](../../nats-core) client (and

--- a/examples/docs/basics_publish.py
+++ b/examples/docs/basics_publish.py
@@ -1,0 +1,19 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Publish a message to the subject "weather.updates"
+    await nc.publish("weather.updates", "Temperature: 72°F".encode())
+    # NATS-DOC-END
+
+    await nc.flush()
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/basics_subscribe.py
+++ b/examples/docs/basics_subscribe.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Subscribe to 'weather.updates' synchronously
+    sub = await nc.subscribe("weather.updates")
+
+    # Process messages
+    while True:
+        try:
+            msg = await sub.next(timeout=1)
+            print(f"Received: {msg.data.decode()}")
+        except TimeoutError:
+            break
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/getting_started_publish.py
+++ b/examples/docs/getting_started_publish.py
@@ -1,0 +1,24 @@
+import asyncio
+
+from nats import client
+
+
+# NATS-DOC-START
+async def main():
+    # Connect to NATS demo server
+    nc = await client.connect("nats://demo.nats.io")
+
+    # Publish a message to the subject "hello"
+    await nc.publish("hello", b"Hello NATS!")
+    await nc.flush()
+
+    print("Message published to hello")
+
+    await nc.close()
+
+
+# NATS-DOC-END
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/getting_started_subscribe.py
+++ b/examples/docs/getting_started_subscribe.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from nats import client
+
+
+# NATS-DOC-START
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # Asynchronous subscriber - iterate messages in a background task
+    async_sub = await nc.subscribe("hello")
+
+    async def async_handler():
+        async for msg in async_sub:
+            print(f"Asynchronous Subscriber Received: {msg.data.decode()}")
+
+    asyncio.create_task(async_handler())
+
+    # Synchronous subscription
+    sync_sub = await nc.subscribe("hello")
+
+    print("Waiting for message on 'hello'")
+
+    # Process messages synchronously
+    while True:
+        try:
+            msg = await sync_sub.next(timeout=1)
+            print(f"Synchronous Subscriber Received: {msg.data.decode()}")
+        except TimeoutError:
+            break
+
+    await nc.close()
+
+
+# NATS-DOC-END
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/jetstream_basic.py
+++ b/examples/docs/jetstream_basic.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from nats import client, jetstream
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await client.connect("nats://127.0.0.1:4222")
+
+    # NATS-DOC-START
+    # JetStream context
+    js = jetstream.new(nc)
+
+    # Create a stream that captures any subject under `orders.`
+    stream = await js.create_stream(name="ORDERS", subjects=["orders.>"], storage="file")
+
+    # Publish a few orders
+    await js.publish("orders.new", b"Order #1001")
+    await js.publish("orders.new", b"Order #1002")
+    await js.publish("orders.shipped", b"Order #1001 shipped")
+
+    # Create a durable pull consumer that delivers from the beginning
+    consumer = await stream.create_or_update_consumer(
+        name="order-processor",
+        ack_policy="explicit",
+    )
+
+    # Fetch a batch and acknowledge each message
+    batch = await consumer.fetch(max_messages=3, max_wait=2.0)
+    async for msg in batch:
+        print(f"Received on {msg.subject}: {msg.data.decode()}")
+        await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_publish_subscribe_publish.py
+++ b/examples/docs/learn_core_nats_publish_subscribe_publish.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Publish one order to the orders.created subject. Publishing is
+    # fire-and-forget: the call hands the message to the server and returns.
+    order = '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}'
+    await client.publish("orders.created", order.encode())
+    # NATS-DOC-END
+
+    await client.flush()
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_publish_subscribe_subscribe.py
+++ b/examples/docs/learn_core_nats_publish_subscribe_subscribe.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Subscribe as the warehouse service to orders.created. Each matching
+    # message is delivered to this subscription as it is published.
+    async with await client.subscribe("orders.created") as subscription:
+        async for message in subscription:
+            print(f"warehouse received: {message.data.decode()}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_queue_groups_queue_subscribe.py
+++ b/examples/docs/learn_core_nats_queue_groups_queue_subscribe.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Join the "packers" queue group on orders.created. Every subscriber that
+    # names the same group shares the load: each order is delivered to exactly
+    # one member. Run this in several processes to watch the load balance.
+    async with await client.subscribe("orders.created", queue="packers") as subscription:
+        async for message in subscription:
+            print(f"packer handling: {message.data.decode()}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_request_reply_replies.py
+++ b/examples/docs/learn_core_nats_request_reply_replies.py
@@ -1,0 +1,35 @@
+import asyncio
+import uuid
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Gather more than one reply to a single request. A plain request() returns
+    # only the first reply, so when several services may answer, subscribe to
+    # your own inbox and collect replies until they stop arriving.
+    order = '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}'
+    inbox = f"_INBOX.{uuid.uuid4().hex}"
+    async with await client.subscribe(inbox) as subscription:
+        await client.publish("orders.inventory.check", order.encode(), reply=inbox)
+
+        replies = []
+        while True:
+            try:
+                # Stop once no further reply arrives within the gap deadline.
+                message = await subscription.next(timeout=0.3)
+                replies.append(message.data.decode())
+            except TimeoutError:
+                break
+
+    print(f"gathered {len(replies)} replies: {replies}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_request_reply_request.py
+++ b/examples/docs/learn_core_nats_request_reply_request.py
@@ -1,0 +1,29 @@
+import asyncio
+
+from nats.client import connect
+from nats.client.errors import NoRespondersError
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Ask the inventory service whether an order's item is in stock. The client
+    # creates a private inbox, sends the request, and waits up to the timeout
+    # for one reply. A missing service surfaces immediately as
+    # NoRespondersError; a slow one surfaces as TimeoutError.
+    order = '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}'
+    try:
+        reply = await client.request("orders.inventory.check", order.encode(), timeout=2.0)
+        print(f"inventory replied: {reply.data.decode()}")
+    except NoRespondersError:
+        print("no inventory service is running")
+    except TimeoutError:
+        print("inventory service did not answer in time")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_request_reply_respond.py
+++ b/examples/docs/learn_core_nats_request_reply_respond.py
@@ -1,0 +1,22 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # The inventory service: subscribe to orders.inventory.check and answer
+    # every request by publishing back to the reply subject each one carries.
+    async with await client.subscribe("orders.inventory.check") as subscription:
+        async for message in subscription:
+            if message.reply:
+                await client.publish(message.reply, b'{"in_stock":true,"warehouse":"us-east"}')
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_scatter_gather_gather.py
+++ b/examples/docs/learn_core_nats_scatter_gather_gather.py
@@ -1,0 +1,35 @@
+import asyncio
+import uuid
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Scatter one request to every shipping-quote provider and gather the
+    # replies. Subscribe to a private inbox, publish the request with that inbox
+    # as the reply subject, then collect quotes until they stop arriving and
+    # pick the cheapest.
+    order = '{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}'
+    inbox = f"_INBOX.{uuid.uuid4().hex}"
+    async with await client.subscribe(inbox) as subscription:
+        await client.publish("shipping.quote", order.encode(), reply=inbox)
+
+        quotes = []
+        while True:
+            try:
+                message = await subscription.next(timeout=0.3)
+                quotes.append(message.data.decode())
+            except TimeoutError:
+                break
+
+    print(f"gathered {len(quotes)} quotes: {quotes}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_scatter_gather_provider.py
+++ b/examples/docs/learn_core_nats_scatter_gather_provider.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # A shipping-quote provider. Subscribe plainly to shipping.quote (NOT in a
+    # queue group, so every provider sees each request) and reply with a price.
+    # Run several copies, each quoting a different number.
+    async with await client.subscribe("shipping.quote") as subscription:
+        async for message in subscription:
+            if message.reply:
+                await client.publish(message.reply, b'{"carrier":"carrier-a","quote_cents":1500}')
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_subjects_and_wildcards_wildcard_multi.py
+++ b/examples/docs/learn_core_nats_subjects_and_wildcards_wildcard_multi.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Audit service: catch every order message at any depth. The multi-token
+    # wildcard > matches one or more tokens and must be the last token, so
+    # orders.> matches orders.created, orders.us.created, and
+    # orders.us.west.created alike.
+    async with await client.subscribe("orders.>") as subscription:
+        async for message in subscription:
+            print(f"audit: {message.subject}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_core_nats_subjects_and_wildcards_wildcard_single.py
+++ b/examples/docs/learn_core_nats_subjects_and_wildcards_wildcard_single.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from nats.client import connect
+
+
+async def main():
+    client = await connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # Regional analytics: one subscription catches created orders from every
+    # region. The single-token wildcard * matches exactly one token, so both
+    # orders.us.created and orders.eu.created match, while orders.created and
+    # orders.us.west.created do not.
+    async with await client.subscribe("orders.*.created") as subscription:
+        async for message in subscription:
+            print(f"analytics: new order on {message.subject}")
+    # NATS-DOC-END
+
+    await client.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_acknowledgment_nak_with_delay.py
+++ b/examples/docs/learn_jetstream_acknowledgment_nak_with_delay.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer and pull a single message.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    msgs = await psub.fetch(batch=1, timeout=5)
+    msg = msgs[0]
+    print(f"{msg.subject}: {msg.data.decode()}")
+
+    # Negative ack with a delay: redeliver this message after 10 seconds.
+    await msg.nak(delay=10)
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_acknowledgment_term_poison.py
+++ b/examples/docs/learn_jetstream_acknowledgment_term_poison.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer and pull a single message.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    msgs = await psub.fetch(batch=1, timeout=5)
+    msg = msgs[0]
+    print(f"{msg.subject}: {msg.data.decode()}")
+
+    # Terminate a poison message: stop delivery for good, no redelivery.
+    await msg.term()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_acknowledgment_watch_max_deliveries.py
+++ b/examples/docs/learn_jetstream_acknowledgment_watch_max_deliveries.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # NATS-DOC-START
+    # JetStream publishes an advisory when a message hits its max delivery limit.
+    # Subscribe with the core API to watch them for the shipping consumer.
+    subject = "$JS.EVENT.ADVISORY.CONSUMER.MAX_DELIVERIES.ORDERS.shipping"
+
+    async def handler(msg):
+        print(f"max deliveries advisory: {msg.data.decode()}")
+
+    await nc.subscribe(subject, cb=handler)
+    print(f"Watching {subject}")
+
+    # Keep the subscription open to receive advisories as they arrive.
+    await asyncio.sleep(60)
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_advanced_publishing_async.py
+++ b/examples/docs/learn_jetstream_advanced_publishing_async.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # nats.py has no dedicated async-publish API: publish() already returns a
+    # coroutine, so the async-publish pattern is to start them all and gather
+    # the results instead of awaiting one at a time. The round trips overlap,
+    # but the client does not bound how many are in flight -- check every ack,
+    # and add your own limit for large bursts.
+    orders = [
+        b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200}',
+        b'{"order_id":"ord_2zr9","customer":"globex","total_cents":7800}',
+        b'{"order_id":"ord_5t1m","customer":"initech","total_cents":1500}',
+        b'{"order_id":"ord_9p3x","customer":"hooli","total_cents":9900}',
+    ]
+
+    pending = [js.publish("orders.created", order) for order in orders]
+    results = await asyncio.gather(*pending, return_exceptions=True)
+
+    for i, result in enumerate(results, start=1):
+        if isinstance(result, Exception):
+            print(f"order {i} failed, re-publish it: {result}")
+        else:
+            print(f"order {i} stored at sequence {result.seq}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_advanced_publishing_atomic.py
+++ b/examples/docs/learn_jetstream_advanced_publishing_atomic.py
@@ -1,0 +1,51 @@
+import asyncio
+
+from nats.jetstream.headers import (
+    NATS_BATCH_COMMIT,
+    NATS_BATCH_COMMIT_FINAL,
+    NATS_BATCH_ID,
+    NATS_BATCH_SEQUENCE,
+)
+
+import nats
+from nats import jetstream
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # JetStream context over the connection (jetstream.new takes the client).
+    js = jetstream.new(nc)
+
+    # Ensure the "ORDERS" stream exists with atomic batch publishing enabled.
+    try:
+        config = jetstream.StreamConfig(name="ORDERS", subjects=["orders.>"], allow_atomic=True)
+        await js.create_stream(config)
+    except jetstream.StreamNameAlreadyInUseError:
+        pass
+
+    # NATS-DOC-START
+    # Atomic batch (ADR-50): tag each line item with one batch id and a rising
+    # sequence, then mark the last one committed. The server stores all three or
+    # none, and sends a single ack -- on the commit -- for the whole batch.
+    batch = "ord_8w2k-batch"
+    await js.client.request(
+        "orders.created", b'{"sku":"TEE"}', headers={NATS_BATCH_ID: batch, NATS_BATCH_SEQUENCE: "1"}
+    )
+    await js.client.publish(
+        "orders.created", b'{"sku":"MUG"}', headers={NATS_BATCH_ID: batch, NATS_BATCH_SEQUENCE: "2"}
+    )
+    ack = await js.publish(
+        "orders.created",
+        b'{"sku":"CAP"}',
+        headers={NATS_BATCH_ID: batch, NATS_BATCH_SEQUENCE: "3", NATS_BATCH_COMMIT: NATS_BATCH_COMMIT_FINAL},
+    )
+    print(f"committed batch {ack.batch_id}: {ack.batch_size} messages stored")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_filtering_create_filtered.py
+++ b/examples/docs/learn_jetstream_filtering_create_filtered.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from nats.js.api import AckPolicy, ConsumerConfig
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create a durable pull consumer that only sees orders.shipped.
+    # The filter is applied server-side: orders.created never reaches this consumer.
+    await js.add_consumer(
+        "ORDERS",
+        ConsumerConfig(
+            durable_name="analytics",
+            ack_policy=AckPolicy.EXPLICIT,
+            filter_subject="orders.shipped",
+        ),
+    )
+    print("Created filtered consumer analytics on stream ORDERS")
+
+    # Fetch a small batch. Only orders.shipped messages come back.
+    psub = await js.pull_subscribe_bind("analytics", stream="ORDERS")
+    msgs = await psub.fetch(batch=5, timeout=2)
+    for msg in msgs:
+        print(f"got {msg.subject}")
+        await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_filtering_filter_matches_nothing.py
+++ b/examples/docs/learn_jetstream_filtering_filter_matches_nothing.py
@@ -1,0 +1,41 @@
+import asyncio
+
+import nats.errors
+from nats.js.api import AckPolicy, ConsumerConfig
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Note the typo: "orders.shiped" matches no subject in the stream.  # codespell:ignore shiped
+    # JetStream accepts the consumer anyway. The wrong filter fails silently.
+    await js.add_consumer(
+        "ORDERS",
+        ConsumerConfig(
+            durable_name="analytics-typo",
+            ack_policy=AckPolicy.EXPLICIT,
+            filter_subject="orders.shiped",  # codespell:ignore shiped
+        ),
+    )
+
+    psub = await js.pull_subscribe_bind("analytics-typo", stream="ORDERS")
+    try:
+        await psub.fetch(batch=5, timeout=2)
+    except nats.errors.TimeoutError:
+        # No error from the server. The pull simply returned nothing because the
+        # filter matched no stored subject. A wrong filter looks like an empty stream.
+        print("Fetch timed out: the filter matched no stored subject")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_get_direct_by_sequence.py
+++ b/examples/docs/learn_jetstream_get_direct_by_sequence.py
@@ -1,0 +1,26 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Get one stored message by its sequence number — the number the PubAck
+    # returned when it was published. This regular get is served by the
+    # stream's leader, so it always sees the latest write.
+    msg = await js.get_msg("ORDERS", seq=2)
+
+    print(f"seq {msg.seq} on {msg.subject}: {msg.data.decode()}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_get_direct_direct_read.py
+++ b/examples/docs/learn_jetstream_get_direct_direct_read.py
@@ -1,0 +1,26 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Read directly from the stream's store with the Direct Get API. With
+    # direct=True the read is served by any server holding a copy of the
+    # stream, not just the leader (the stream must have allow_direct set).
+    msg = await js.get_msg("ORDERS", seq=1, direct=True)
+
+    print(f"seq {msg.seq} on {msg.subject} (direct): {msg.data.decode()}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_get_direct_enable.py
+++ b/examples/docs/learn_jetstream_get_direct_enable.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # Fetch the current ORDERS configuration so we can flip one field.
+    info = await js.stream_info("ORDERS")
+    config = info.config
+
+    # NATS-DOC-START
+    # Turn on Direct Get for the stream. With allow_direct enabled, get-message
+    # requests can be served by any replica instead of only the stream leader.
+    config.allow_direct = True
+    updated = await js.update_stream(config)
+
+    print(f"allow_direct is now {updated.config.allow_direct}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_get_direct_last_for_subject.py
+++ b/examples/docs/learn_jetstream_get_direct_last_for_subject.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Get the most recent message stored on a subject, when you know the
+    # subject but not the sequence. This is the read a key-value lookup uses.
+    msg = await js.get_last_msg("ORDERS", "orders.shipped")
+
+    print(f"seq {msg.seq} on {msg.subject}: {msg.data.decode()}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_message_ttl_publish_with_ttl.py
+++ b/examples/docs/learn_jetstream_message_ttl_publish_with_ttl.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from nats.js.api import StreamConfig
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # Create a stream that allows per-message TTLs. Without allow_msg_ttl the
+    # server ignores the Nats-TTL header. Requires NATS Server 2.11+.
+    await js.add_stream(
+        StreamConfig(
+            name="ORDERS",
+            subjects=["orders.>"],
+            allow_msg_ttl=True,
+        )
+    )
+
+    # NATS-DOC-START
+    # Publish with a Nats-TTL header so the server deletes this message 60
+    # seconds after it's stored, no matter what the stream would otherwise keep.
+    ack = await js.publish(
+        "orders.cancelled",
+        b'{"id": "A-1001", "reason": "customer"}',
+        headers={"Nats-TTL": "60s"},
+    )
+
+    print(f"stored in {ack.stream} at sequence {ack.seq}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_message_ttl_publish_with_ttl.py
+++ b/examples/docs/learn_jetstream_message_ttl_publish_with_ttl.py
@@ -26,7 +26,7 @@ async def main():
     # Publish with a Nats-TTL header so the server deletes this message 60
     # seconds after it's stored, no matter what the stream would otherwise keep.
     ack = await js.publish(
-        "orders.cancelled",
+        "orders.canceled",
         b'{"id": "A-1001", "reason": "customer"}',
         headers={"Nats-TTL": "60s"},
     )

--- a/examples/docs/learn_jetstream_message_ttl_ttl_on_disabled_stream.py
+++ b/examples/docs/learn_jetstream_message_ttl_ttl_on_disabled_stream.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from nats.js.api import StreamConfig
+from nats.js.errors import APIError
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # Create a stream that does NOT allow per-message TTLs (allow_msg_ttl
+    # defaults to off), so the server rejects any Nats-TTL header.
+    await js.add_stream(
+        StreamConfig(
+            name="ORDERS_NO_TTL",
+            subjects=["no-ttl.>"],
+        )
+    )
+
+    # NATS-DOC-START
+    # Publishing with a Nats-TTL header fails when the stream doesn't allow
+    # per-message TTLs. The server rejects it with err_code 10166 and stores
+    # nothing.
+    try:
+        await js.publish(
+            "no-ttl.msg",
+            b'{"id": "A-1002"}',
+            headers={"Nats-TTL": "60s"},
+        )
+    except APIError as e:
+        # "per-message TTL is disabled" — the fix is to create or update the
+        # stream with allow_msg_ttl=True.
+        print(f"publish rejected: {e.description} (err_code {e.err_code})")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_mirrors_and_sources_create_mirror.py
+++ b/examples/docs/learn_jetstream_mirrors_and_sources_create_mirror.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from nats.js.api import StreamSource
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create ORDERS-ARCHIVE as a read-only mirror of ORDERS. A mirror takes
+    # no subjects of its own; it follows the upstream stream.
+    info = await js.add_stream(name="ORDERS-ARCHIVE", mirror=StreamSource(name="ORDERS"))
+
+    print(f"Created mirror {info.config.name} of {info.config.mirror.name}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_mirrors_and_sources_create_source.py
+++ b/examples/docs/learn_jetstream_mirrors_and_sources_create_source.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from nats.js.api import StreamSource
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # Setup: the three regional streams ALL-ORDERS aggregates, each with its own subjects.
+    await js.add_stream(name="ORDERS-US", subjects=["us.orders.>"])
+    await js.add_stream(name="ORDERS-EU", subjects=["eu.orders.>"])
+    await js.add_stream(name="ORDERS-APAC", subjects=["apac.orders.>"])
+
+    # NATS-DOC-START
+    # Create ALL-ORDERS as an aggregate that sources the three regional streams
+    # into one. Unlike a mirror, a stream can list several sources.
+    info = await js.add_stream(
+        name="ALL-ORDERS",
+        sources=[
+            StreamSource(name="ORDERS-US"),
+            StreamSource(name="ORDERS-EU"),
+            StreamSource(name="ORDERS-APAC"),
+        ],
+    )
+
+    print(f"Created {info.config.name} sourcing {len(info.config.sources)} streams")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_mirrors_and_sources_mirror_lag.py
+++ b/examples/docs/learn_jetstream_mirrors_and_sources_mirror_lag.py
@@ -1,0 +1,27 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # A mirror is eventually consistent. Read its lag before trusting it to
+    # hold what the upstream just received: 0 means fully caught up.
+    info = await js.stream_info("ORDERS-ARCHIVE")
+
+    print(f"Upstream:  {info.mirror.name}")
+    print(f"Lag:       {info.mirror.lag}")
+    print(f"Last seen: {info.mirror.active}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_ordered_consumer_read.py
+++ b/examples/docs/learn_jetstream_ordered_consumer_read.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from nats.js.api import DeliverPolicy
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Ask for an ordered consumer with ordered_consumer=True. There's no ack to
+    # send: nats.py runs the consumer for you and recreates it if it ever misses
+    # a message, so you read every order in stream order. deliver_policy=ALL
+    # starts from the first order.
+    psub = await js.subscribe(
+        "orders.>",
+        stream="ORDERS",
+        ordered_consumer=True,
+        deliver_policy=DeliverPolicy.ALL,
+    )
+
+    # Read the whole log once, in order, stopping when caught up (num_pending 0).
+    while True:
+        msg = await psub.next_msg(timeout=5)
+        print(f"order {msg.data.decode()}")
+        if msg.metadata.num_pending == 0:
+            break
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_publishing_confirm_stored.py
+++ b/examples/docs/learn_jetstream_publishing_confirm_stored.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Publish one order. The publish only resolves once the server has stored
+    # the message, so reading the acknowledgement confirms it is durable.
+    ack = await js.publish(
+        "orders.created",
+        b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}',
+    )
+
+    # The stream name and sequence number prove the message is stored.
+    print(f"Confirmed stored in {ack.stream} at sequence {ack.seq}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_publishing_dedup.py
+++ b/examples/docs/learn_jetstream_publishing_dedup.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Set "Nats-Msg-Id" so the server can detect duplicates within the stream's
+    # duplicate window.
+    payload = b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}'
+    headers = {"Nats-Msg-Id": "ord_8w2k-created"}
+
+    # Publish the same message twice with the same id.
+    first = await js.publish("orders.created", payload, headers=headers)
+    print(f"First:  sequence {first.seq}, duplicate {first.duplicate}")
+
+    second = await js.publish("orders.created", payload, headers=headers)
+    print(f"Second: sequence {second.seq}, duplicate {second.duplicate}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_publishing_pub_ack.py
+++ b/examples/docs/learn_jetstream_publishing_pub_ack.py
@@ -1,0 +1,31 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Publish one order and inspect the acknowledgement the server returns.
+    ack = await js.publish(
+        "orders.created",
+        b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}',
+    )
+
+    # The PubAck reports which stream stored the message, the sequence it was
+    # assigned, and whether it was rejected as a duplicate.
+    print(f"Stream:    {ack.stream}")
+    print(f"Sequence:  {ack.seq}")
+    print(f"Duplicate: {ack.duplicate}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_publishing_sync.py
+++ b/examples/docs/learn_jetstream_publishing_sync.py
@@ -1,0 +1,39 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Publish three orders. Each publish waits for the server's acknowledgement,
+    # which carries the stream name and the assigned sequence number.
+    ack = await js.publish(
+        "orders.created",
+        b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:22Z"}',
+    )
+    print(f"Stored in {ack.stream}, sequence {ack.seq}")
+
+    ack = await js.publish(
+        "orders.created",
+        b'{"order_id":"ord_2zr9","customer":"globex","total_cents":7800,"ts":"2026-05-22T10:14:25Z"}',
+    )
+    print(f"Stored in {ack.stream}, sequence {ack.seq}")
+
+    ack = await js.publish(
+        "orders.shipped",
+        b'{"order_id":"ord_8w2k","customer":"acme-co","total_cents":4200,"ts":"2026-05-22T10:14:31Z"}',
+    )
+    print(f"Stored in {ack.stream}, sequence {ack.seq}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_pull_consumers_consume_continuous.py
+++ b/examples/docs/learn_jetstream_pull_consumers_consume_continuous.py
@@ -1,0 +1,34 @@
+import asyncio
+
+import nats.errors
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable "shipping" consumer.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    # nats.py drives a pull consumer with fetch, so a continuous flow is a fetch
+    # loop: pull a batch, process it, come back. fetch times out when nothing is
+    # waiting; keep looping so new orders are picked up as soon as they land.
+    while True:
+        try:
+            msgs = await psub.fetch(batch=10, timeout=5)
+        except nats.errors.TimeoutError:
+            continue
+        for msg in msgs:
+            print(f"shipping {msg.data.decode()}")
+            await msg.ack()
+    # NATS-DOC-END
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_pull_consumers_empty_fetch.py
+++ b/examples/docs/learn_jetstream_pull_consumers_empty_fetch.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import nats.errors
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable "shipping" consumer.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    # On a drained consumer, fetch raises TimeoutError once the timeout passes.
+    # Treat that as "nothing right now," not a failure: catch it, wait, and
+    # fetch again instead of crashing.
+    try:
+        msgs = await psub.fetch(batch=10, timeout=2)
+    except nats.errors.TimeoutError:
+        print("no orders waiting, will retry")
+        msgs = []
+
+    for msg in msgs:
+        print(f"shipping {msg.data.decode()}")
+        await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_pull_consumers_fetch_batch.py
+++ b/examples/docs/learn_jetstream_pull_consumers_fetch_batch.py
@@ -1,0 +1,30 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable "shipping" consumer.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    # Fetch a batch of up to 10 orders, waiting up to 2 seconds for them. The
+    # call returns the messages it has when the batch is full or the timeout
+    # passes. Process and ack each, then fetch again to keep going.
+    msgs = await psub.fetch(batch=10, timeout=2)
+    for msg in msgs:
+        print(f"shipping {msg.data.decode()}")
+        await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_reading_back_create.py
+++ b/examples/docs/learn_jetstream_reading_back_create.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create a durable consumer that reads the whole stream from the start.
+    # add_consumer is idempotent: calling it again with the same config is a no-op.
+    await js.add_consumer(
+        "ORDERS",
+        ConsumerConfig(
+            durable_name="billing",
+            ack_policy=AckPolicy.EXPLICIT,
+            deliver_policy=DeliverPolicy.ALL,
+        ),
+    )
+    print("Created durable consumer billing on stream ORDERS")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_reading_back_read.py
+++ b/examples/docs/learn_jetstream_reading_back_read.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import nats.errors
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer created earlier and pull every stored message.
+    psub = await js.pull_subscribe_bind("billing", stream="ORDERS")
+
+    # Fetch in batches until a fetch times out, which means the stream is drained.
+    # The consumer uses explicit ack, so acknowledge each message after handling it.
+    while True:
+        try:
+            msgs = await psub.fetch(batch=100, timeout=1)
+        except nats.errors.TimeoutError:
+            break
+
+        for msg in msgs:
+            print(
+                f"stream seq {msg.metadata.sequence.stream}, "
+                f"consumer seq {msg.metadata.sequence.consumer}: "
+                f"{msg.data.decode()}"
+            )
+            await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_retention_policies_retention_switch_rejected.py
+++ b/examples/docs/learn_jetstream_retention_policies_retention_switch_rejected.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from nats.js.api import RetentionPolicy, StreamConfig
+from nats.js.errors import APIError
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams and consumers.
+    js = nc.jetstream()
+
+    # Make sure the FULFILLMENT WorkQueue stream exists.
+    await js.add_stream(
+        StreamConfig(
+            name="FULFILLMENT",
+            subjects=["fulfill.>"],
+            retention=RetentionPolicy.WORK_QUEUE,
+        )
+    )
+
+    # NATS-DOC-START
+    # Read the current config and try to switch FULFILLMENT from WorkQueue to
+    # Limits retention. The server refuses: retention is fixed at create time,
+    # so you cannot turn a queue into a record (or back) on an existing stream.
+    info = await js.stream_info("FULFILLMENT")
+    try:
+        await js.update_stream(info.config, retention=RetentionPolicy.LIMITS)
+        print("retention changed (unexpected)")
+    except APIError as e:
+        print(f"retention switch rejected: {e}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_retention_policies_work_queue_create.py
+++ b/examples/docs/learn_jetstream_retention_policies_work_queue_create.py
@@ -1,0 +1,57 @@
+import asyncio
+import json
+
+from nats.js.api import AckPolicy, ConsumerConfig, RetentionPolicy, StreamConfig
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams and consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # FULFILLMENT is the queue of paid orders awaiting shipment. WorkQueue
+    # retention delivers each order to a single worker; the first ack removes
+    # it for everyone, so the stream drains to empty.
+    info = await js.add_stream(
+        StreamConfig(
+            name="FULFILLMENT",
+            subjects=["fulfill.>"],
+            retention=RetentionPolicy.WORK_QUEUE,
+        )
+    )
+    print(f"FULFILLMENT retention is {info.config.retention}")
+
+    # A paid order arrives and needs shipping.
+    await js.publish(
+        "fulfill.us",
+        json.dumps({"order_id": "ord_8w2k", "customer": "acme-co"}).encode(),
+    )
+
+    # Shipping workers pull from a durable consumer with explicit ack.
+    await js.add_consumer(
+        "FULFILLMENT",
+        ConsumerConfig(durable_name="shippers", ack_policy=AckPolicy.EXPLICIT),
+    )
+
+    # A worker takes one order and acks it once the order has shipped.
+    psub = await js.pull_subscribe_bind("shippers", stream="FULFILLMENT")
+    msgs = await psub.fetch(batch=1, timeout=5)
+    await msgs[0].ack()
+    print(f"shipped {msgs[0].data.decode()}")
+
+    # The ack removed the task, so the WorkQueue stream is now empty. A Limits
+    # stream like ORDERS would still hold the message after the ack.
+    info = await js.stream_info("FULFILLMENT")
+    print(f"messages left in FULFILLMENT: {info.state.messages}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_retention_policies_workqueue_overlap.py
+++ b/examples/docs/learn_jetstream_retention_policies_workqueue_overlap.py
@@ -1,0 +1,72 @@
+import asyncio
+
+from nats.js.api import AckPolicy, ConsumerConfig, RetentionPolicy, StreamConfig
+from nats.js.errors import APIError
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams and consumers.
+    js = nc.jetstream()
+
+    # Make sure the FULFILLMENT WorkQueue stream exists.
+    await js.add_stream(
+        StreamConfig(
+            name="FULFILLMENT",
+            subjects=["fulfill.>"],
+            retention=RetentionPolicy.WORK_QUEUE,
+        )
+    )
+
+    # NATS-DOC-START
+    # One unfiltered consumer covers every fulfill.> subject. That is allowed.
+    await js.add_consumer(
+        "FULFILLMENT",
+        ConsumerConfig(durable_name="shippers", ack_policy=AckPolicy.EXPLICIT),
+    )
+    print("added unfiltered consumer shippers")
+
+    # A WorkQueue stream gives each message to exactly one consumer, so two
+    # consumers whose subjects overlap would compete for the same orders. A
+    # second unfiltered consumer overlaps with the first and is rejected.
+    try:
+        await js.add_consumer(
+            "FULFILLMENT",
+            ConsumerConfig(durable_name="eu-shippers", ack_policy=AckPolicy.EXPLICIT),
+        )
+    except APIError as e:
+        print(f"second unfiltered consumer rejected: {e}")
+
+    # Drop the unfiltered consumer so the subject space is free again.
+    await js.delete_consumer("FULFILLMENT", "shippers")
+
+    # Filtered consumers work as long as their subjects do not overlap. Split
+    # the queue by region: one worker pool per destination.
+    await js.add_consumer(
+        "FULFILLMENT",
+        ConsumerConfig(
+            durable_name="us-shippers",
+            filter_subject="fulfill.us",
+            ack_policy=AckPolicy.EXPLICIT,
+        ),
+    )
+    await js.add_consumer(
+        "FULFILLMENT",
+        ConsumerConfig(
+            durable_name="eu-shippers",
+            filter_subject="fulfill.eu",
+            ack_policy=AckPolicy.EXPLICIT,
+        ),
+    )
+    print("added filtered consumers us-shippers and eu-shippers")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_shaping_the_stream_discard_new.py
+++ b/examples/docs/learn_jetstream_shaping_the_stream_discard_new.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from nats.js.api import DiscardPolicy
+from nats.js.errors import APIError
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Switch ORDERS to Discard New. Discard New never drops stored messages, so
+    # capping it at one message leaves the existing orders in place and puts the
+    # stream instantly over its limit; the next publish is rejected.
+    info = await js.stream_info("ORDERS")
+    config = info.config
+    config.discard = DiscardPolicy.NEW
+    config.max_msgs = 1
+    await js.update_stream(config)
+
+    # This publish hits the full stream and is rejected instead of succeeding
+    # silently. Handle it in the publisher.
+    try:
+        await js.publish("orders.created", b'{"order_id":"ord_8w2k"}')
+    except APIError as err:
+        print(f"publish rejected: {err.description}")
+
+    # Put ORDERS back: Discard Old, no message cap (age and byte limits stay).
+    config.discard = DiscardPolicy.OLD
+    config.max_msgs = -1
+    await js.update_stream(config)
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_shaping_the_stream_per_subject_limit.py
+++ b/examples/docs/learn_jetstream_shaping_the_stream_per_subject_limit.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Add a per-subject ceiling so one noisy subject can't evict another's
+    # messages. max_msgs_per_subject keeps the most recent N messages for every
+    # subject independently, alongside the whole-stream limits.
+    info = await js.stream_info("ORDERS")
+    config = info.config
+    config.max_msgs_per_subject = 100000
+    await js.update_stream(config)
+    print("ORDERS now keeps 100000 messages per subject")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_shaping_the_stream_set_limits.py
+++ b/examples/docs/learn_jetstream_shaping_the_stream_set_limits.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Cap ORDERS with a seven-day age limit and a 1 GiB byte ceiling. Fetch the
+    # current config, set the limits, and update the stream in place; the stored
+    # messages stay put. max_age is in seconds.
+    info = await js.stream_info("ORDERS")
+    config = info.config
+    config.max_age = 7 * 24 * 3600  # 7 days
+    config.max_bytes = 1024 * 1024 * 1024  # 1 GiB
+    await js.update_stream(config)
+    print("ORDERS capped at 7d age and 1 GiB")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_subject_mapping_republish.py
+++ b/examples/docs/learn_jetstream_subject_mapping_republish.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from nats.js.api import RePublish
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # Fetch the current ORDERS configuration so we can add republish to it.
+    info = await js.stream_info("ORDERS")
+    config = info.config
+
+    # NATS-DOC-START
+    # Republish every stored orders.> message onto a dash.orders.> subject, so
+    # core subscribers can watch the stream live without a consumer.
+    # Set headers_only=True to republish just the headers, not the body.
+    config.republish = RePublish(
+        src="orders.>",
+        dest="dash.orders.>",
+        # headers_only=True,
+    )
+    updated = await js.update_stream(config)
+
+    print(f"republishing to {updated.config.republish.dest}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_subject_mapping_transform.py
+++ b/examples/docs/learn_jetstream_subject_mapping_transform.py
@@ -1,0 +1,38 @@
+import asyncio
+
+from nats.js.api import StreamConfig, SubjectTransform
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create a stream that rewrites subjects as it stores them. Incoming
+    # ingest.<customer> messages become orders.<bucket>.<customer>, where
+    # partition(3,1) hashes the first wildcard token into one of three
+    # buckets — sharding each customer into a fixed partition.
+    info = await js.add_stream(
+        StreamConfig(
+            name="ORDERS-SHARDED",
+            subjects=["ingest.*"],
+            subject_transform=SubjectTransform(
+                src="ingest.*",
+                dest="orders.{{partition(3,1)}}.{{wildcard(1)}}",
+            ),
+        )
+    )
+
+    print(f"created stream {info.config.name}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_worker_pool_max_pending.py
+++ b/examples/docs/learn_jetstream_worker_pool_max_pending.py
@@ -1,0 +1,36 @@
+import asyncio
+
+from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Raise max_ack_pending so a larger pool can hold more orders in progress at
+    # once. The cap is shared across the whole "shipping" consumer, not per
+    # worker, so size it to at least your worker count. add_consumer with an
+    # existing durable updates it in place.
+    await js.add_consumer(
+        "ORDERS",
+        ConsumerConfig(
+            durable_name="shipping",
+            ack_policy=AckPolicy.EXPLICIT,
+            deliver_policy=DeliverPolicy.ALL,
+            max_ack_pending=5000,
+        ),
+    )
+    print("shipping max_ack_pending set to 5000")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_worker_pool_redelivery_count.py
+++ b/examples/docs/learn_jetstream_worker_pool_redelivery_count.py
@@ -1,0 +1,40 @@
+import asyncio
+
+import nats.errors
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable "shipping" consumer.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    # Each message records how many times it has been delivered. A count above
+    # one means a redelivery: the server handed this order out before, but a
+    # worker crashed or ran past AckWait before acking. Key your side effects by
+    # order_id so handling the same order twice is harmless.
+    try:
+        msgs = await psub.fetch(batch=10, timeout=1)
+    except nats.errors.TimeoutError:
+        msgs = []
+
+    for msg in msgs:
+        if msg.metadata.num_delivered > 1:
+            print(f"redelivery #{msg.metadata.num_delivered} of {msg.data.decode()}")
+        else:
+            print(f"first delivery of {msg.data.decode()}")
+        await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_worker_pool_worker.py
+++ b/examples/docs/learn_jetstream_worker_pool_worker.py
@@ -1,0 +1,36 @@
+import asyncio
+
+import nats.errors
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable "shipping" consumer created earlier. Run this same
+    # program in several processes: they all share the one consumer, and the
+    # server splits the stored orders across them, one order to one worker.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    # Pull one order at a time and ack it. fetch times out when nothing is
+    # waiting; keep looping so the worker stays ready for the next order.
+    while True:
+        try:
+            msgs = await psub.fetch(batch=1, timeout=5)
+        except nats.errors.TimeoutError:
+            continue
+
+        for msg in msgs:
+            print(f"shipping {msg.data.decode()}")
+            await msg.ack()
+    # NATS-DOC-END
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_consumer_create.py
+++ b/examples/docs/learn_jetstream_your_first_consumer_create.py
@@ -1,0 +1,33 @@
+import asyncio
+
+from nats.js.api import AckPolicy, ConsumerConfig, DeliverPolicy
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create a durable pull consumer that reads the whole stream from the start.
+    # add_consumer is idempotent: calling it again with the same config is a no-op.
+    await js.add_consumer(
+        "ORDERS",
+        ConsumerConfig(
+            durable_name="shipping",
+            ack_policy=AckPolicy.EXPLICIT,
+            deliver_policy=DeliverPolicy.ALL,
+        ),
+    )
+    print("Created durable consumer shipping on stream ORDERS")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_consumer_double_ack.py
+++ b/examples/docs/learn_jetstream_your_first_consumer_double_ack.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer and pull a single message.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    msgs = await psub.fetch(batch=1, timeout=5)
+    msg = msgs[0]
+    print(f"{msg.subject}: {msg.data.decode()}")
+
+    # Double ack: wait for the server to confirm the ack was recorded.
+    await msg.ack_sync()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_consumer_next.py
+++ b/examples/docs/learn_jetstream_your_first_consumer_next.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer and pull a single message.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    msgs = await psub.fetch(batch=1, timeout=5)
+    msg = msgs[0]
+    print(f"{msg.subject}: {msg.data.decode()}")
+
+    # No ack here. The message stays in flight and is redelivered after Ack Wait.
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_consumer_pull_and_ack.py
+++ b/examples/docs/learn_jetstream_your_first_consumer_pull_and_ack.py
@@ -1,0 +1,29 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages consumers.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Bind to the durable consumer and pull a single message.
+    psub = await js.pull_subscribe_bind("shipping", stream="ORDERS")
+
+    msgs = await psub.fetch(batch=1, timeout=5)
+    msg = msgs[0]
+    print(f"{msg.subject}: {msg.data.decode()}")
+
+    # Explicit ack removes the message from this consumer's pending list.
+    await msg.ack()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_stream_create.py
+++ b/examples/docs/learn_jetstream_your_first_stream_create.py
@@ -1,0 +1,25 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Create the "ORDERS" stream, capturing every subject under "orders.".
+    info = await js.add_stream(name="ORDERS", subjects=["orders.>"])
+
+    # Confirm success by printing the stream name the server returned.
+    print(f"Created stream: {info.config.name}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/learn_jetstream_your_first_stream_info.py
+++ b/examples/docs/learn_jetstream_your_first_stream_info.py
@@ -1,0 +1,28 @@
+import asyncio
+
+import nats
+
+
+async def main():
+    # JetStream requires a server with JetStream enabled (demo.nats.io does not).
+    nc = await nats.connect("nats://localhost:4222")
+
+    # Get a JetStream context, which also manages streams.
+    js = nc.jetstream()
+
+    # NATS-DOC-START
+    # Fetch the latest information about the "ORDERS" stream.
+    info = await js.stream_info("ORDERS")
+
+    # Print key fields: name and subjects come from the config,
+    # the live message count comes from the stream state.
+    print(f"Stream:   {info.config.name}")
+    print(f"Subjects: {info.config.subjects}")
+    print(f"Messages: {info.state.messages}")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/queue_groups_basic.py
+++ b/examples/docs/queue_groups_basic.py
@@ -1,0 +1,36 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    async def worker(sub, name):
+        async for msg in sub:
+            print(f"Worker {name} Received: {msg.data.decode()}")
+
+    sub_a = await nc.subscribe("orders.new", queue="new-orders-queue")
+    sub_b = await nc.subscribe("orders.new", queue="new-orders-queue")
+    sub_c = await nc.subscribe("orders.new", queue="new-orders-queue")
+
+    asyncio.create_task(worker(sub_a, "A"))
+    asyncio.create_task(worker(sub_b, "B"))
+    asyncio.create_task(worker(sub_c, "C"))
+
+    # flush() waits for the server to acknowledge all pending commands.
+    # This ensures all subscriptions are at the server before publish starts.
+    await nc.flush(timeout=1)
+
+    for i in range(1, 11):
+        await nc.publish("orders.new", f"Order {i}".encode())
+    # NATS-DOC-END
+
+    # give time for all the messages to be received
+    await asyncio.sleep(1)
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/queue_groups_dynamic_scaling.py
+++ b/examples/docs/queue_groups_dynamic_scaling.py
@@ -1,0 +1,49 @@
+import asyncio
+
+from nats import client
+
+
+# NATS-DOC-START
+class Worker:
+    def __init__(self, worker_id):
+        self.id = worker_id
+        self.subscription = None
+        self.task = None
+
+    async def start(self, nc, subject, queue):
+        self.subscription = await nc.subscribe(subject, queue=queue)
+        self.task = asyncio.create_task(self._run())
+
+    async def _run(self):
+        async for msg in self.subscription:
+            print(f"Worker {self.id} processing: {msg.data.decode()}")
+
+    async def stop(self):
+        await self.subscription.unsubscribe()
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    workers = []
+    subject = "tasks"
+    queue = "workers"
+
+    # Scale up
+    for i in range(1, 6):
+        w = Worker(i)
+        await w.start(nc, subject, queue)
+        workers.append(w)
+
+    # Scale down
+    for w in workers:
+        await w.stop()
+
+    await nc.close()
+
+
+# NATS-DOC-END
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/queue_groups_mixed_subscribers.py
+++ b/examples/docs/queue_groups_mixed_subscribers.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    async def reader(sub, label):
+        async for msg in sub:
+            print(f"[{label}] {msg.subject}: {msg.data.decode()}")
+
+    # Audit logger - receives all messages
+    audit_sub = await nc.subscribe("orders.>")
+    asyncio.create_task(reader(audit_sub, "AUDIT"))
+
+    # Metrics collector - receives all messages
+    metrics_sub = await nc.subscribe("orders.>")
+    asyncio.create_task(reader(metrics_sub, "METRICS"))
+
+    # Workers in queue group - load balanced
+    worker_a_sub = await nc.subscribe("orders.new", queue="new-orders-queue")
+    asyncio.create_task(reader(worker_a_sub, "WORKER A"))
+
+    worker_b_sub = await nc.subscribe("orders.new", queue="new-orders-queue")
+    asyncio.create_task(reader(worker_b_sub, "WORKER B"))
+
+    await nc.flush()
+
+    # Publish order
+    await nc.publish("orders.new", b"Order 123")
+    await nc.publish("orders.new", b"Order 124")
+    # Audit and metrics see them, one worker processes each
+    # NATS-DOC-END
+
+    await asyncio.sleep(0.5)
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/queue_groups_request_reply.py
+++ b/examples/docs/queue_groups_request_reply.py
@@ -1,0 +1,42 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    async def service_instance(sub, instance_id):
+        async for msg in sub:
+            parts = msg.data.decode().split(",")
+            result = int(parts[0]) + int(parts[1])
+            response = f"Result: {result}, processed by: instance-{instance_id}"
+            if msg.reply:
+                await nc.publish(msg.reply, response.encode())
+            print(f"Instance instance-{instance_id} processed request")
+
+    # Set up 3 instances of the service
+    for i in range(1, 4):
+        sub = await nc.subscribe("api.calculate", queue="api-workers-queue")
+        asyncio.create_task(service_instance(sub, i))
+
+    await nc.flush()
+
+    # Make requests - messages are balanced among the subscribers in the queue
+    for i in range(10):
+        data = f"{i},{i * 2}"
+        try:
+            m = await nc.request("api.calculate", data.encode(), timeout=0.5)
+            print(m.data.decode())
+        except (TimeoutError, NoRespondersError):
+            print(f"{i}) No Response")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_basic.py
+++ b/examples/docs/request_reply_basic.py
@@ -1,0 +1,37 @@
+import asyncio
+from datetime import datetime, timezone
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Set up a service
+    sub = await nc.subscribe("time")
+
+    async def time_service():
+        async for msg in sub:
+            now = datetime.now(timezone.utc).isoformat()
+            if msg.reply:
+                await nc.publish(msg.reply, now.encode())
+
+    asyncio.create_task(time_service())
+    await nc.flush()
+
+    # Make a request with a timeout and direct response
+    try:
+        m = await nc.request("time", b"", timeout=1)
+        print(f"Response: {m.data.decode()}")
+    except (TimeoutError, NoRespondersError):
+        print("Request failed, no response.")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_calculator.py
+++ b/examples/docs/request_reply_calculator.py
@@ -1,0 +1,50 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Calculator service
+    sub = await nc.subscribe("calc.add")
+
+    async def calc_service():
+        async for msg in sub:
+            # data is in the form "x y"
+            try:
+                parts = msg.data.decode().split()
+                if len(parts) == 2 and msg.reply:
+                    x = int(parts[0])
+                    y = int(parts[1])
+                    await nc.publish(msg.reply, str(x + y).encode())
+            except Exception:
+                # you could send some other reply here
+                pass
+
+    asyncio.create_task(calc_service())
+    await nc.flush()
+
+    # Make a request with a timeout
+    try:
+        m = await nc.request("calc.add", b"5 3", timeout=0.5)
+        print(f"5 + 3 = {m.data.decode()}")
+    except (TimeoutError, NoRespondersError):
+        print("1) No Response")
+
+    # Make another request
+    try:
+        m = await nc.request("calc.add", b"10 7", timeout=0.5)
+        print(f"10 + 7 = {m.data.decode()}")
+    except (TimeoutError, NoRespondersError):
+        print("2) No Response")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_headers.py
+++ b/examples/docs/request_reply_headers.py
@@ -1,0 +1,45 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Header aware service
+    sub = await nc.subscribe("service")
+
+    async def service():
+        async for msg in sub:
+            response_headers: dict[str, str | list[str]] = {}
+            if msg.headers:
+                request_id = msg.headers.get("X-Request-ID") or ""
+                response_headers["X-Response-ID"] = request_id
+                for key, values in msg.headers.items():
+                    response_headers[key] = values
+            if msg.reply:
+                await nc.publish(msg.reply, msg.data, headers=response_headers)
+
+    asyncio.create_task(service())
+    await nc.flush()
+
+    # Make a request with headers
+    headers = {"X-Request-ID": "123", "X-Priority": "high"}
+    try:
+        m = await nc.request("service", b"data", timeout=0.5, headers=headers)
+        data = m.data.decode() if m.data else ""
+        print(f"Response: {data}")
+        if m.headers:
+            print(f"Response ID: {m.headers.get('X-Response-ID')}")
+    except (TimeoutError, NoRespondersError):
+        print("No Response")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_multiple_responders.py
+++ b/examples/docs/request_reply_multiple_responders.py
@@ -1,0 +1,37 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Multiple responders - only the first response is returned to the requester
+    sub_a = await nc.subscribe("calc.add")
+    sub_b = await nc.subscribe("calc.add")
+
+    async def service(sub, label):
+        async for msg in sub:
+            if msg.reply:
+                await nc.publish(msg.reply, f"calculated result from {label}".encode())
+
+    asyncio.create_task(service(sub_a, "A"))
+    asyncio.create_task(service(sub_b, "B"))
+    await nc.flush()
+
+    # Gets one response
+    try:
+        m = await nc.request("calc.add", b"", timeout=0.5)
+        print(f"Got response: {m.data.decode()}")
+    except (TimeoutError, NoRespondersError):
+        print("No Response")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_no_responders.py
+++ b/examples/docs/request_reply_no_responders.py
@@ -1,0 +1,25 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    try:
+        m = await nc.request("no.such.service", b"test", timeout=0.5)
+        print(f"Response: {m.data.decode()}")
+    except NoRespondersError:
+        print("No services available to handle request")
+    except TimeoutError:
+        print("Request timed out")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/request_reply_timeout.py
+++ b/examples/docs/request_reply_timeout.py
@@ -1,0 +1,26 @@
+import asyncio
+
+from nats.client.errors import NoRespondersError
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Request with custom timeout
+    try:
+        m = await nc.request("service", b"data", timeout=2)
+        print(f"Response: {m.data.decode()}")
+    except TimeoutError:
+        print("Request timed out")
+    except NoRespondersError:
+        print("No responders for the request")
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/subjects_monitoring.py
+++ b/examples/docs/subjects_monitoring.py
@@ -1,0 +1,39 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Create a wire tap for monitoring - subscribe to everything
+    sub = await nc.subscribe(">")
+    received = asyncio.Event()
+    seen = 0
+
+    async def monitor():
+        nonlocal seen
+        async for msg in sub:
+            seen += 1
+            print(f"[MONITOR] {msg.subject} --> {msg.data.decode()}")
+            if seen >= 3:
+                received.set()
+
+    asyncio.create_task(monitor())
+    await nc.flush()
+
+    # Publish a message to various subjects
+    await nc.publish("hello", b"Hello NATS!")
+    await nc.publish("event.new", b"click")
+    await nc.publish("weather.north.fr", "Temperature: 11°C".encode())
+
+    print("Waiting for messages...")
+    await received.wait()
+    # NATS-DOC-END
+
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/subjects_multi_wildcard.py
+++ b/examples/docs/subjects_multi_wildcard.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Subscribe to all alarms
+    sub_alarm = await nc.subscribe("sensor.alarm.*")
+
+    # Subscribe to all critical
+    sub_critical = await nc.subscribe("sensor.*.*.critical")
+
+    # Subscribe to everything under sensor
+    sub_all = await nc.subscribe("sensor.>")
+
+    async def reader(sub, label):
+        async for msg in sub:
+            print(f"[{label:<22}] {msg.data.decode():<15} ({msg.subject})")
+
+    asyncio.create_task(reader(sub_alarm, "sensor.alarm.*"))
+    asyncio.create_task(reader(sub_critical, "sensor.*.*.critical"))
+    asyncio.create_task(reader(sub_all, "sensor.>"))
+
+    await nc.flush()
+
+    # Publish to specific subjects
+    await nc.publish("sensor.alarm.smoke", b"kitchen,14:22")
+    await nc.publish("sensor.alarm.smoke.critical", b"kitchen,14:23")
+    await nc.publish("sensor.alarm.water", b"basement,16:42")
+    await nc.publish("sensor.alarm.water.critical", b"basement,16:43")
+    # NATS-DOC-END
+
+    await asyncio.sleep(0.5)
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/docs/subjects_single_wildcard.py
+++ b/examples/docs/subjects_single_wildcard.py
@@ -1,0 +1,41 @@
+import asyncio
+
+from nats import client
+
+
+async def main():
+    nc = await client.connect("nats://demo.nats.io")
+
+    # NATS-DOC-START
+    # Subscribe to shipped orders
+    sub_shipped = await nc.subscribe("orders.*.shipped")
+
+    # Subscribe to placed orders
+    sub_placed = await nc.subscribe("orders.*.placed")
+
+    # Subscribe to retail orders
+    sub_retail = await nc.subscribe("orders.retail.*")
+
+    async def reader(sub, label):
+        async for msg in sub:
+            print(f"[{label:<18}] {msg.data.decode()}  ({msg.subject})")
+
+    asyncio.create_task(reader(sub_shipped, "orders.*.shipped"))
+    asyncio.create_task(reader(sub_placed, "orders.*.placed"))
+    asyncio.create_task(reader(sub_retail, "orders.retail.*"))
+
+    await nc.flush()
+
+    # Publish to specific subjects
+    await nc.publish("orders.wholesale.placed", b"Order W73737")
+    await nc.publish("orders.retail.placed", b"Order R65432")
+    await nc.publish("orders.wholesale.shipped", b"Order W73001")
+    await nc.publish("orders.retail.shipped", b"Order R65321")
+    # NATS-DOC-END
+
+    await asyncio.sleep(0.5)
+    await nc.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Moves the documentation examples from the `doc-examples`, `core-docs` and `jetstream-docs` branches into `examples/docs/` on main (71 files, additive union).

Why: the new docs.nats.io build fetches these snippets at build time. On side branches they were failing `check` (import order + codespell) and can be broken by branch pruning; on main, ruff format/lint + codespell cover them on every PR.

Included fixes: `ruff format` (5 files), `ruff check --fix` (28 import-order errors), and `# codespell:ignore` markers on the intentional `orders.shiped` teaching typo in `learn_jetstream_filtering_filter_matches_nothing.py` (the example demonstrates a filter typo that matches nothing — the misspelling is the point). Verified locally: `ruff format --check`, `ruff check`, and root `codespell` all pass.

Note: please keep the docs branches until the docs repo's fetch config is switched to `main` (follow-up PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)