### PR TITLE
Validate header keys and sanitize values in nats-core

### DIFF
--- a/nats-core/src/nats/client/protocol/command.py
+++ b/nats-core/src/nats/client/protocol/command.py
@@ -3,10 +3,19 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from nats.client.protocol.types import ConnectInfo
+
+# Header keys must be printable ASCII without separators (RFC 7230 token
+# characters); anything else, CRLF in particular, is rejected outright.
+_HEADER_KEY_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
+
+# Header values are trimmed and CR/LF are replaced by spaces so a value can
+# never terminate the header line or inject further protocol commands.
+_HEADER_VALUE_NEWLINES = str.maketrans({"\r": " ", "\n": " "})
 
 
 def encode_connect(info: ConnectInfo) -> bytes:
@@ -50,10 +59,21 @@ def encode_pub(
 
 
 def encode_headers(headers: dict[str, str | list[str]]) -> bytes:
-    """Encode a headers dict into the ``NATS/1.0`` wire form, including the trailing blank line."""
-    header_lines = ["NATS/1.0"] + [
-        f"{key}: {item}" for key, value in headers.items() for item in (value if isinstance(value, list) else [value])
-    ]
+    """Encode a headers dict into the ``NATS/1.0`` wire form, including the trailing blank line.
+
+    Keys must be non-empty printable ASCII without separator characters.
+    Values are trimmed and any CR or LF inside them is replaced by a space.
+
+    Raises:
+        ValueError: A header key is empty or contains an invalid character.
+    """
+    header_lines = ["NATS/1.0"]
+    for key, value in headers.items():
+        if not _HEADER_KEY_RE.fullmatch(key):
+            msg = f"invalid header key: {key!r}"
+            raise ValueError(msg)
+        for item in value if isinstance(value, list) else [value]:
+            header_lines.append(f"{key}: {item.strip().translate(_HEADER_VALUE_NEWLINES)}")
     return ("\r\n".join(header_lines) + "\r\n\r\n").encode()
 
 

--- a/nats-core/src/nats/client/protocol/command.py
+++ b/nats-core/src/nats/client/protocol/command.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
 # characters); anything else, CRLF in particular, is rejected outright.
 _HEADER_KEY_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 
-# Header values are trimmed and CR/LF are replaced by spaces so a value can
+# Header values are trimmed and CR/LF/NUL are replaced by spaces so a value can
 # never terminate the header line or inject further protocol commands.
-_HEADER_VALUE_NEWLINES = str.maketrans({"\r": " ", "\n": " "})
+_HEADER_VALUE_CONTROL = str.maketrans({"\r": " ", "\n": " ", "\0": " "})
 
 
 def encode_connect(info: ConnectInfo) -> bytes:
@@ -73,7 +73,7 @@ def encode_headers(headers: dict[str, str | list[str]]) -> bytes:
             msg = f"invalid header key: {key!r}"
             raise ValueError(msg)
         for item in value if isinstance(value, list) else [value]:
-            header_lines.append(f"{key}: {item.strip().translate(_HEADER_VALUE_NEWLINES)}")
+            header_lines.append(f"{key}: {item.strip().translate(_HEADER_VALUE_CONTROL)}")
     return ("\r\n".join(header_lines) + "\r\n\r\n").encode()
 
 

--- a/nats-core/tests/test_client.py
+++ b/nats-core/tests/test_client.py
@@ -793,6 +793,38 @@ async def test_publish_with_headers(client):
     assert message.headers.get_all("key2") == ["value2", "value3"]
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param("foo:bar", id="colon"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_publish_rejects_invalid_header_key(client, key):
+    """Publish rejects header keys that are not printable ASCII token characters."""
+    with pytest.raises(ValueError):
+        await client.publish(f"test.headers.{uuid.uuid4()}", b"payload", headers={key: "value"})
+
+
+@pytest.mark.asyncio
+async def test_publish_sanitizes_header_value(client):
+    """CR/LF in a header value cannot inject additional headers."""
+    test_subject = f"test.headers.{uuid.uuid4()}"
+    subscription = await client.subscribe(test_subject)
+    await client.flush()
+
+    await client.publish(test_subject, b"payload", headers=Headers({"foo": "  bar\r\nInjected: yes  "}))
+    await client.flush()
+
+    message = await subscription.next(timeout=1.0)
+    assert message.headers is not None
+    assert message.headers.get("foo") == "bar  Injected: yes"
+    assert message.headers.get("Injected") is None
+    assert message.data == b"payload"
+
+
 @pytest.mark.asyncio
 async def test_publish_with_byte_subject(client):
     """Test that a message can be published with a byte subject."""

--- a/nats-core/tests/test_protocol.py
+++ b/nats-core/tests/test_protocol.py
@@ -209,6 +209,37 @@ def test_encode_hpub():
     assert b"multi: val2" in command
 
 
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param("", id="empty"),
+        pytest.param("foo bar", id="embedded_space"),
+        pytest.param(" foo", id="leading_space"),
+        pytest.param("foo:bar", id="colon"),
+        pytest.param("foo\r\nbar", id="crlf_injection"),
+        pytest.param("(foo)", id="separator"),
+        pytest.param("foo/bar", id="slash"),
+        pytest.param("f\u00f6\u00f6", id="non_ascii"),
+    ],
+)
+def test_encode_headers_rejects_invalid_key(key):
+    """Header keys must be printable ASCII without separator characters."""
+    with pytest.raises(ValueError, match="invalid header key"):
+        encode_headers({key: "value"})
+
+
+def test_encode_headers_accepts_token_characters():
+    """Every RFC 7230 token character is a valid header key."""
+    key = "!#$%&'*+-.^_`|~0123456789AZaz"
+    assert encode_headers({key: "v"}) == f"NATS/1.0\r\n{key}: v\r\n\r\n".encode()
+
+
+def test_encode_headers_sanitizes_value():
+    """Values are trimmed and CR/LF cannot terminate the header line."""
+    header_data = encode_headers({"foo": "  bar\r\nInjected: yes\n  ", "multi": ["a\r", "\nb"]})
+    assert header_data == b"NATS/1.0\r\nfoo: bar  Injected: yes\r\nmulti: a\r\nmulti: b\r\n\r\n"
+
+
 def test_encode_sub():
     """Test encoding SUB command."""
     # Test without queue group

--- a/nats-core/tests/test_protocol.py
+++ b/nats-core/tests/test_protocol.py
@@ -236,8 +236,8 @@ def test_encode_headers_accepts_token_characters():
 
 def test_encode_headers_sanitizes_value():
     """Values are trimmed and CR/LF cannot terminate the header line."""
-    header_data = encode_headers({"foo": "  bar\r\nInjected: yes\n  ", "multi": ["a\r", "\nb"]})
-    assert header_data == b"NATS/1.0\r\nfoo: bar  Injected: yes\r\nmulti: a\r\nmulti: b\r\n\r\n"
+    header_data = encode_headers({"foo": "  bar\r\nInjected: yes\n  ", "multi": ["a\r", "\nb"], "nul": "a\0b"})
+    assert header_data == b"NATS/1.0\r\nfoo: bar  Injected: yes\r\nmulti: a\r\nmulti: b\r\nnul: a b\r\n\r\n"
 
 
 def test_encode_sub():


### PR DESCRIPTION
Companion to #1017 for the modern client. `encode_headers` now rejects header keys that are empty, non-ASCII, or contain a separator character (spaces, colons, parentheses, slashes, and so on) with a `ValueError`, the same error the subject validation uses. Header values are trimmed, and any CR or LF inside a value is replaced with a space, closing a header-line injection hole. The decoder already strips values, so trimming is round-trip neutral.

Unlike subjects this is not gated by `skip_subject_validation`, matching nats.go where header key validation is unconditional.
