### PR TITLE
Publish KV mutations through the JetStream API prefix for domain contexts

### DIFF
--- a/nats/src/nats/js/kv.py
+++ b/nats/src/nats/js/kv.py
@@ -149,6 +149,14 @@ class KeyValue:
         self._js = js
         self._direct = direct
 
+        # KV mutations publish through the JetStream API prefix when the
+        # context targets a non-default domain (nats.go useJSPfx behavior):
+        # "$JS.<domain>.API.$KV.<bucket>.<key>". Reads and watchers keep the
+        # local data subject since stream subjects are not prefixed.
+        self._mutation_pre = pre
+        if js._prefix != api.DEFAULT_PREFIX:
+            self._mutation_pre = f"{js._prefix}.{pre}"
+
     async def get(self, key: str, revision: Optional[int] = None, validate_keys: bool = True) -> Entry:
         """
         get returns the latest value for the key.
@@ -219,7 +227,7 @@ class KeyValue:
         if validate_keys and not _is_key_valid(key):
             raise nats.js.errors.InvalidKeyError(key)
 
-        pa = await self._js.publish(f"{self._pre}{key}", value)
+        pa = await self._js.publish(f"{self._mutation_pre}{key}", value)
         return pa.seq
 
     async def create(self, key: str, value: bytes, validate_keys: bool = True, msg_ttl: Optional[float] = None) -> int:
@@ -292,7 +300,7 @@ class KeyValue:
 
         pa = None
         try:
-            pa = await self._js.publish(f"{self._pre}{key}", value, headers=hdrs, msg_ttl=msg_ttl)
+            pa = await self._js.publish(f"{self._mutation_pre}{key}", value, headers=hdrs, msg_ttl=msg_ttl)
         except nats.js.errors.APIError as err:
             # Check for a BadRequest::KeyWrongLastSequenceError error code.
             # 10071: JSStreamWrongLastSequenceErrF
@@ -336,7 +344,7 @@ class KeyValue:
         if last and last > 0:
             hdrs[api.Header.EXPECTED_LAST_SUBJECT_SEQUENCE] = str(last)
 
-        await self._js.publish(f"{self._pre}{key}", headers=hdrs)
+        await self._js.publish(f"{self._mutation_pre}{key}", headers=hdrs)
         return True
 
     async def purge(self, key: str, msg_ttl: Optional[float] = None) -> bool:
@@ -349,7 +357,7 @@ class KeyValue:
         hdrs = {}
         hdrs[KV_OP] = KV_PURGE
         hdrs[api.Header.ROLLUP] = MSG_ROLLUP_SUBJECT
-        await self._js.publish(f"{self._pre}{key}", headers=hdrs, msg_ttl=msg_ttl)
+        await self._js.publish(f"{self._mutation_pre}{key}", headers=hdrs, msg_ttl=msg_ttl)
         return True
 
     async def purge_deletes(self, olderthan: int = 30 * 60) -> bool:

--- a/nats/tests/conf/js-domain.conf
+++ b/nats/tests/conf/js-domain.conf
@@ -1,0 +1,6 @@
+port: 4222
+http: 8222
+
+jetstream: {
+  domain: "test-domain"
+}

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -4372,7 +4372,6 @@ class ObjectStoreTest(SingleJetStreamServerTestCase):
 
         with pytest.raises(nats.js.errors.InvalidBucketNameError):
             await js.create_object_store(bucket="notok!")
-
         obs = await js.create_object_store(bucket="OBJS", description="testing")
         assert obs._name == "OBJS"
         assert obs._stream == "OBJ_OBJS"
@@ -4879,6 +4878,120 @@ class ObjectStoreTest(SingleJetStreamServerTestCase):
             info = await obs.put("pyproject2", f)
             assert info.name == "pyproject2"
             assert info.chunks == 1
+
+        await nc.close()
+
+
+class KVDomainTest(SingleJetStreamServerDomainTestCase):
+    async def _spy_subjects(self, nc):
+        """Record the subjects of every request/publish on this connection."""
+        subjects = []
+
+        orig_request = nc.request
+        orig_publish = nc.publish
+
+        async def request(subject, payload=b"", timeout=0.5, headers=None):
+            subjects.append(subject)
+            return await orig_request(subject, payload, timeout=timeout, headers=headers)
+
+        async def publish(subject, payload=b"", reply="", headers=None):
+            subjects.append(subject)
+            return await orig_publish(subject, payload, reply=reply, headers=headers)
+
+        nc.request = request
+        nc.publish = publish
+        return subjects
+
+    @async_test
+    async def test_kv_mutations_use_domain_qualified_subject(self):
+        """KV mutations from a domain-scoped JetStreamContext publish to the
+        domain-qualified $JS.<domain>.API.$KV.<bucket>.<key> subject.
+
+        Regression test for https://github.com/nats-io/nats.py/issues/1010.
+        """
+        nc = await nats.connect()
+        js = nc.jetstream(domain="test-domain")
+
+        kv = await js.create_key_value(bucket="TEST_DOMAIN")
+        subjects = await self._spy_subjects(nc)
+
+        await kv.put("hello", b"world")
+        assert subjects[-1] == "$JS.test-domain.API.$KV.TEST_DOMAIN.hello"
+
+        await kv.create("created", b"value")
+        assert subjects[-1] == "$JS.test-domain.API.$KV.TEST_DOMAIN.created"
+
+        await kv.update("created", b"updated", last=2)
+        assert subjects[-1] == "$JS.test-domain.API.$KV.TEST_DOMAIN.created"
+
+        await kv.delete("created")
+        assert subjects[-1] == "$JS.test-domain.API.$KV.TEST_DOMAIN.created"
+
+        await kv.purge("hello")
+        assert subjects[-1] == "$JS.test-domain.API.$KV.TEST_DOMAIN.hello"
+
+        await nc.close()
+
+    @async_test
+    async def test_kv_mutations_work_over_domain(self):
+        """Full KV round-trip through a domain-scoped context."""
+        nc = await nats.connect()
+        js = nc.jetstream(domain="test-domain")
+
+        kv = await js.create_key_value(bucket="TEST_DOMAIN_RT")
+
+        seq = await kv.put("hello", b"world")
+        assert seq == 1
+
+        entry = await kv.get("hello")
+        assert entry.key == "hello"
+        assert entry.value == b"world"
+
+        # create on an existing key must conflict
+        with pytest.raises(KeyWrongLastSequenceError):
+            await kv.create("hello", b"again")
+
+        # create + update with CAS
+        seq = await kv.create("created", b"value")
+        assert seq == 2
+        seq = await kv.update("created", b"updated", last=2)
+        assert seq == 3
+
+        # stale CAS fails
+        with pytest.raises(KeyWrongLastSequenceError):
+            await kv.update("created", b"stale", last=2)
+
+        # delete
+        await kv.delete("created")
+        with pytest.raises(KeyNotFoundError):
+            await kv.get("created")
+
+        # purge
+        await kv.purge("hello")
+        with pytest.raises(KeyNotFoundError):
+            await kv.get("hello")
+
+        await nc.close()
+
+    @async_test
+    async def test_kv_binding_via_key_value_uses_domain(self):
+        """A KeyValue bound through key_value() on a domain context mutates
+        through the domain-qualified subject too."""
+        nc = await nats.connect()
+        js = nc.jetstream(domain="test-domain")
+
+        await js.create_key_value(bucket="TEST_DOMAIN_LOOKUP")
+        kv = await js.key_value("TEST_DOMAIN_LOOKUP")
+
+        seq = await kv.put("hello", b"world")
+        assert seq == 1
+
+        entry = await kv.get("hello")
+        assert entry.value == b"world"
+
+        await kv.delete("hello")
+        with pytest.raises(KeyNotFoundError):
+            await kv.get("hello")
 
         await nc.close()
 

--- a/nats/tests/utils.py
+++ b/nats/tests/utils.py
@@ -490,6 +490,27 @@ class SingleJetStreamServerLimitsTestCase(unittest.TestCase):
         self.loop.close()
 
 
+class SingleJetStreamServerDomainTestCase(unittest.TestCase):
+    def setUp(self):
+        self.server_pool = []
+        self.loop = asyncio.new_event_loop()
+
+        server = NATSD(
+            port=4222,
+            with_jetstream=True,
+            config_file=get_config_file("conf/js-domain.conf"),
+        )
+        self.server_pool.append(server)
+        for natsd in self.server_pool:
+            start_natsd(natsd)
+
+    def tearDown(self):
+        for natsd in self.server_pool:
+            natsd.stop()
+            shutil.rmtree(natsd.store_dir)
+        self.loop.close()
+
+
 class NoAuthUserServerTestCase(unittest.TestCase):
     def setUp(self):
         self.server_pool = []


### PR DESCRIPTION
Fixes #1010.

## Problem

When a `JetStreamContext` targets a JetStream domain (`nc.jetstream(domain="leaf")`), the API prefix becomes `$JS.<domain>.API`, but `KeyValue` mutations (`put`, `create`, `update`, `delete`, `purge`) still published to the unqualified local `$KV.<bucket>.<key>` subject. Over a leafnode this fails with `NoStreamResponseError`, while reads (bucket lookup, `get`, `watch`) already worked through the domain-scoped API.

## Fix

Match the Go client behavior (`nats.go` `useJSPfx`): when the context's API prefix is not the default `$JS.API`, prepend it to the KV data subject for mutations, yielding `$JS.<domain>.API.$KV.<bucket>.<key>`.

Reads (`get`, `history`, `keys`, `watch`, `purge_deletes`) intentionally keep the local `$KV.` prefix: stream subjects are not prefixed, and watchers filter on the stream's subjects. This mirrors the Go split between `pre` (read) and the JS-prefixed mutation subject.

## Tests

- New `SingleJetStreamServerDomainTestCase` (`nats/tests/utils.py`) starting a server with `jetstream { domain: "test-domain" }` (`nats/tests/conf/js-domain.conf`).
- New `KVDomainTest` (`nats/tests/test_js.py`):
  - `test_kv_mutations_use_domain_qualified_subject` — spies on the connection and asserts every mutation request goes to `$JS.test-domain.API.$KV.TEST_DOMAIN.<key>` (regression test for the reported bug).
  - `test_kv_mutations_work_over_domain` — full put/get/create/update/CAS/delete/purge round-trip through a domain-scoped context.
  - `test_kv_binding_via_key_value_uses_domain` — covers the `key_value()` binding path from the issue.

All `nats/tests` pass locally (237 passed, 21 skipped).

## Out of scope

`ObjectStore` mutations have the same unqualified-subject issue (`$O.<bucket>.C/M.`). Left for a follow-up to keep this change minimal.