### PR TITLE
Deduplicate CI runs and finish full matrices

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,12 +2,18 @@ name: check
 on:
     push:
         branches:
-            - "*"
+            - main
     pull_request:
         branches:
-            - "*"
+            - "**"
 permissions:
     contents: read
+
+# Pull requests supersede their own earlier runs; pushes to main are keyed by
+# run_id so they always run to completion.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
 jobs:
     format:
         runs-on: ubuntu-latest
@@ -97,6 +103,7 @@ jobs:
         runs-on: ubuntu-latest
         name: build
         strategy:
+            fail-fast: false
             matrix:
                 package: [nats-py, nats-core, nats-server, nats-jetstream, nats-key-value]
         steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,19 @@ name: test
 on:
     push:
         branches:
-            - "**"
+            - main
     pull_request:
         branches:
             - "**"
 
 permissions:
     contents: read
+
+# Pull requests supersede their own earlier runs; pushes to main are keyed by
+# run_id so they always run to completion.
+concurrency:
+    group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+    cancel-in-progress: true
 
 jobs:
     nats:
@@ -58,6 +64,7 @@ jobs:
         name: ${{ matrix.project }} (python-${{ matrix.python-version }}, nats-server-${{ matrix.nats-server-version }}, ${{ matrix.os }})
         runs-on: ${{ matrix.os }}
         strategy:
+            fail-fast: false
             matrix:
                 python-version: ["3.13"]
                 os: ["ubuntu-latest", "macos-latest", "windows-latest"]


### PR DESCRIPTION
Every PR was running the whole matrix twice against the same commit, because both workflows trigger on `push` **and** `pull_request` for all branches. On #1002 that produced two `test` runs for the same SHA 12 seconds apart, one of which showed up as a confusing `cancelled`.

Restricting `push` to `main` leaves `pull_request` as the single trigger for branch work. The concurrency group additionally retires a PR's earlier runs when it is pushed again; `main` pushes key on `run_id` so they always finish.

Separately, the `project` and `build` matrices had no `fail-fast` setting, so one failing leg cancelled its siblings — a single flaky ubuntu job took the macOS and Windows results with it (10-15 cancelled jobs on #938, #941 and #1002). The legacy `nats` matrix already sets `fail-fast: false`.

Note the tradeoff: pushes to a branch with no open PR no longer get CI.