### PR TITLE
Drain server output to keep shutdown from hanging

### DIFF
--- a/nats-server/src/nats/server/__init__.py
+++ b/nats-server/src/nats/server/__init__.py
@@ -31,6 +31,10 @@ from typing import Self
 # Set up logging
 logger = logging.getLogger(__name__)
 
+# Read size for the background drain; large enough that a chatty server does
+# not wake the loop per log line.
+_DRAIN_CHUNK_SIZE = 65536
+
 # Regex patterns for parsing server output
 FATAL_PATTERN = re.compile(r"\[FTL\]\s+(.*)")
 INFO_PATTERN = re.compile(r"\[INF\]\s+(.*)")
@@ -82,10 +86,23 @@ class ServerCluster:
         await self.shutdown()
 
 
+async def _drain(stream: asyncio.StreamReader) -> None:
+    """Read and discard server output until the pipe closes.
+
+    Nothing consumes the server's log output once it has reported ready. Left
+    unread, the pipe buffer fills, the server blocks on its next write, and a
+    process blocked mid-write never reaches the exit that ``wait()`` awaits.
+    """
+    with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+        while await stream.read(_DRAIN_CHUNK_SIZE):
+            pass
+
+
 class Server:
     """Process controller for a NATS server instance."""
 
     _process: asyncio.subprocess.Process | None
+    _drain_task: asyncio.Task[None] | None
     _host: str
     _port: int
     _websocket_scheme: str | None
@@ -117,6 +134,9 @@ class Server:
         self._websocket_scheme = websocket_scheme
         self._websocket_host = websocket_host
         self._websocket_port = websocket_port
+        self._drain_task = (
+            asyncio.create_task(_drain(process.stderr)) if process.stderr else None
+        )
 
     @property
     def host(self) -> str:
@@ -211,11 +231,15 @@ class Server:
             # Process didn't terminate in time, force kill
             try:
                 self._process.kill()
-                await self._process.wait()
-            except ProcessLookupError:
-                # Process already terminated, ignore
+                await asyncio.wait_for(self._process.wait(), timeout=timeout)
+            except (ProcessLookupError, asyncio.TimeoutError):
+                # Process already terminated or is not reaping, ignore
                 pass
         finally:
+            if self._drain_task is not None:
+                self._drain_task.cancel()
+                await asyncio.gather(self._drain_task, return_exceptions=True)
+                self._drain_task = None
             self._process = None
 
     async def __aenter__(self) -> Self:
@@ -293,7 +317,9 @@ async def _create_server_process(
 
     return await asyncio.create_subprocess_exec(
         *cmd,
-        stdout=asyncio.subprocess.PIPE,
+        # The server logs to stderr; stdout is never read, so keeping it as a
+        # pipe would only add a second buffer nobody drains.
+        stdout=asyncio.subprocess.DEVNULL,
         stderr=asyncio.subprocess.PIPE,
     )
 

--- a/nats-server/tests/test_server.py
+++ b/nats-server/tests/test_server.py
@@ -435,6 +435,43 @@ async def test_server_double_shutdown():
     assert server.is_running is False
 
 
+async def test_server_output_is_drained_for_process_lifetime():
+    """Test that server output keeps being consumed after startup.
+
+    The readiness parser stops reading once the server reports ready. Something
+    has to keep draining from then on, or the pipe buffer fills and the server
+    blocks on its next write.
+    """
+    server = await run(port=0, debug=True)
+
+    drain_task = server._drain_task
+    assert drain_task is not None
+    assert not drain_task.done()
+
+    await server.shutdown()
+    assert drain_task.done()
+
+
+async def test_server_shutdown_after_heavy_log_output():
+    """Test that a chatty server still shuts down promptly.
+
+    Nothing reads the server's output once it reports ready, so without a
+    background drain the stderr pipe fills, the server blocks on its next
+    write, and a process blocked mid-write never reaches the exit that
+    wait() awaits.
+    """
+    server = await run(port=0, debug=True)
+
+    # Churn connections to push well past a pipe buffer of server log output.
+    for _ in range(500):
+        _reader, writer = await asyncio.open_connection(server.host, server.port)
+        writer.close()
+        await writer.wait_closed()
+
+    await asyncio.wait_for(server.shutdown(), timeout=30)
+    assert server.is_running is False
+
+
 async def test_server_shutdown_with_timeout():
     """Test shutdown with very short timeout triggers kill path."""
     server = await run(port=0)

--- a/nats-server/tests/test_server.py
+++ b/nats-server/tests/test_server.py
@@ -462,9 +462,13 @@ async def test_server_shutdown_after_heavy_log_output():
     """
     server = await run(port=0, debug=True)
 
+    # server.host is the bind address (0.0.0.0), which is not connectable on
+    # Windows; client_url resolves it the way the other tests do.
+    parsed = urlparse(server.client_url)
+
     # Churn connections to push well past a pipe buffer of server log output.
     for _ in range(500):
-        _reader, writer = await asyncio.open_connection(server.host, server.port)
+        _reader, writer = await asyncio.open_connection(parsed.hostname, parsed.port)
         writer.close()
         await writer.wait_closed()
 


### PR DESCRIPTION
The readiness parser reads stderr only until the server reports ready, then stops. Nothing reads it after that, so the pipe buffer fills, the server blocks on its next write, and a process blocked mid-write never reaches the exit that `wait()` awaits — the [documented deadlock](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.asyncio.subprocess.Process.wait) for `Process.wait()` with a pipe. This drains stderr in the background for the lifetime of the process, and sends stdout to `DEVNULL` since it was never parsed at all.

The kill path made it unrecoverable: its `wait()` had no timeout, unlike the graceful one above it.

Both are real defects, but to be clear about scope: **this does not fix the Windows `nats-jetstream` hang.** That was originally the motivation here, and it turned out to be unrelated — the cause is an ordered consumer that never resets when its consumer stops answering, fixed in #1005. This PR stands on its own.

The deadlock cannot be reproduced on Linux or macOS at any log volume, because `terminate()` there fells a process blocked on a full pipe regardless; it needs `wait()` also waiting for pipe transports to close, as it does on Windows. The regression test therefore asserts the mechanism — that output keeps being drained after startup — which fails on any platform if the drain is removed.