### PR TITLE
Validate header keys and sanitize values in nats.aio

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -105,6 +105,14 @@ NO_RESPONDERS_STATUS = "503"
 CTRL_STATUS = "100"
 STATUS_MSG_LEN = 3  # e.g. 20x, 40x, 50x
 
+# Header keys must be printable ASCII without separators (RFC 7230 token
+# characters); anything else, CRLF in particular, is rejected outright.
+_HEADER_KEY_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+
+# Header values are trimmed and CR/LF are replaced by spaces so a value can
+# never terminate the header line or inject further protocol commands.
+_HEADER_VALUE_NEWLINES = str.maketrans({"\r": " ", "\n": " "})
+
 Callback = Callable[[], Awaitable[None]]
 ErrorCallback = Callable[[Exception], Awaitable[None]]
 JWTCallback = Callable[[], Union[bytearray, bytes]]
@@ -954,9 +962,11 @@ class Client:
                 if not key:
                     # Skip empty keys
                     continue
+                if not _HEADER_KEY_RE.fullmatch(key):
+                    raise errors.BadHeaderError
                 hdr.extend(key.encode())
                 hdr.extend(b": ")
-                value = v.strip()
+                value = v.strip().translate(_HEADER_VALUE_NEWLINES)
                 hdr.extend(value.encode())
                 hdr.extend(_CRLF_)
             hdr.extend(_CRLF_)

--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -963,7 +963,7 @@ class Client:
                     # Skip empty keys
                     continue
                 if not _HEADER_KEY_RE.fullmatch(key):
-                    raise errors.BadHeaderError
+                    raise errors.BadHeaderError(key)
                 hdr.extend(key.encode())
                 hdr.extend(b": ")
                 value = v.strip().translate(_HEADER_VALUE_NEWLINES)

--- a/nats/src/nats/errors.py
+++ b/nats/src/nats/errors.py
@@ -84,6 +84,11 @@ class BadSubjectError(Error):
         return "nats: invalid subject"
 
 
+class BadHeaderError(Error):
+    def __str__(self) -> str:
+        return "nats: invalid header"
+
+
 class SlowConsumerError(Error):
     def __init__(self, subject: str, reply: str, sid: int, sub: Subscription) -> None:
         self.subject = subject

--- a/nats/src/nats/errors.py
+++ b/nats/src/nats/errors.py
@@ -85,7 +85,12 @@ class BadSubjectError(Error):
 
 
 class BadHeaderError(Error):
+    def __init__(self, key: str = "") -> None:
+        self.key = key
+
     def __str__(self) -> str:
+        if self.key:
+            return f"nats: invalid header: {self.key!r}"
         return "nats: invalid header"
 
 

--- a/nats/tests/test_client_v2.py
+++ b/nats/tests/test_client_v2.py
@@ -80,6 +80,40 @@ class HeadersTest(SingleServerTestCase):
 
         await nc.close()
 
+    @async_test
+    async def test_invalid_header_key(self):
+        nc = await nats.connect()
+
+        for key in ["foo bar", "foo:bar", "foo\r\nbar", "foo(bar)", "foo/bar", "f\u00f6\u00f6"]:
+            with self.assertRaises(nats.errors.BadHeaderError):
+                await nc.publish("foo", b"hello world", headers={key: "bar"})
+
+        # Token characters are all accepted.
+        sub = await nc.subscribe("foo")
+        await nc.flush()
+        hdrs = {"Nats-Msg-Id": "1", "x_y.z": "2", "!#$%&'*+-^`|~": "3"}
+        await nc.publish("foo", b"hello world", headers=hdrs)
+        msg = await sub.next_msg()
+        self.assertEqual(msg.headers, hdrs)
+
+        await nc.close()
+
+    @async_test
+    async def test_header_value_sanitized(self):
+        nc = await nats.connect()
+
+        sub = await nc.subscribe("foo")
+        await nc.flush()
+
+        # CR/LF in a value cannot terminate the header line or inject
+        # additional headers; it is replaced by spaces and trimmed.
+        await nc.publish("foo", b"hello world", headers={"foo": "  bar\r\nInjected: yes\n  "})
+        msg = await sub.next_msg()
+        self.assertEqual(msg.headers, {"foo": "bar  Injected: yes"})
+        self.assertEqual(msg.data, b"hello world")
+
+        await nc.close()
+
 
 if __name__ == "__main__":
     import sys

--- a/nats/tests/test_client_v2.py
+++ b/nats/tests/test_client_v2.py
@@ -85,8 +85,10 @@ class HeadersTest(SingleServerTestCase):
         nc = await nats.connect()
 
         for key in ["foo bar", "foo:bar", "foo\r\nbar", "foo(bar)", "foo/bar", "f\u00f6\u00f6"]:
-            with self.assertRaises(nats.errors.BadHeaderError):
+            with self.assertRaises(nats.errors.BadHeaderError) as cm:
                 await nc.publish("foo", b"hello world", headers={key: "bar"})
+            self.assertEqual(cm.exception.key, key)
+            self.assertIn(repr(key), str(cm.exception))
 
         # Token characters are all accepted.
         sub = await nc.subscribe("foo")

--- a/nats/tests/test_js.py
+++ b/nats/tests/test_js.py
@@ -839,36 +839,31 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
         msg = await js.get_msg("test-nats", 1)
         assert msgs[0].header == None
 
-        # NOTE: Headers with empty spaces are ignored.
+        # NOTE: Keys with embedded spaces are rejected client-side.
+        with pytest.raises(nats.errors.BadHeaderError):
+            await js.publish(
+                "test.nats.1",
+                b"second_msg",
+                headers={
+                    "  AAA AAA AAA  ": "               ",
+                    " B B B ": "                       ",
+                },
+            )
+
+        # NOTE: Surrounding whitespace is trimmed from keys and values.
         await js.publish(
             "test.nats.1",
             b"second_msg",
             headers={
-                "  AAA AAA AAA  ": "               ",
-                " B B B ": "                       ",
-            },
-        )
-        msgs = await sub.fetch(1)
-        assert msgs[0].header == None
-
-        msg = await js.get_msg("test-nats", 2)
-        assert msgs[0].header == None
-
-        # NOTE: As soon as there is a message with empty spaces are ignored.
-        await js.publish(
-            "test.nats.1",
-            b"third_msg",
-            headers={
                 "  AAA-AAA-AAA  ": "     a          ",
                 "  AAA-BBB-AAA  ": "               ",
-                " B B B ": "        a               ",
             },
         )
         msgs = await sub.fetch(1)
         assert msgs[0].header["AAA-AAA-AAA"] == "a"
         assert msgs[0].header["AAA-BBB-AAA"] == ""
 
-        msg = await js.get_msg("test-nats", 3)
+        msg = await js.get_msg("test-nats", 2)
         assert msg.header["AAA-AAA-AAA"] == "a"
         assert msg.header["AAA-BBB-AAA"] == ""
 
@@ -880,16 +875,14 @@ class PullSubscribeTest(SingleJetStreamServerTestCase):
             "test.nats.1",
             b"third_msg",
             headers={
-                "  AAA AAA AAA  ": "     a          ",
                 "  AAA-BBB-AAA  ": "     b          ",
-                " B B B ": "        a               ",
             },
         )
         msgs = await sub.fetch(1)
         assert msgs[0].header == {"AAA-BBB-AAA": "b"}
 
-        msg = await js.get_msg("test-nats", 4)
-        assert msg.header == None
+        msg = await js.get_msg("test-nats", 3)
+        assert msg.header == {"AAA-BBB-AAA": "b"}
 
         await nc.close()
 


### PR DESCRIPTION
Legacy-client counterpart of nats.go's header handling. Publishing with a header key that is not printable ASCII or contains a separator character (spaces, colons, parentheses, slashes, and so on) now raises a new `BadHeaderError` instead of going out on the wire. Empty or whitespace-only keys are still silently skipped, as they always were. Header values are still trimmed, and any CR or LF inside a value is replaced with a space, closing a header-line injection hole.

Behavior change to note: one JetStream test relied on the server dropping keys with embedded spaces; it now expects the client-side error. The part of that test behind the `fast_parse` extra is not run in CI and was not verified locally.
