### PR TITLE
fix(jetstream): parse leader_since in ClusterInfo

### DIFF
--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -149,6 +149,9 @@ class ClusterInfo(TypedDict):
     leader: NotRequired[str]
     """The server name of the RAFT leader"""
 
+    leader_since: NotRequired[str]
+    """The time the current leader was elected"""
+
     name: NotRequired[str]
     """The cluster name"""
 

--- a/nats-jetstream/src/nats/jetstream/stream.py
+++ b/nats-jetstream/src/nats/jetstream/stream.py
@@ -455,11 +455,17 @@ class ClusterInfo:
     raft_group: str | None = None
     """In clustered environments the name of the Raft group managing the asset."""
 
+    leader_since: datetime | None = None
+    """The time the current leader was elected."""
+
     @classmethod
     def from_response(cls, data: api.ClusterInfo, *, strict: bool = False) -> ClusterInfo:
         name = data.pop("name", None)
         leader = data.pop("leader", None)
         raft_group = data.pop("raft_group", None)
+
+        leader_since_str = data.pop("leader_since", None)
+        leader_since = datetime.fromisoformat(leader_since_str.replace("Z", "+00:00")) if leader_since_str else None
 
         replicas = None
         replicas_data = data.pop("replicas", None)
@@ -475,6 +481,7 @@ class ClusterInfo:
             leader=leader,
             replicas=replicas,
             raft_group=raft_group,
+            leader_since=leader_since,
         )
 
 

--- a/nats-jetstream/tests/test_stream.py
+++ b/nats-jetstream/tests/test_stream.py
@@ -975,3 +975,24 @@ async def test_stream_source_with_consumer(jetstream: JetStream):
     assert cs is not None
     assert cs.name == "C"
     assert cs.deliver_subject == "deliver"
+
+
+def test_cluster_info_parses_leader_since():
+    """leader_since (added in nats-server 2.12) is parsed to a datetime."""
+    from datetime import UTC, datetime
+
+    from nats.jetstream.stream import ClusterInfo
+
+    info = ClusterInfo.from_response(
+        {"name": "C1", "leader": "s1", "leader_since": "2026-08-27T10:00:00Z"},
+        strict=True,
+    )
+    assert info.leader_since == datetime(2026, 8, 27, 10, 0, 0, tzinfo=UTC)
+
+
+def test_cluster_info_leader_since_absent():
+    """Responses without leader_since (pre-2.12 servers) still parse."""
+    from nats.jetstream.stream import ClusterInfo
+
+    info = ClusterInfo.from_response({"name": "C1", "leader": "s1"}, strict=True)
+    assert info.leader_since is None


### PR DESCRIPTION
Fixes #1012.

nats-server 2.12 added `leader_since` to the cluster info block of stream and consumer info responses. The `nats-jetstream` package silently dropped it in default mode and raised `ValueError: ClusterInfo.from_response() has unconsumed fields: ['leader_since']` in strict mode against any 2.12+ server.

Changes:
- `api/types.py`: add `leader_since: NotRequired[str]` to the `ClusterInfo` TypedDict
- `stream.py`: add `leader_since: datetime | None` to the `ClusterInfo` dataclass and parse it in `from_response` (same `fromisoformat` pattern used elsewhere in the file), matching the legacy client's handling (`nats/src/nats/js/api.py`)
- tests: strict-mode parse with `leader_since` present, and absence (pre-2.12 servers) still parsing to `None`

Verified: both new tests fail before the fix (strict-mode ValueError) and pass after; full `nats-jetstream` suite green (313 passed, 2 xfailed); `ruff format --check`, `ruff check`, `codespell` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbNCnGpbvHuv1SQwDBC6nf
