### PR TITLE
Reject credentials without a JWT marker instead of looping at EOF

### DIFF
--- a/nats/src/nats/aio/client.py
+++ b/nats/src/nats/aio/client.py
@@ -685,6 +685,8 @@ class Client:
             user_jwt = None
             while True:
                 line = bytearray(f.readline())
+                if not line:
+                    raise errors.InvalidUserCredentialsError
                 if b"BEGIN NATS USER JWT" in line:
                     user_jwt = bytearray(f.readline())
                     break

--- a/nats/tests/test_client_nkeys.py
+++ b/nats/tests/test_client_nkeys.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import subprocess
+import sys
 
 import pytest
 
@@ -23,6 +25,51 @@ from tests.utils import (
     async_test,
     get_config_file,
 )
+
+
+@pytest.mark.parametrize("credential_kind", ["raw", "str", "path"])
+@pytest.mark.parametrize(
+    "contents",
+    ["", "-----BEGIN USER NKEY SEED-----\nsynthetic-seed\n------END USER NKEY SEED------\n"],
+)
+def test_user_credentials_without_jwt_marker(tmp_path, credential_kind, contents):
+    credentials = tmp_path / "test.creds"
+    credentials.write_bytes(contents.encode())
+
+    # Run in a child process because a regression blocks synchronously at EOF;
+    # an asyncio timeout cannot interrupt the credential callback.
+    script = """
+import sys
+from pathlib import Path
+from nats.aio.client import Client, RawCredentials
+from nats.errors import InvalidUserCredentialsError
+
+kind, contents, filename = sys.argv[1:]
+credentials = {"raw": RawCredentials(contents), "str": filename, "path": Path(filename)}[kind]
+try:
+    Client()._read_creds_user_jwt(credentials)
+except InvalidUserCredentialsError:
+    pass
+else:
+    raise AssertionError("Expected InvalidUserCredentialsError for a missing JWT marker")
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, credential_kind, contents, str(credentials)],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("credential_kind", ["raw", "str", "path"])
+def test_user_credentials_jwt_marker_after_preamble(tmp_path, credential_kind):
+    contents = "Test credentials\n\n-----BEGIN NATS USER JWT-----\nsynthetic-jwt\n------END NATS USER JWT------\n"
+    filename = tmp_path / "test.creds"
+    filename.write_bytes(contents.encode())
+    credentials = {"raw": RawCredentials(contents), "str": str(filename), "path": filename}[credential_kind]
+
+    assert NATS()._read_creds_user_jwt(credentials) == bytearray(b"synthetic-jwt")
 
 
 class ClientNkeysAuthTest(NkeysServerTestCase):


### PR DESCRIPTION
The legacy client's JWT credential reader loops forever at EOF when a credential file or `RawCredentials` value has no `BEGIN NATS USER JWT` marker. Because this reader runs synchronously, the loop can block the asyncio thread; an asyncio timeout cannot interrupt it.

Raise the existing `InvalidUserCredentialsError` on EOF. Regression tests cover empty and seed-only synthetic input through string paths, `Path`, and `RawCredentials`, using a bounded subprocess so the old behavior cannot hang the test runner. Valid JWT blocks after a preamble remain covered. This change leaves reconnect/retry policy unchanged.

Validation on Python 3.12.14/macOS arm64 with NATS Server 2.14.6:
- Full legacy suite: 339 passed, 9 skipped, 54 subtests passed.
- Authentication suite: 16 passed.
- Repository Ruff, formatting, and spelling checks passed.
- A synthetic TCP handshake reproduction blocks on the base revision despite an asyncio timeout and raises the expected error with the patch.

The other Python/OS combinations and modern-client runtime tests remain for upstream CI.

AI assistance: OpenAI Codex implemented and tested this change.
