### PR TITLE
Fix ack floor race in consumer reset test

### DIFF
--- a/nats-jetstream/tests/test_consumer.py
+++ b/nats-jetstream/tests/test_consumer.py
@@ -1127,9 +1127,11 @@ async def test_consumer_reset_to_ack_floor(jetstream: JetStream):
     )
 
     # Consume and ack the first two messages so the ack floor advances.
+    # double_ack waits for the server to apply each ack; a plain ack is
+    # fire-and-forget, so the floor read below could still observe zero.
     batch = await consumer.fetch(max_messages=2, max_wait=1.0)
     async for msg in batch:
-        await msg.ack()
+        await msg.double_ack()
 
     info = await stream.get_consumer_info("reset_floor")
     floor = info.ack_floor["stream_seq"]


### PR DESCRIPTION
The `nats-jetstream` job started running in CI with #998, and `test_consumer_reset_to_ack_floor` fails on most runs: it acks with plain `ack()` (fire-and-forget) then immediately reads `ack_floor` to derive the expected `reset_seq`, so the server has usually not applied the acks yet.

`double_ack()` waits for server confirmation. Reproduced locally at 2/40 trials with `ack()`, 0/40 with `double_ack()`.

Currently the only thing failing CI on #913, #938, #939, #940 and #941.