### PR TITLE
Validate subjects client-side in nats.aio

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -105,6 +105,48 @@ NO_RESPONDERS_STATUS = "503"
 CTRL_STATUS = "100"
 STATUS_MSG_LEN = 3  # e.g. 20x, 40x, 50x
 
+_SUBJECT_INVALID_RE = re.compile(r"[ \t\r\n]")
+
+
+def _validate_subject(subject: str, *, strict: bool = False) -> None:
+    """Validate a NATS subject, raising BadSubjectError if it is malformed.
+
+    Always rejects empty subjects and whitespace or CRLF. CRLF in particular
+    would allow a caller to inject arbitrary protocol commands.
+
+    With ``strict=True`` (the subscribe path), also rejects empty tokens and
+    misplaced wildcards. The publish path leaves token shape to the server.
+    """
+    if not subject:
+        raise errors.BadSubjectError
+    if _SUBJECT_INVALID_RE.search(subject):
+        raise errors.BadSubjectError
+    if not strict:
+        return
+    tokens = subject.split(".")
+    last = len(tokens) - 1
+    for index, token in enumerate(tokens):
+        if not token:
+            raise errors.BadSubjectError
+        if token == ">":
+            if index != last:
+                raise errors.BadSubjectError
+        elif ">" in token:
+            raise errors.BadSubjectError
+        elif "*" in token and token != "*":
+            raise errors.BadSubjectError
+
+
+def _validate_queue(queue: str) -> None:
+    """Validate a queue group name, raising BadSubjectError if it is malformed.
+
+    An empty queue is treated as unset. Only whitespace and CRLF are rejected;
+    wildcards and dots are valid tokens on the wire.
+    """
+    if queue and _SUBJECT_INVALID_RE.search(queue):
+        raise errors.BadSubjectError
+
+
 Callback = Callable[[], Awaitable[None]]
 ErrorCallback = Callable[[Exception], Awaitable[None]]
 JWTCallback = Callable[[], Union[bytearray, bytes]]
@@ -314,6 +356,7 @@ class Client:
         self._nuid = NUID()
         self._inbox_prefix = bytearray(DEFAULT_INBOX_PREFIX)
         self._auth_configured: bool = False
+        self._skip_subject_validation: bool = False
 
         # NKEYS support
         #
@@ -382,6 +425,7 @@ class Client:
         ws_connection_headers: Optional[Dict[str, List[str]]] = None,
         reconnect_to_server_handler: Optional[ReconnectToServerHandler] = None,
         lame_duck_mode_cb: Optional[Callback] = None,
+        skip_subject_validation: bool = False,
     ) -> None:
         """
         Establishes a connection to NATS.
@@ -394,6 +438,10 @@ class Client:
         :param discovered_server_cb: Callback to report when a new server joins the cluster.
         :param pending_size: Max size of the pending buffer for publishing commands.
         :param flush_timeout: Max duration to wait for a forced flush to occur.
+        :param skip_subject_validation: Disable client-side validation of subjects,
+            reply subjects and queue groups on publish, subscribe and request.
+            Not recommended: the performance gain is minimal and it removes the
+            protection against CRLF injection into the protocol stream.
 
         Connecting setting all callbacks::
 
@@ -523,6 +571,8 @@ class Client:
         self.options["drain_timeout"] = drain_timeout
         self.options["tls_handshake_first"] = tls_handshake_first
         self.options["ws_connection_headers"] = ws_connection_headers
+        self.options["skip_subject_validation"] = skip_subject_validation
+        self._skip_subject_validation = skip_subject_validation
 
         if tls:
             self.options["tls"] = tls
@@ -910,6 +960,10 @@ class Client:
                 asyncio.run(main())
 
         """
+        if not self._skip_subject_validation:
+            _validate_subject(subject)
+            if reply:
+                _validate_subject(reply)
 
         if self.is_closed:
             raise errors.ConnectionClosedError
@@ -986,11 +1040,12 @@ class Client:
         If a callback isn't provided, messages can be retrieved via an
         asynchronous iterator on the returned subscription object.
         """
-        if not subject or (" " in subject):
-            raise errors.BadSubjectError
-
-        if queue and (" " in queue):
-            raise errors.BadSubjectError
+        if self._skip_subject_validation:
+            if not subject:
+                raise errors.BadSubjectError
+        else:
+            _validate_subject(subject, strict=True)
+            _validate_queue(queue)
 
         if self.is_closed:
             raise errors.ConnectionClosedError
@@ -1065,6 +1120,9 @@ class Client:
         the responses.
 
         """
+        if not self._skip_subject_validation:
+            _validate_subject(subject)
+
         if old_style:
             # FIXME: Support headers in old style requests.
             return await self._request_old_style(subject, payload, timeout=timeout)

--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -1120,6 +1120,8 @@ class Client:
         the responses.
 
         """
+        # Validated here as well as in publish() so a bad subject fails
+        # before the inbox subscription and response future are set up.
         if not self._skip_subject_validation:
             _validate_subject(subject)
 

--- a/nats/tests/test_client.py
+++ b/nats/tests/test_client.py
@@ -549,6 +549,85 @@ class ClientTest(SingleServerTestCase):
         self.assertEqual(100, varz["in_bytes"])
 
     @async_test
+    async def test_publish_rejects_invalid_subject(self):
+        nc = NATS()
+        await nc.connect()
+
+        # Empty subjects and whitespace/CRLF are rejected client-side.
+        for subject in ["", " ", "foo bar", "foo\tbar", "foo\r\nbar", "foo\nbar"]:
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.publish(subject, b"payload")
+
+        # Whitespace/CRLF in the reply subject is rejected too.
+        for reply in ["foo bar", "foo\r\nbar"]:
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.publish("foo", b"payload", reply=reply)
+
+        # Token shape and wildcards are left to the server on publish.
+        for subject in ["foo.*", "foo.>", ".foo", "foo..bar"]:
+            await nc.publish(subject, b"payload")
+        await nc.flush()
+
+        await nc.close()
+
+    @async_test
+    async def test_request_rejects_invalid_subject(self):
+        nc = NATS()
+        await nc.connect()
+
+        for subject in ["", "foo bar", "foo\r\nbar"]:
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.request(subject, b"payload", timeout=0.5)
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.request(subject, b"payload", timeout=0.5, old_style=True)
+
+        await nc.close()
+
+    @async_test
+    async def test_subscribe_rejects_invalid_subject(self):
+        nc = NATS()
+        await nc.connect()
+
+        for subject in ["", "foo bar", "foo\r\nbar", ".foo", "foo..bar", "foo.>.bar", "foo.**", "foo.a>"]:
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.subscribe(subject)
+
+        for queue in ["q with space", "q\r\n"]:
+            with self.assertRaises(nats.errors.BadSubjectError):
+                await nc.subscribe("foo", queue=queue)
+
+        # Standard wildcards are accepted.
+        for subject in ["foo.*", "foo.*.bar", "foo.>", "foo.bar.>"]:
+            sub = await nc.subscribe(subject)
+            await sub.unsubscribe()
+
+        # Queue shape beyond whitespace/CRLF is left to the server.
+        for queue in ["workers.east", "q*", "q>"]:
+            sub = await nc.subscribe("foo", queue=queue)
+            await sub.unsubscribe()
+        await nc.flush()
+
+        await nc.close()
+
+    @async_test
+    async def test_skip_subject_validation(self):
+        nc = NATS()
+        await nc.connect(skip_subject_validation=True)
+
+        # Validation is skipped, so nothing is raised before the wire write.
+        await nc.publish("foo bar", b"payload")
+        sub = await nc.subscribe("foo..bar", queue="q with space")
+        await sub.unsubscribe()
+
+        # Empty subjects are still rejected.
+        with self.assertRaises(nats.errors.BadSubjectError):
+            await nc.publish("", b"payload")
+        with self.assertRaises(nats.errors.BadSubjectError):
+            await nc.subscribe("")
+
+        await nc.close()
+
+    @async_test
     async def test_rtt(self):
         nc = NATS()
         await nc.connect()
@@ -721,7 +800,8 @@ class ClientTest(SingleServerTestCase):
             if not done.done():
                 done.set_result(nc.last_error)
 
-        nc = await nats.connect(closed_cb=closed_cb, error_cb=err_cb)
+        # Skip client-side validation so the invalid subject reaches the server.
+        nc = await nats.connect(closed_cb=closed_cb, error_cb=err_cb, skip_subject_validation=True)
         sub = await nc.subscribe("foo.")
         res = await asyncio.wait_for(done, 1)
         nats_error = done.result()


### PR DESCRIPTION
Backport of the nats-core subject validation from #897 to the legacy client. Publish and request reject empty subjects and whitespace/CRLF in the subject and reply, which closes a protocol-injection hole. Subscribe additionally rejects empty tokens and misplaced wildcards, and queue groups are checked for whitespace/CRLF. Everything raises the existing `BadSubjectError`.

A `skip_subject_validation` connect option (default off) opts out, mirroring the nats-core and nats.go option. With it set, only the pre-existing empty-subject checks remain.

Behavior change to note: subscribing to subjects like `foo..bar` or `foo.>.bar` now fails client-side instead of via the server's `-ERR 'Invalid Subject'`. The one existing test that relied on that server error now connects with validation skipped.
