### PR TITLE
fix(jetstream): add prioritized to PriorityPolicy Literal

### DIFF
--- a/nats-jetstream/src/nats/jetstream/api/types.py
+++ b/nats-jetstream/src/nats/jetstream/api/types.py
@@ -277,7 +277,7 @@ class ErrorResponse(TypedDict):
     error: Error
 
 
-PriorityPolicy = Literal["none", "overflow", "pinned_client"]
+PriorityPolicy = Literal["none", "overflow", "pinned_client", "prioritized"]
 
 
 class LastPerSubjectDeliverPolicy(TypedDict):

--- a/nats-jetstream/tests/test_api.py
+++ b/nats-jetstream/tests/test_api.py
@@ -151,3 +151,12 @@ def test_check_response_list_data():
     assert is_valid is False
     assert unknown == set()
     assert missing == set()
+
+
+def test_priority_policy_includes_prioritized():
+    """Server 2.12 added the "prioritized" priority policy (ADR-42)."""
+    from typing import get_args
+
+    from nats.jetstream.api.types import PriorityPolicy
+
+    assert set(get_args(PriorityPolicy)) == {"none", "overflow", "pinned_client", "prioritized"}


### PR DESCRIPTION
nats-server 2.12 added the `"prioritized"` priority-group policy (ADR-42). The `nats-jetstream` runtime already passes it through — `ConsumerConfig.priority_policy` is a plain `str` and the integration tests use `"prioritized"` — but the wire-type `PriorityPolicy` Literal in `api/types.py` still listed only `none`/`overflow`/`pinned_client`, so type checkers reject the value.

One-line fix plus a test pinning the Literal to the server's enum (`nats-server/server/consumer.go`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbNCnGpbvHuv1SQwDBC6nf
